### PR TITLE
Fix floating point bug

### DIFF
--- a/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
@@ -154,8 +154,13 @@
     }
   }
 
+import os
+
   @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
   extension CKRecord {
+    @TaskLocal static var fooo = false
+
+
     @discardableResult
     package func setValue(
       _ newValue: some CKRecordValueProtocol & Equatable,
@@ -163,9 +168,20 @@
       at userModificationTime: Int64
     ) -> Bool {
       guard
-        encryptedValues[at: key] < userModificationTime,
+        encryptedValues[at: key] <= userModificationTime,
         encryptedValues[key] != newValue
       else {
+        if Self.fooo, encryptedValues[key] != newValue {
+          Logger().info("""
+            ⚠️⚠️⚠️ A write to '\(key)' is being ignored
+            key                       \(key)
+            encryptedValues[at: key]: \(self.encryptedValues[at: key])
+            userModificationDate:     \(userModificationTime)
+            encryptedValues[key]:     \(String(describing: self.encryptedValues[key]))
+            newValue:                 \(String(describing: newValue))
+            """)
+          print("!!!")
+        }
         return false
       }
       encryptedValues[key] = newValue
@@ -182,7 +198,7 @@
     ) -> Bool {
       @Dependency(\.dataManager) var dataManager
 
-      guard encryptedValues[at: key] < userModificationTime
+      guard encryptedValues[at: key] <= userModificationTime
       else {
         return false
       }
@@ -204,7 +220,7 @@
       forKey key: CKRecord.FieldKey,
       at userModificationTime: Int64
     ) -> Bool {
-      guard encryptedValues[at: key] < userModificationTime
+      guard encryptedValues[at: key] <= userModificationTime
       else {
         return false
       }
@@ -223,38 +239,41 @@
     }
 
     func update<T: PrimaryKeyedTable>(with row: T, userModificationTime: Int64) {
-      for column in T.TableColumns.writableColumns {
-        func open<Root, Value>(_ column: some WritableTableColumnExpression<Root, Value>) {
-          let column = column as! any WritableTableColumnExpression<T, Value>
-          let value = Value(queryOutput: row[keyPath: column.keyPath])
-          switch value.queryBinding {
-          case .blob(let value):
-            setValue(value, forKey: column.name, at: userModificationTime)
-          case .bool(let value):
-            setValue(value, forKey: column.name, at: userModificationTime)
-          case .double(let value):
-            setValue(value, forKey: column.name, at: userModificationTime)
-          case .date(let value):
-            setValue(value, forKey: column.name, at: userModificationTime)
-          case .int(let value):
-            setValue(value, forKey: column.name, at: userModificationTime)
-          case .null:
-            removeValue(forKey: column.name, at: userModificationTime)
-          case .text(let value):
-            setValue(value, forKey: column.name, at: userModificationTime)
-          case .uint(let value):
-            setValue(value, forKey: column.name, at: userModificationTime)
-          case .uuid(let value):
-            setValue(
-              value.uuidString.lowercased(),
-              forKey: column.name,
-              at: userModificationTime
-            )
-          case .invalid(let error):
-            reportIssue(error)
+      Self.$fooo.withValue(true) {
+
+        for column in T.TableColumns.writableColumns {
+          func open<Root, Value>(_ column: some WritableTableColumnExpression<Root, Value>) {
+            let column = column as! any WritableTableColumnExpression<T, Value>
+            let value = Value(queryOutput: row[keyPath: column.keyPath])
+            switch value.queryBinding {
+            case .blob(let value):
+              setValue(value, forKey: column.name, at: userModificationTime)
+            case .bool(let value):
+              setValue(value, forKey: column.name, at: userModificationTime)
+            case .double(let value):
+              setValue(value, forKey: column.name, at: userModificationTime)
+            case .date(let value):
+              setValue(value, forKey: column.name, at: userModificationTime)
+            case .int(let value):
+              setValue(value, forKey: column.name, at: userModificationTime)
+            case .null:
+              removeValue(forKey: column.name, at: userModificationTime)
+            case .text(let value):
+              setValue(value, forKey: column.name, at: userModificationTime)
+            case .uint(let value):
+              setValue(value, forKey: column.name, at: userModificationTime)
+            case .uuid(let value):
+              setValue(
+                value.uuidString.lowercased(),
+                forKey: column.name,
+                at: userModificationTime
+              )
+            case .invalid(let error):
+              reportIssue(error)
+            }
           }
+          open(column)
         }
-        open(column)
       }
     }
 

--- a/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
@@ -374,10 +374,4 @@ import os
       set { self[#function] = newValue }
     }
   }
-
-  // NB: We add a small amount of leeway when comparing dates due to floating point inaccuracies.
-  private func date(_ date: Date, comesBefore otherDate: Date) -> Bool {
-    date.addingTimeInterval(-0.001) < otherDate.addingTimeInterval(0.001)
-  }
-
 #endif

--- a/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
@@ -163,9 +163,11 @@
       at userModificationDate: Date
     ) -> Bool {
       guard
-        encryptedValues[at: key] < userModificationDate,
+        date(encryptedValues[at: key], comesBefore: userModificationDate),
         encryptedValues[key] != newValue
-      else { return false }
+      else {
+        return false
+      }
       encryptedValues[key] = newValue
       encryptedValues[at: key] = userModificationDate
       self.userModificationDate = userModificationDate
@@ -180,7 +182,10 @@
     ) -> Bool {
       @Dependency(\.dataManager) var dataManager
 
-      guard encryptedValues[at: key] < userModificationDate else { return false }
+      guard date(encryptedValues[at: key], comesBefore: userModificationDate)
+      else {
+        return false
+      }
 
       let asset = CKAsset(fileURL: URL(hash: newValue))
       guard let fileURL = asset.fileURL, (self[key] as? CKAsset)?.fileURL != fileURL
@@ -199,8 +204,10 @@
       forKey key: CKRecord.FieldKey,
       at userModificationDate: Date
     ) -> Bool {
-      guard encryptedValues[at: key] < userModificationDate
-      else { return false }
+      guard date(encryptedValues[at: key], comesBefore: userModificationDate)
+      else {
+        return false
+      }
       if encryptedValues[key] != nil {
         encryptedValues[key] = nil
         encryptedValues[at: key] = userModificationDate
@@ -348,4 +355,13 @@
       set { self[#function] = newValue }
     }
   }
+
+  // NB: We add a small amount of leeway when comparing dates due to floating point inaccuracies.
+  private func date(_ date: Date, comesBefore otherDate: Date) -> Bool {
+    date
+      .addingTimeInterval(-0.001)
+    < otherDate
+      .addingTimeInterval(0.001)
+  }
+
 #endif

--- a/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
@@ -358,10 +358,7 @@
 
   // NB: We add a small amount of leeway when comparing dates due to floating point inaccuracies.
   private func date(_ date: Date, comesBefore otherDate: Date) -> Bool {
-    date
-      .addingTimeInterval(-0.001)
-    < otherDate
-      .addingTimeInterval(0.001)
+    date.addingTimeInterval(-0.001) < otherDate.addingTimeInterval(0.001)
   }
 
 #endif

--- a/Sources/SQLiteData/CloudKit/Internal/CloudKitFunctions.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/CloudKitFunctions.swift
@@ -2,9 +2,9 @@
   import CloudKit
   import Foundation
 
-  @DatabaseFunction("sqlitedata_icloud_datetime")
-  func datetime() -> Date {
-    @Dependency(\.datetime.now) var now
+  @DatabaseFunction("sqlitedata_icloud_currentTime")
+  func currentTime() -> Int64 {
+    @Dependency(\.currentTime.now) var now
     return now
   }
 

--- a/Sources/SQLiteData/CloudKit/Internal/DatetimeGenerator.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/DatetimeGenerator.swift
@@ -1,26 +1,26 @@
 import Dependencies
 import Foundation
 
-package struct DatetimeGenerator: DependencyKey, Sendable {
-  private var generate: @Sendable () -> Date
-  package var now: Date {
+package struct CurrentTimeGenerator: DependencyKey, Sendable {
+  private var generate: @Sendable () -> Int64
+  package var now: Int64 {
     get { self.generate() }
     set { self.generate = { newValue } }
   }
-  package func callAsFunction() -> Date {
+  package func callAsFunction() -> Int64 {
     self.generate()
   }
-  package static var liveValue: DatetimeGenerator {
-    Self { Date() }
+  package static var liveValue: CurrentTimeGenerator {
+    Self { Int64(clock_gettime_nsec_np(CLOCK_REALTIME)) }
   }
-  package static var testValue: DatetimeGenerator {
-    Self { Date() }
+  package static var testValue: CurrentTimeGenerator {
+    Self { Int64(clock_gettime_nsec_np(CLOCK_REALTIME)) }
   }
 }
 
 extension DependencyValues {
-  package var datetime: DatetimeGenerator {
-    get { self[DatetimeGenerator.self] }
-    set { self[DatetimeGenerator.self] = newValue }
+  package var currentTime: CurrentTimeGenerator {
+    get { self[CurrentTimeGenerator.self] }
+    set { self[CurrentTimeGenerator.self] = newValue }
   }
 }

--- a/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
@@ -64,7 +64,7 @@
           "share" BLOB,
           "hasLastKnownServerRecord" INTEGER NOT NULL AS ("lastKnownServerRecord" IS NOT NULL),
           "isShared" INTEGER NOT NULL AS ("share" IS NOT NULL),
-          "userModificationDate" TEXT NOT NULL DEFAULT (\($datetime())),
+          "userModificationTime" INTEGER NOT NULL DEFAULT (\($currentTime())),
           "_isDeleted" INTEGER NOT NULL DEFAULT 0,
 
           PRIMARY KEY ("recordPrimaryKey", "recordType"),

--- a/Sources/SQLiteData/CloudKit/Internal/Triggers.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Triggers.swift
@@ -118,7 +118,7 @@
       } doUpdate: {
         $0.parentRecordPrimaryKey = $1.parentRecordPrimaryKey
         $0.parentRecordType = $1.parentRecordType
-        $0.userModificationDate = $1.userModificationDate
+        $0.userModificationTime = $1.userModificationTime
       }
     }
   }

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -322,7 +322,7 @@
         )
         .execute(db)
       }
-      db.add(function: $datetime)
+      db.add(function: $currentTime)
       db.add(function: $syncEngineIsSynchronizingChanges)
       db.add(function: $didUpdate)
       db.add(function: $didDelete)
@@ -571,7 +571,7 @@
         db.remove(function: $didDelete)
         db.remove(function: $didUpdate)
         db.remove(function: $syncEngineIsSynchronizingChanges)
-        db.remove(function: $datetime)
+        db.remove(function: $currentTime)
       }
       try metadatabase.erase()
       try migrate(metadatabase: metadatabase)
@@ -932,7 +932,7 @@
 
           record.update(
             with: T(queryOutput: row),
-            userModificationDate: metadata.userModificationDate
+            userModificationTime: metadata.userModificationTime
           )
           await refreshLastKnownServerRecord(record)
           sentRecord = recordID
@@ -1509,7 +1509,7 @@
                 lastKnownServerRecord: serverRecord,
                 _lastKnownServerRecordAllFields: serverRecord,
                 share: nil,
-                userModificationDate: serverRecord.userModificationDate
+                userModificationTime: serverRecord.userModificationTime
               )
             } onConflict: {
               ($0.recordPrimaryKey, $0.recordType)
@@ -1526,8 +1526,8 @@
             .where { $0.recordName.eq(serverRecord.recordID.recordName) }
             .fetchOne(db)
         }
-        serverRecord.userModificationDate =
-          metadata?.userModificationDate ?? serverRecord.userModificationDate
+        serverRecord.userModificationTime =
+          metadata?.userModificationTime ?? serverRecord.userModificationTime
 
         func open<T: PrimaryKeyedTable>(_: T.Type) async throws {
           let columnNames: [String]
@@ -2009,7 +2009,7 @@
       self.lastKnownServerRecord = lastKnownServerRecord
       self._lastKnownServerRecordAllFields = lastKnownServerRecord
       if let lastKnownServerRecord {
-        self.userModificationDate = lastKnownServerRecord.userModificationDate
+        self.userModificationTime = lastKnownServerRecord.userModificationTime
       }
     }
   }

--- a/Sources/SQLiteData/CloudKit/SyncMetadata.swift
+++ b/Sources/SQLiteData/CloudKit/SyncMetadata.swift
@@ -75,8 +75,8 @@
     @Column(generated: .virtual)
     public let isShared: Bool
 
-    /// The date the user last modified the record.
-    public var userModificationDate: Date
+    /// The time the user last modified the record.
+    public var userModificationTime: Int64
   }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
@@ -118,7 +118,7 @@
       lastKnownServerRecord: CKRecord? = nil,
       _lastKnownServerRecordAllFields: CKRecord? = nil,
       share: CKShare? = nil,
-      userModificationDate: Date
+      userModificationTime: Int64
     ) {
       self.recordPrimaryKey = recordPrimaryKey
       self.recordType = recordType
@@ -135,7 +135,7 @@
       self.share = share
       self.hasLastKnownServerRecord = lastKnownServerRecord != nil
       self.isShared = share != nil
-      self.userModificationDate = userModificationDate
+      self.userModificationTime = userModificationTime
     }
   }
 

--- a/Tests/SQLiteDataTests/CloudKitTests/AccountLifecycleTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/AccountLifecycleTests.swift
@@ -171,7 +171,7 @@
         │   _isDeleted: false,                                               │
         │   hasLastKnownServerRecord: true,                                  │
         │   isShared: false,                                                 │
-        │   userModificationDate: Date(1970-01-01T00:00:00.000Z)             │
+        │   userModificationTime: 0                                          │
         │ )                                                                  │
         ├────────────────────────────────────────────────────────────────────┤
         │ SyncMetadata(                                                      │
@@ -187,7 +187,7 @@
         │   _isDeleted: false,                                               │
         │   hasLastKnownServerRecord: false,                                 │
         │   isShared: false,                                                 │
-        │   userModificationDate: Date(1970-01-01T00:00:00.000Z)             │
+        │   userModificationTime: 0                                          │
         │ )                                                                  │
         └────────────────────────────────────────────────────────────────────┘
         """
@@ -248,7 +248,7 @@
         │   _isDeleted: false,                                                                    │
         │   hasLastKnownServerRecord: true,                                                       │
         │   isShared: false,                                                                      │
-        │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+        │   userModificationTime: 0                                                               │
         │ )                                                                                       │
         ├─────────────────────────────────────────────────────────────────────────────────────────┤
         │ SyncMetadata(                                                                           │
@@ -278,7 +278,7 @@
         │   _isDeleted: false,                                                                    │
         │   hasLastKnownServerRecord: true,                                                       │
         │   isShared: false,                                                                      │
-        │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+        │   userModificationTime: 0                                                               │
         │ )                                                                                       │
         └─────────────────────────────────────────────────────────────────────────────────────────┘
         """
@@ -402,7 +402,7 @@
         │   _isDeleted: false,                                                                                │
         │   hasLastKnownServerRecord: true,                                                                   │
         │   isShared: true,                                                                                   │
-        │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                              │
+        │   userModificationTime: 0                                                                           │
         │ )                                                                                                   │
         ├─────────────────────────────────────────────────────────────────────────────────────────────────────┤
         │ SyncMetadata(                                                                                       │
@@ -418,7 +418,7 @@
         │   _isDeleted: false,                                                                                │
         │   hasLastKnownServerRecord: false,                                                                  │
         │   isShared: false,                                                                                  │
-        │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                              │
+        │   userModificationTime: 0                                                                           │
         │ )                                                                                                   │
         └─────────────────────────────────────────────────────────────────────────────────────────────────────┘
         """
@@ -490,7 +490,7 @@
         │   _isDeleted: false,                                                                                │
         │   hasLastKnownServerRecord: true,                                                                   │
         │   isShared: true,                                                                                   │
-        │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                              │
+        │   userModificationTime: 0                                                                           │
         │ )                                                                                                   │
         ├─────────────────────────────────────────────────────────────────────────────────────────────────────┤
         │ SyncMetadata(                                                                                       │
@@ -520,7 +520,7 @@
         │   _isDeleted: false,                                                                                │
         │   hasLastKnownServerRecord: true,                                                                   │
         │   isShared: false,                                                                                  │
-        │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                              │
+        │   userModificationTime: 0                                                                           │
         │ )                                                                                                   │
         └─────────────────────────────────────────────────────────────────────────────────────────────────────┘
         """

--- a/Tests/SQLiteDataTests/CloudKitTests/AssetsTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/AssetsTests.swift
@@ -71,7 +71,7 @@
         }
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try await userDatabase.userWrite { db in
             try RemindersListAsset

--- a/Tests/SQLiteDataTests/CloudKitTests/AssetsTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/AssetsTests.swift
@@ -71,7 +71,7 @@
         }
 
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try await userDatabase.userWrite { db in
             try RemindersListAsset

--- a/Tests/SQLiteDataTests/CloudKitTests/CloudKitTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/CloudKitTests.swift
@@ -502,7 +502,7 @@
         }
 
         try await withDependencies {
-          $0.currentTime.now += (60)
+          $0.currentTime.now += 60
         } operation: {
           try await userDatabase.userWrite { db in
             try RemindersList
@@ -569,7 +569,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.currentTime.now += (60)
+          $0.currentTime.now += 60
         } operation: {
           let record = try syncEngine.private.database.record(for: RemindersList.recordID(for: 1))
           record.setValue("Work", forKey: "title", at: now)
@@ -631,7 +631,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try await userDatabase.userWrite { db in
             try RemindersList.find(1).update { $0.title = "My stuff" }.execute(db)

--- a/Tests/SQLiteDataTests/CloudKitTests/CloudKitTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/CloudKitTests.swift
@@ -447,7 +447,7 @@
         ) {
           """
           [
-            [0]: "sqlitedata_icloud_datetime",
+            [0]: "sqlitedata_icloud_currenttime",
             [1]: "sqlitedata_icloud_diddelete",
             [2]: "sqlitedata_icloud_didupdate",
             [3]: "sqlitedata_icloud_haspermission",
@@ -502,7 +502,7 @@
         }
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(60)
+          $0.currentTime.now += (60)
         } operation: {
           try await userDatabase.userWrite { db in
             try RemindersList
@@ -569,7 +569,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(60)
+          $0.currentTime.now += (60)
         } operation: {
           let record = try syncEngine.private.database.record(for: RemindersList.recordID(for: 1))
           record.setValue("Work", forKey: "title", at: now)
@@ -587,13 +587,13 @@
           """
         }
         assertQuery(
-          SyncMetadata.select(\.userModificationDate),
+          SyncMetadata.select(\.userModificationTime),
           database: syncEngine.metadatabase
         ) {
           """
-          ┌────────────────────────────────┐
-          │ Date(1970-01-01T00:01:00.000Z) │
-          └────────────────────────────────┘
+          ┌────┐
+          │ 60 │
+          └────┘
           """
         }
         assertInlineSnapshot(of: container, as: .customDump) {
@@ -631,7 +631,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try await userDatabase.userWrite { db in
             try RemindersList.find(1).update { $0.title = "My stuff" }.execute(db)
@@ -683,13 +683,13 @@
 
         assertQuery(Reminder.all, database: userDatabase.database)
         assertQuery(
-          SyncMetadata.select(\.userModificationDate),
+          SyncMetadata.select(\.userModificationTime),
           database: syncEngine.metadatabase
         ) {
           """
-          ┌────────────────────────────────┐
-          │ Date(1970-01-01T00:00:00.000Z) │
-          └────────────────────────────────┘
+          ┌───┐
+          │ 0 │
+          └───┘
           """
         }
         assertInlineSnapshot(of: container, as: .customDump) {

--- a/Tests/SQLiteDataTests/CloudKitTests/FetchRecordZoneChangesTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/FetchRecordZoneChangesTests.swift
@@ -64,7 +64,7 @@
         }
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.isCompleted.toggle() }.execute(db)
@@ -120,7 +120,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           let reminderRecord = try syncEngine.private.database
             .record(for: Reminder.recordID(for: 1))
@@ -134,7 +134,7 @@
         }
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(2)
+          $0.currentTime.now += (2)
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.isCompleted.toggle() }.execute(db)
@@ -224,7 +224,7 @@
         try await syncEngine.modifyRecords(scope: .private, saving: [remindersListRecord]).notify()
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try await userDatabase.userWrite { db in
             try RemindersList.find(1).update { $0.title = "My stuff" }.execute(db)
@@ -306,7 +306,7 @@
         await remindersListModification.notify()
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.title = "Buy milk" }.execute(db)
@@ -426,7 +426,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try await userDatabase.userWrite { db in
             try Tag.find("weekend").update { $0.title = "optional" }.execute(db)
@@ -545,7 +545,7 @@
           │   _isDeleted: false,                                       │
           │   hasLastKnownServerRecord: true,                          │
           │   isShared: false,                                         │
-          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)     │
+          │   userModificationTime: 0                                  │
           │ )                                                          │
           └────────────────────────────────────────────────────────────┘
           """
@@ -625,7 +625,7 @@
           │   _isDeleted: false,                                       │
           │   hasLastKnownServerRecord: true,                          │
           │   isShared: false,                                         │
-          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)     │
+          │   userModificationTime: 0                                  │
           │ )                                                          │
           └────────────────────────────────────────────────────────────┘
           """
@@ -692,7 +692,7 @@
           │   _isDeleted: false,                                           │
           │   hasLastKnownServerRecord: true,                              │
           │   isShared: false,                                             │
-          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)         │
+          │   userModificationTime: 0                                      │
           │ )                                                              │
           └────────────────────────────────────────────────────────────────┘
           """

--- a/Tests/SQLiteDataTests/CloudKitTests/FetchRecordZoneChangesTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/FetchRecordZoneChangesTests.swift
@@ -124,7 +124,7 @@
         } operation: {
           let reminderRecord = try syncEngine.private.database
             .record(for: Reminder.recordID(for: 1))
-          reminderRecord.setValue("2", forKey: "remindersListID", at: now)
+          reminderRecord.setValue(2, forKey: "remindersListID", at: now)
           reminderRecord.parent = CKRecord.Reference(
             recordID: RemindersList.recordID(for: 2),
             action: .none
@@ -133,8 +133,12 @@
           try await syncEngine.modifyRecords(scope: .private, saving: [reminderRecord]).notify()
         }
 
-        try await userDatabase.userWrite { db in
-          try Reminder.find(1).update { $0.isCompleted.toggle() }.execute(db)
+        try await withDependencies {
+          $0.datetime.now.addTimeInterval(2)
+        } operation: {
+          try await userDatabase.userWrite { db in
+            try Reminder.find(1).update { $0.isCompleted.toggle() }.execute(db)
+          }
         }
 
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
@@ -177,8 +181,8 @@
                   parent: CKReference(recordID: CKRecord.ID(2:remindersLists/zone/__defaultOwner__)),
                   share: nil,
                   id: 1,
-                  isCompleted: 0,
-                  remindersListID: "2",
+                  isCompleted: 1,
+                  remindersListID: 2,
                   title: "Get milk"
                 ),
                 [1]: CKRecord(

--- a/Tests/SQLiteDataTests/CloudKitTests/FetchRecordZoneChangesTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/FetchRecordZoneChangesTests.swift
@@ -64,7 +64,7 @@
         }
 
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.isCompleted.toggle() }.execute(db)
@@ -120,7 +120,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           let reminderRecord = try syncEngine.private.database
             .record(for: Reminder.recordID(for: 1))
@@ -134,7 +134,7 @@
         }
 
         try await withDependencies {
-          $0.currentTime.now += (2)
+          $0.currentTime.now += 2
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.isCompleted.toggle() }.execute(db)
@@ -224,7 +224,7 @@
         try await syncEngine.modifyRecords(scope: .private, saving: [remindersListRecord]).notify()
 
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try await userDatabase.userWrite { db in
             try RemindersList.find(1).update { $0.title = "My stuff" }.execute(db)
@@ -306,7 +306,7 @@
         await remindersListModification.notify()
 
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.title = "Buy milk" }.execute(db)
@@ -426,7 +426,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try await userDatabase.userWrite { db in
             try Tag.find("weekend").update { $0.title = "optional" }.execute(db)

--- a/Tests/SQLiteDataTests/CloudKitTests/ForeignKeyConstraintTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ForeignKeyConstraintTests.swift
@@ -43,7 +43,7 @@
         await remindersListModification.notify()
 
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.title = "Buy milk" }.execute(db)
@@ -388,7 +388,7 @@
         }
 
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.title = "Buy milk" }.execute(db)
@@ -485,7 +485,7 @@
         ).notify()
 
         let modifications = try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           let reminderRecord = try syncEngine.private.database.record(
             for: Reminder.recordID(for: 1)
@@ -606,7 +606,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         let modifications = try withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           let reminderRecord = try syncEngine.private.database
             .record(for: Reminder.recordID(for: 1))
@@ -619,7 +619,7 @@
         }
 
         try await withDependencies {
-          $0.currentTime.now += (2)
+          $0.currentTime.now += 2
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1)
@@ -705,7 +705,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         let modifications = try withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           let reminderRecord = try syncEngine.private.database
             .record(for: Reminder.recordID(for: 1))
@@ -718,7 +718,7 @@
         }
 
         try await withDependencies {
-          $0.currentTime.now += (2)
+          $0.currentTime.now += 2
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.remindersListID = 3 }.execute(db)

--- a/Tests/SQLiteDataTests/CloudKitTests/ForeignKeyConstraintTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ForeignKeyConstraintTests.swift
@@ -43,7 +43,7 @@
         await remindersListModification.notify()
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.title = "Buy milk" }.execute(db)
@@ -388,7 +388,7 @@
         }
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.title = "Buy milk" }.execute(db)
@@ -485,7 +485,7 @@
         ).notify()
 
         let modifications = try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           let reminderRecord = try syncEngine.private.database.record(
             for: Reminder.recordID(for: 1)
@@ -606,7 +606,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         let modifications = try withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           let reminderRecord = try syncEngine.private.database
             .record(for: Reminder.recordID(for: 1))
@@ -619,7 +619,7 @@
         }
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(2)
+          $0.currentTime.now += (2)
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1)
@@ -705,7 +705,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         let modifications = try withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           let reminderRecord = try syncEngine.private.database
             .record(for: Reminder.recordID(for: 1))
@@ -718,7 +718,7 @@
         }
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(2)
+          $0.currentTime.now += (2)
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.remindersListID = 3 }.execute(db)

--- a/Tests/SQLiteDataTests/CloudKitTests/MergeConflictTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MergeConflictTests.swift
@@ -65,14 +65,13 @@
         }
 
         let record = try syncEngine.private.database.record(for: Reminder.recordID(for: 1))
-        let userModificationDate = now.addingTimeInterval(60)
-        record.setValue("Buy milk", forKey: "title", at: userModificationDate)
+        record.setValue("Buy milk", forKey: "title", at: 60)
         let modificationCallback = try {
           try syncEngine.modifyRecords(scope: .private, saving: [record])
         }()
 
         try await withDependencies {
-          $0.datetime.now = now.addingTimeInterval(30)
+          $0.currentTime.now += 30
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.isCompleted = true }.execute(db)
@@ -220,14 +219,13 @@
         }
 
         let record = try syncEngine.private.database.record(for: Reminder.recordID(for: 1))
-        let userModificationDate = now.addingTimeInterval(30)
-        record.setValue("Buy milk", forKey: "title", at: userModificationDate)
+        record.setValue("Buy milk", forKey: "title", at: 30)
         let modificationCallback = try {
           try syncEngine.modifyRecords(scope: .private, saving: [record])
         }()
 
         try await withDependencies {
-          $0.datetime.now = now.addingTimeInterval(60)
+          $0.currentTime.now += 60
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.isCompleted = true }.execute(db)
@@ -334,14 +332,13 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         let record = try syncEngine.private.database.record(for: Reminder.recordID(for: 1))
-        let userModificationDate = now.addingTimeInterval(30)
-        record.setValue("Buy milk", forKey: "title", at: userModificationDate)
+        record.setValue("Buy milk", forKey: "title", at: 30)
         let modificationCallback = try {
           try syncEngine.modifyRecords(scope: .private, saving: [record])
         }()
 
         try await withDependencies {
-          $0.datetime.now = now.addingTimeInterval(60)
+          $0.currentTime.now += 60
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.isCompleted = true }.execute(db)
@@ -404,13 +401,13 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.datetime.now = now.addingTimeInterval(30)
+          $0.currentTime.now += 30
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.title = "Get milk" }.execute(db)
           }
           try await withDependencies {
-            $0.datetime.now = now.addingTimeInterval(30)
+            $0.currentTime.now += 30
           } operation: {
             let record = try syncEngine.private.database.record(for: Reminder.recordID(for: 1))
             record.setValue("Buy milk", forKey: "title", at: now)
@@ -454,7 +451,7 @@
                   isCompleted🗓️: 0,
                   remindersListID: 1,
                   remindersListID🗓️: 0,
-                  title: "Get milk",
+                  title: "Buy milk",
                   title🗓️: 60,
                   🗓️: 60
                 ),
@@ -491,14 +488,13 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         let record = try syncEngine.private.database.record(for: Reminder.recordID(for: 1))
-        let userModificationDate = now.addingTimeInterval(30)
-        record.setValue("Buy milk", forKey: "title", at: userModificationDate)
+        record.setValue("Buy milk", forKey: "title", at: 30)
         let modificationCallback = try {
           try syncEngine.modifyRecords(scope: .private, saving: [record])
         }()
 
         try await withDependencies {
-          $0.datetime.now = now.addingTimeInterval(60)
+          $0.currentTime.now += 60
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.title = "Get milk" }.execute(db)
@@ -561,14 +557,13 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         let record = try syncEngine.private.database.record(for: Reminder.recordID(for: 1))
-        let userModificationDate = now.addingTimeInterval(30)
-        record.setValue("Buy milk", forKey: "title", at: userModificationDate)
+        record.setValue("Buy milk", forKey: "title", at: 30)
         let modificationCallback = try {
           try syncEngine.modifyRecords(scope: .private, saving: [record])
         }()
 
         try await withDependencies {
-          $0.datetime.now = now.addingTimeInterval(60)
+          $0.currentTime.now += 60
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.title = "Get milk" }.execute(db)
@@ -634,10 +629,10 @@
         let reminderRecord = try syncEngine.private.database.record(
           for: Reminder.recordID(for: 1)
         )
-        reminderRecord.setValue(
-          now.addingTimeInterval(30),
+        reminderRecord.setValue(Date(
+          timeIntervalSince1970: Double(now + 30)),
           forKey: "dueDate",
-          at: now.addingTimeInterval(1)
+          at: now + 1
         )
         let modificationsFinished = try syncEngine.modifyRecords(
           scope: .private,
@@ -645,7 +640,7 @@
         )
 
         try withDependencies {
-          $0.datetime.now.addTimeInterval(2)
+          $0.currentTime.now += (2)
         } operation: {
           try userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.priority = 3 }.execute(db)

--- a/Tests/SQLiteDataTests/CloudKitTests/MergeConflictTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MergeConflictTests.swift
@@ -640,7 +640,7 @@
         )
 
         try withDependencies {
-          $0.currentTime.now += (2)
+          $0.currentTime.now += 2
         } operation: {
           try userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.priority = 3 }.execute(db)

--- a/Tests/SQLiteDataTests/CloudKitTests/MergeConflictTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MergeConflictTests.swift
@@ -451,7 +451,7 @@
                   isCompleted🗓️: 0,
                   remindersListID: 1,
                   remindersListID🗓️: 0,
-                  title: "Buy milk",
+                  title: "Get milk",
                   title🗓️: 60,
                   🗓️: 60
                 ),

--- a/Tests/SQLiteDataTests/CloudKitTests/MergeConflictTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MergeConflictTests.swift
@@ -714,10 +714,6 @@
           )
         }
       }
-
-      @Test func doubleResolution() {
-
-      }
     }
   }
 #endif

--- a/Tests/SQLiteDataTests/CloudKitTests/MetadataTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MetadataTests.swift
@@ -25,7 +25,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try withDependencies {
-          $0.datetime.now.addTimeInterval(60)
+          $0.currentTime.now += (60)
         } operation: {
           try userDatabase.userWrite { db in
             try Reminder.find(1)
@@ -234,7 +234,7 @@
           │   _isDeleted: false,                                                                    │
           │   hasLastKnownServerRecord: true,                                                       │
           │   isShared: false,                                                                      │
-          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+          │   userModificationTime: 0                                                               │
           │ )                                                                                       │
           ├─────────────────────────────────────────────────────────────────────────────────────────┤
           │ SyncMetadata(                                                                           │
@@ -264,7 +264,7 @@
           │   _isDeleted: false,                                                                    │
           │   hasLastKnownServerRecord: true,                                                       │
           │   isShared: false,                                                                      │
-          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+          │   userModificationTime: 0                                                               │
           │ )                                                                                       │
           ├─────────────────────────────────────────────────────────────────────────────────────────┤
           │ SyncMetadata(                                                                           │
@@ -292,7 +292,7 @@
           │   _isDeleted: false,                                                                    │
           │   hasLastKnownServerRecord: true,                                                       │
           │   isShared: false,                                                                      │
-          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+          │   userModificationTime: 0                                                               │
           │ )                                                                                       │
           ├─────────────────────────────────────────────────────────────────────────────────────────┤
           │ SyncMetadata(                                                                           │
@@ -321,7 +321,7 @@
           │   _isDeleted: false,                                                                    │
           │   hasLastKnownServerRecord: true,                                                       │
           │   isShared: false,                                                                      │
-          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+          │   userModificationTime: 0                                                               │
           │ )                                                                                       │
           ├─────────────────────────────────────────────────────────────────────────────────────────┤
           │ SyncMetadata(                                                                           │
@@ -351,7 +351,7 @@
           │   _isDeleted: false,                                                                    │
           │   hasLastKnownServerRecord: true,                                                       │
           │   isShared: false,                                                                      │
-          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+          │   userModificationTime: 0                                                               │
           │ )                                                                                       │
           ├─────────────────────────────────────────────────────────────────────────────────────────┤
           │ SyncMetadata(                                                                           │
@@ -379,7 +379,7 @@
           │   _isDeleted: false,                                                                    │
           │   hasLastKnownServerRecord: true,                                                       │
           │   isShared: false,                                                                      │
-          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+          │   userModificationTime: 0                                                               │
           │ )                                                                                       │
           ├─────────────────────────────────────────────────────────────────────────────────────────┤
           │ SyncMetadata(                                                                           │
@@ -408,7 +408,7 @@
           │   _isDeleted: false,                                                                    │
           │   hasLastKnownServerRecord: true,                                                       │
           │   isShared: false,                                                                      │
-          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+          │   userModificationTime: 0                                                               │
           │ )                                                                                       │
           ├─────────────────────────────────────────────────────────────────────────────────────────┤
           │ SyncMetadata(                                                                           │
@@ -438,7 +438,7 @@
           │   _isDeleted: false,                                                                    │
           │   hasLastKnownServerRecord: true,                                                       │
           │   isShared: false,                                                                      │
-          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+          │   userModificationTime: 0                                                               │
           │ )                                                                                       │
           ├─────────────────────────────────────────────────────────────────────────────────────────┤
           │ SyncMetadata(                                                                           │
@@ -465,7 +465,7 @@
           │   _isDeleted: false,                                                                    │
           │   hasLastKnownServerRecord: true,                                                       │
           │   isShared: false,                                                                      │
-          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+          │   userModificationTime: 0                                                               │
           │ )                                                                                       │
           ├─────────────────────────────────────────────────────────────────────────────────────────┤
           │ SyncMetadata(                                                                           │
@@ -492,7 +492,7 @@
           │   _isDeleted: false,                                                                    │
           │   hasLastKnownServerRecord: true,                                                       │
           │   isShared: false,                                                                      │
-          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+          │   userModificationTime: 0                                                               │
           │ )                                                                                       │
           └─────────────────────────────────────────────────────────────────────────────────────────┘
           """
@@ -542,7 +542,7 @@
           │                     │   _isDeleted: false,                                               │
           │                     │   hasLastKnownServerRecord: true,                                  │
           │                     │   isShared: false,                                                 │
-          │                     │   userModificationDate: Date(1970-01-01T00:00:00.000Z)             │
+          │                     │   userModificationTime: 0                                          │
           │                     │ )                                                                  │
           ├─────────────────────┼────────────────────────────────────────────────────────────────────┤
           │ RemindersList(      │ SyncMetadata(                                                      │
@@ -570,7 +570,7 @@
           │                     │   _isDeleted: false,                                               │
           │                     │   hasLastKnownServerRecord: true,                                  │
           │                     │   isShared: false,                                                 │
-          │                     │   userModificationDate: Date(1970-01-01T00:00:00.000Z)             │
+          │                     │   userModificationTime: 0                                          │
           │                     │ )                                                                  │
           └─────────────────────┴────────────────────────────────────────────────────────────────────┘
           """

--- a/Tests/SQLiteDataTests/CloudKitTests/MetadataTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MetadataTests.swift
@@ -25,7 +25,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try withDependencies {
-          $0.currentTime.now += (60)
+          $0.currentTime.now += 60
         } operation: {
           try userDatabase.userWrite { db in
             try Reminder.find(1)

--- a/Tests/SQLiteDataTests/CloudKitTests/NextRecordZoneChangeBatchTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/NextRecordZoneChangeBatchTests.swift
@@ -40,7 +40,7 @@
             SyncMetadata(
               recordPrimaryKey: "1",
               recordType: UnrecognizedTable.tableName,
-              userModificationDate: .distantPast
+              userModificationTime: 0
             )
           }
           .execute(db)
@@ -70,7 +70,7 @@
             SyncMetadata(
               recordPrimaryKey: "1",
               recordType: RemindersList.tableName,
-              userModificationDate: .distantPast
+              userModificationTime: 0
             )
           }
           .execute(db)

--- a/Tests/SQLiteDataTests/CloudKitTests/ReferenceViolationTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ReferenceViolationTests.swift
@@ -29,7 +29,7 @@
           deleting: [RemindersList.recordID(for: 2)]
         )
         try withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.remindersListID = 2 }.execute(db)
@@ -92,14 +92,14 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try await userDatabase.userWrite { db in
             try RemindersList.find(1).delete().execute(db)
           }
         }
         let modifications = try withDependencies {
-          $0.datetime.now.addTimeInterval(2)
+          $0.currentTime.now += (2)
         } operation: {
           let reminderRecord = CKRecord(
             recordType: Reminder.tableName,
@@ -174,14 +174,14 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try await userDatabase.userWrite { db in
             try RemindersList.find(1).delete().execute(db)
           }
         }
         let modifications = try withDependencies {
-          $0.datetime.now.addTimeInterval(2)
+          $0.currentTime.now += (2)
         } operation: {
           let reminderRecord = CKRecord(
             recordType: Reminder.tableName,
@@ -262,14 +262,14 @@
           deleting: [Parent.recordID(for: 2)]
         )
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try await userDatabase.userWrite { db in
             try ChildWithOnDeleteSetNull.find(1).update { $0.parentID = 2 }.execute(db)
           }
         }
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(2)
+          $0.currentTime.now += (2)
         } operation: {
           try await syncEngine.processPendingRecordZoneChanges(scope: .private)
           await modifications.notify()
@@ -340,14 +340,14 @@
           deleting: [Parent.recordID(for: 2)]
         )
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try await userDatabase.userWrite { db in
             try ChildWithOnDeleteSetDefault.find(1).update { $0.parentID = 2 }.execute(db)
           }
         }
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(2)
+          $0.currentTime.now += (2)
         } operation: {
           try await syncEngine.processPendingRecordZoneChanges(scope: .private)
           await modifications.notify()

--- a/Tests/SQLiteDataTests/CloudKitTests/ReferenceViolationTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ReferenceViolationTests.swift
@@ -29,7 +29,7 @@
           deleting: [RemindersList.recordID(for: 2)]
         )
         try withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.remindersListID = 2 }.execute(db)
@@ -92,14 +92,14 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try await userDatabase.userWrite { db in
             try RemindersList.find(1).delete().execute(db)
           }
         }
         let modifications = try withDependencies {
-          $0.currentTime.now += (2)
+          $0.currentTime.now += 2
         } operation: {
           let reminderRecord = CKRecord(
             recordType: Reminder.tableName,
@@ -174,14 +174,14 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try await userDatabase.userWrite { db in
             try RemindersList.find(1).delete().execute(db)
           }
         }
         let modifications = try withDependencies {
-          $0.currentTime.now += (2)
+          $0.currentTime.now += 2
         } operation: {
           let reminderRecord = CKRecord(
             recordType: Reminder.tableName,
@@ -262,14 +262,14 @@
           deleting: [Parent.recordID(for: 2)]
         )
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try await userDatabase.userWrite { db in
             try ChildWithOnDeleteSetNull.find(1).update { $0.parentID = 2 }.execute(db)
           }
         }
         try await withDependencies {
-          $0.currentTime.now += (2)
+          $0.currentTime.now += 2
         } operation: {
           try await syncEngine.processPendingRecordZoneChanges(scope: .private)
           await modifications.notify()
@@ -340,14 +340,14 @@
           deleting: [Parent.recordID(for: 2)]
         )
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try await userDatabase.userWrite { db in
             try ChildWithOnDeleteSetDefault.find(1).update { $0.parentID = 2 }.execute(db)
           }
         }
         try await withDependencies {
-          $0.currentTime.now += (2)
+          $0.currentTime.now += 2
         } operation: {
           try await syncEngine.processPendingRecordZoneChanges(scope: .private)
           await modifications.notify()

--- a/Tests/SQLiteDataTests/CloudKitTests/SchemaChangeTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SchemaChangeTests.swift
@@ -31,7 +31,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.currentTime.now += (60)
+          $0.currentTime.now += 60
         } operation: {
           let personalListRecord = try syncEngine.private.database.record(
             for: RemindersList.recordID(for: 1)
@@ -121,7 +121,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.currentTime.now += (60)
+          $0.currentTime.now += 60
         } operation: {
           let personalListRecord = try syncEngine.private.database.record(
             for: RemindersList.recordID(for: 1)
@@ -180,7 +180,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.currentTime.now += (60)
+          $0.currentTime.now += 60
         } operation: {
           let personalListRecord = try syncEngine.private.database.record(
             for: RemindersList.recordID(for: 1)
@@ -241,7 +241,7 @@
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func newTable() async throws {
         try await withDependencies {
-          $0.currentTime.now += (60)
+          $0.currentTime.now += 60
         } operation: {
           let imageRecord = CKRecord(
             recordType: "images",

--- a/Tests/SQLiteDataTests/CloudKitTests/SchemaChangeTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SchemaChangeTests.swift
@@ -31,7 +31,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(60)
+          $0.currentTime.now += (60)
         } operation: {
           let personalListRecord = try syncEngine.private.database.record(
             for: RemindersList.recordID(for: 1)
@@ -121,7 +121,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(60)
+          $0.currentTime.now += (60)
         } operation: {
           let personalListRecord = try syncEngine.private.database.record(
             for: RemindersList.recordID(for: 1)
@@ -180,7 +180,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(60)
+          $0.currentTime.now += (60)
         } operation: {
           let personalListRecord = try syncEngine.private.database.record(
             for: RemindersList.recordID(for: 1)
@@ -241,7 +241,7 @@
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func newTable() async throws {
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(60)
+          $0.currentTime.now += (60)
         } operation: {
           let imageRecord = CKRecord(
             recordType: "images",

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingPermissionsTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingPermissionsTests.swift
@@ -336,7 +336,7 @@
         freshShare.currentUserParticipant?.permission = .readOnly
         let _ = try syncEngine.modifyRecords(scope: .shared, saving: [freshShare])
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try await self.userDatabase.userWrite { db in
             try db.seed {
@@ -424,7 +424,7 @@
         let _ = try syncEngine.modifyRecords(scope: .shared, saving: [freshShare])
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(1)
+          $0.currentTime.now += (1)
         } operation: {
           try await self.userDatabase.userWrite { db in
             try RemindersList.find(1).update { $0.title = "Business" }.execute(db)

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingPermissionsTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingPermissionsTests.swift
@@ -336,7 +336,7 @@
         freshShare.currentUserParticipant?.permission = .readOnly
         let _ = try syncEngine.modifyRecords(scope: .shared, saving: [freshShare])
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try await self.userDatabase.userWrite { db in
             try db.seed {
@@ -424,7 +424,7 @@
         let _ = try syncEngine.modifyRecords(scope: .shared, saving: [freshShare])
 
         try await withDependencies {
-          $0.currentTime.now += (1)
+          $0.currentTime.now += 1
         } operation: {
           try await self.userDatabase.userWrite { db in
             try RemindersList.find(1).update { $0.title = "Business" }.execute(db)

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -171,7 +171,7 @@
         try await syncEngine.modifyRecords(scope: .shared, saving: [remindersListRecord]).notify()
 
         try await withDependencies {
-          $0.currentTime.now += (60)
+          $0.currentTime.now += 60
         } operation: {
           try await userDatabase.userWrite { db in
             try db.seed {
@@ -344,7 +344,7 @@
         try await syncEngine.modifyRecords(scope: .shared, saving: [modelARecord]).notify()
 
         try await withDependencies {
-          $0.currentTime.now += (60)
+          $0.currentTime.now += 60
         } operation: {
           try await userDatabase.userWrite { db in
             try db.seed {
@@ -430,7 +430,7 @@
         ).notify()
 
         try await withDependencies {
-          $0.currentTime.now += (60)
+          $0.currentTime.now += 60
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).delete().execute(db)

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -171,7 +171,7 @@
         try await syncEngine.modifyRecords(scope: .shared, saving: [remindersListRecord]).notify()
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(60)
+          $0.currentTime.now += (60)
         } operation: {
           try await userDatabase.userWrite { db in
             try db.seed {
@@ -318,7 +318,7 @@
           │   _isDeleted: false,                                                                                │
           │   hasLastKnownServerRecord: true,                                                                   │
           │   isShared: true,                                                                                   │
-          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                              │
+          │   userModificationTime: 0                                                                           │
           │ )                                                                                                   │
           └─────────────────────────────────────────────────────────────────────────────────────────────────────┘
           """
@@ -344,7 +344,7 @@
         try await syncEngine.modifyRecords(scope: .shared, saving: [modelARecord]).notify()
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(60)
+          $0.currentTime.now += (60)
         } operation: {
           try await userDatabase.userWrite { db in
             try db.seed {
@@ -430,7 +430,7 @@
         ).notify()
 
         try await withDependencies {
-          $0.datetime.now.addTimeInterval(60)
+          $0.currentTime.now += (60)
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).delete().execute(db)

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineLifecycleTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineLifecycleTests.swift
@@ -33,39 +33,39 @@
 
           assertQuery(SyncMetadata.all, database: syncEngine.metadatabase) {
             """
-            ┌────────────────────────────────────────────────────────┐
-            │ SyncMetadata(                                          │
-            │   recordPrimaryKey: "1",                               │
-            │   recordType: "remindersLists",                        │
-            │   recordName: "1:remindersLists",                      │
-            │   parentRecordPrimaryKey: nil,                         │
-            │   parentRecordType: nil,                               │
-            │   parentRecordName: nil,                               │
-            │   lastKnownServerRecord: nil,                          │
-            │   _lastKnownServerRecordAllFields: nil,                │
-            │   share: nil,                                          │
-            │   _isDeleted: false,                                   │
-            │   hasLastKnownServerRecord: false,                     │
-            │   isShared: false,                                     │
-            │   userModificationDate: Date(1970-01-01T00:00:00.000Z) │
-            │ )                                                      │
-            ├────────────────────────────────────────────────────────┤
-            │ SyncMetadata(                                          │
-            │   recordPrimaryKey: "1",                               │
-            │   recordType: "reminders",                             │
-            │   recordName: "1:reminders",                           │
-            │   parentRecordPrimaryKey: "1",                         │
-            │   parentRecordType: "remindersLists",                  │
-            │   parentRecordName: "1:remindersLists",                │
-            │   lastKnownServerRecord: nil,                          │
-            │   _lastKnownServerRecordAllFields: nil,                │
-            │   share: nil,                                          │
-            │   _isDeleted: false,                                   │
-            │   hasLastKnownServerRecord: false,                     │
-            │   isShared: false,                                     │
-            │   userModificationDate: Date(1970-01-01T00:00:00.000Z) │
-            │ )                                                      │
-            └────────────────────────────────────────────────────────┘
+            ┌─────────────────────────────────────────┐
+            │ SyncMetadata(                           │
+            │   recordPrimaryKey: "1",                │
+            │   recordType: "remindersLists",         │
+            │   recordName: "1:remindersLists",       │
+            │   parentRecordPrimaryKey: nil,          │
+            │   parentRecordType: nil,                │
+            │   parentRecordName: nil,                │
+            │   lastKnownServerRecord: nil,           │
+            │   _lastKnownServerRecordAllFields: nil, │
+            │   share: nil,                           │
+            │   _isDeleted: false,                    │
+            │   hasLastKnownServerRecord: false,      │
+            │   isShared: false,                      │
+            │   userModificationTime: 0               │
+            │ )                                       │
+            ├─────────────────────────────────────────┤
+            │ SyncMetadata(                           │
+            │   recordPrimaryKey: "1",                │
+            │   recordType: "reminders",              │
+            │   recordName: "1:reminders",            │
+            │   parentRecordPrimaryKey: "1",          │
+            │   parentRecordType: "remindersLists",   │
+            │   parentRecordName: "1:remindersLists", │
+            │   lastKnownServerRecord: nil,           │
+            │   _lastKnownServerRecordAllFields: nil, │
+            │   share: nil,                           │
+            │   _isDeleted: false,                    │
+            │   hasLastKnownServerRecord: false,      │
+            │   isShared: false,                      │
+            │   userModificationTime: 0               │
+            │ )                                       │
+            └─────────────────────────────────────────┘
             """
           }
           assertInlineSnapshot(of: container, as: .customDump) {
@@ -178,7 +178,7 @@
           syncEngine.stop()
 
           try await withDependencies {
-            $0.datetime.now.addTimeInterval(1)
+            $0.currentTime.now += (1)
           } operation: {
             try await userDatabase.userWrite { db in
               try RemindersList.find(1).update { $0.title += "!" }.execute(db)
@@ -257,7 +257,7 @@
           syncEngine.stop()
 
           try await withDependencies {
-            $0.datetime.now.addTimeInterval(60)
+            $0.currentTime.now += (60)
           } operation: {
             try await userDatabase.userWrite { db in
               try db.seed {
@@ -434,39 +434,39 @@
 
           assertQuery(SyncMetadata.all, database: syncEngine.metadatabase) {
             """
-            ┌────────────────────────────────────────────────────────┐
-            │ SyncMetadata(                                          │
-            │   recordPrimaryKey: "1",                               │
-            │   recordType: "remindersLists",                        │
-            │   recordName: "1:remindersLists",                      │
-            │   parentRecordPrimaryKey: nil,                         │
-            │   parentRecordType: nil,                               │
-            │   parentRecordName: nil,                               │
-            │   lastKnownServerRecord: nil,                          │
-            │   _lastKnownServerRecordAllFields: nil,                │
-            │   share: nil,                                          │
-            │   _isDeleted: false,                                   │
-            │   hasLastKnownServerRecord: false,                     │
-            │   isShared: false,                                     │
-            │   userModificationDate: Date(1970-01-01T00:00:00.000Z) │
-            │ )                                                      │
-            ├────────────────────────────────────────────────────────┤
-            │ SyncMetadata(                                          │
-            │   recordPrimaryKey: "1",                               │
-            │   recordType: "reminders",                             │
-            │   recordName: "1:reminders",                           │
-            │   parentRecordPrimaryKey: "1",                         │
-            │   parentRecordType: "remindersLists",                  │
-            │   parentRecordName: "1:remindersLists",                │
-            │   lastKnownServerRecord: nil,                          │
-            │   _lastKnownServerRecordAllFields: nil,                │
-            │   share: nil,                                          │
-            │   _isDeleted: false,                                   │
-            │   hasLastKnownServerRecord: false,                     │
-            │   isShared: false,                                     │
-            │   userModificationDate: Date(1970-01-01T00:00:00.000Z) │
-            │ )                                                      │
-            └────────────────────────────────────────────────────────┘
+            ┌─────────────────────────────────────────┐
+            │ SyncMetadata(                           │
+            │   recordPrimaryKey: "1",                │
+            │   recordType: "remindersLists",         │
+            │   recordName: "1:remindersLists",       │
+            │   parentRecordPrimaryKey: nil,          │
+            │   parentRecordType: nil,                │
+            │   parentRecordName: nil,                │
+            │   lastKnownServerRecord: nil,           │
+            │   _lastKnownServerRecordAllFields: nil, │
+            │   share: nil,                           │
+            │   _isDeleted: false,                    │
+            │   hasLastKnownServerRecord: false,      │
+            │   isShared: false,                      │
+            │   userModificationTime: 0               │
+            │ )                                       │
+            ├─────────────────────────────────────────┤
+            │ SyncMetadata(                           │
+            │   recordPrimaryKey: "1",                │
+            │   recordType: "reminders",              │
+            │   recordName: "1:reminders",            │
+            │   parentRecordPrimaryKey: "1",          │
+            │   parentRecordType: "remindersLists",   │
+            │   parentRecordName: "1:remindersLists", │
+            │   lastKnownServerRecord: nil,           │
+            │   _lastKnownServerRecordAllFields: nil, │
+            │   share: nil,                           │
+            │   _isDeleted: false,                    │
+            │   hasLastKnownServerRecord: false,      │
+            │   isShared: false,                      │
+            │   userModificationTime: 0               │
+            │ )                                       │
+            └─────────────────────────────────────────┘
             """
           }
           assertInlineSnapshot(of: container, as: .customDump) {
@@ -517,7 +517,7 @@
             │   _isDeleted: false,                                                                    │
             │   hasLastKnownServerRecord: true,                                                       │
             │   isShared: false,                                                                      │
-            │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+            │   userModificationTime: 0                                                               │
             │ )                                                                                       │
             ├─────────────────────────────────────────────────────────────────────────────────────────┤
             │ SyncMetadata(                                                                           │
@@ -547,7 +547,7 @@
             │   _isDeleted: false,                                                                    │
             │   hasLastKnownServerRecord: true,                                                       │
             │   isShared: false,                                                                      │
-            │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+            │   userModificationTime: 0                                                               │
             │ )                                                                                       │
             └─────────────────────────────────────────────────────────────────────────────────────────┘
             """

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineLifecycleTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineLifecycleTests.swift
@@ -178,7 +178,7 @@
           syncEngine.stop()
 
           try await withDependencies {
-            $0.currentTime.now += (1)
+            $0.currentTime.now += 1
           } operation: {
             try await userDatabase.userWrite { db in
               try RemindersList.find(1).update { $0.title += "!" }.execute(db)
@@ -257,7 +257,7 @@
           syncEngine.stop()
 
           try await withDependencies {
-            $0.currentTime.now += (60)
+            $0.currentTime.now += 60
           } operation: {
             try await userDatabase.userWrite { db in
               try db.seed {

--- a/Tests/SQLiteDataTests/CloudKitTests/TriggerTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/TriggerTests.swift
@@ -450,7 +450,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'childWithOnDeleteSetDefaults', "new"."parentID", 'parents'
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [28]: """
@@ -473,7 +473,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'childWithOnDeleteSetNulls', "new"."parentID", 'parents'
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [29]: """
@@ -496,7 +496,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'modelAs', NULL, NULL
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [30]: """
@@ -519,7 +519,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'modelBs', "new"."modelAID", 'modelAs'
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [31]: """
@@ -542,7 +542,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'modelCs', "new"."modelBID", 'modelBs'
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [32]: """
@@ -565,7 +565,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'parents', NULL, NULL
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [33]: """
@@ -588,7 +588,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'reminderTags', NULL, NULL
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [34]: """
@@ -611,7 +611,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'reminders', "new"."remindersListID", 'remindersLists'
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [35]: """
@@ -634,7 +634,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'remindersListAssets', "new"."remindersListID", 'remindersLists'
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [36]: """
@@ -657,7 +657,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'remindersListPrivates', "new"."remindersListID", 'remindersLists'
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [37]: """
@@ -680,7 +680,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'remindersLists', NULL, NULL
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [38]: """
@@ -703,7 +703,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."title", 'tags', NULL, NULL
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [39]: """
@@ -978,7 +978,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'childWithOnDeleteSetDefaults', "new"."parentID", 'parents'
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [52]: """
@@ -1001,7 +1001,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'childWithOnDeleteSetNulls', "new"."parentID", 'parents'
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [53]: """
@@ -1024,7 +1024,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'modelAs', NULL, NULL
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [54]: """
@@ -1047,7 +1047,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'modelBs', "new"."modelAID", 'modelAs'
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [55]: """
@@ -1070,7 +1070,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'modelCs', "new"."modelBID", 'modelBs'
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [56]: """
@@ -1093,7 +1093,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'parents', NULL, NULL
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [57]: """
@@ -1116,7 +1116,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'reminderTags', NULL, NULL
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [58]: """
@@ -1139,7 +1139,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'reminders', "new"."remindersListID", 'remindersLists'
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [59]: """
@@ -1162,7 +1162,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'remindersListAssets', "new"."remindersListID", 'remindersLists'
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [60]: """
@@ -1185,7 +1185,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'remindersListPrivates', "new"."remindersListID", 'remindersLists'
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [61]: """
@@ -1208,7 +1208,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'remindersLists', NULL, NULL
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """,
               [62]: """
@@ -1231,7 +1231,7 @@
                 ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."title", 'tags', NULL, NULL
                 ON CONFLICT ("recordPrimaryKey", "recordType")
-                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
+                DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationTime" = "excluded"."userModificationTime";
               END
               """
             ]

--- a/Tests/SQLiteDataTests/CloudKitTests/UserlandTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/UserlandTests.swift
@@ -21,7 +21,7 @@
       try await withDependencies {
         $0.defaultDatabase = database
         $0.defaultSyncEngine = syncEngine
-        $0.datetime.now = Date.init(timeIntervalSince1970: 1)
+        $0.currentTime.now = 1
       } operation: {
         @FetchAll var modelAs: [ModelA] = []
         try await database.write { db in

--- a/Tests/SQLiteDataTests/Internal/BaseCloudKitTests.swift
+++ b/Tests/SQLiteDataTests/Internal/BaseCloudKitTests.swift
@@ -9,7 +9,7 @@ import os
 @Suite(
   .snapshots(record: .missing),
   .dependencies {
-    $0.datetime.now = Date(timeIntervalSince1970: 0)
+    $0.currentTime.now = 0
     $0.dataManager = InMemoryDataManager()
   }
 )
@@ -18,7 +18,7 @@ class BaseCloudKitTests: @unchecked Sendable {
   private let _syncEngine: any Sendable
   private let _container: any Sendable
 
-  @Dependency(\.datetime.now) var now
+  @Dependency(\.currentTime.now) var now
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   var container: MockCloudContainer {

--- a/Tests/SQLiteDataTests/Internal/CloudKit+CustomDump.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKit+CustomDump.swift
@@ -28,22 +28,22 @@
       let keys = encryptedValues.allKeys()
         .filter { key in
           CKRecord.printTimestamps
-            || !key.hasPrefix(CKRecord.userModificationDateKey)
+            || !key.hasPrefix(CKRecord.userModificationTimeKey)
         }
         .sorted { lhs, rhs in
-          guard lhs != CKRecord.userModificationDateKey
+          guard lhs != CKRecord.userModificationTimeKey
           else { return false }
-          guard rhs != CKRecord.userModificationDateKey
+          guard rhs != CKRecord.userModificationTimeKey
           else { return true }
-          let lhsHasPrefix = lhs.hasPrefix(CKRecord.userModificationDateKey)
+          let lhsHasPrefix = lhs.hasPrefix(CKRecord.userModificationTimeKey)
           let baseLHS =
             lhsHasPrefix
-            ? String(lhs.dropFirst(CKRecord.userModificationDateKey.count + 1))
+            ? String(lhs.dropFirst(CKRecord.userModificationTimeKey.count + 1))
             : lhs
-          let rhsHasPrefix = rhs.hasPrefix(CKRecord.userModificationDateKey)
+          let rhsHasPrefix = rhs.hasPrefix(CKRecord.userModificationTimeKey)
           let baseRHS =
             rhsHasPrefix
-            ? String(rhs.dropFirst(CKRecord.userModificationDateKey.count + 1))
+            ? String(rhs.dropFirst(CKRecord.userModificationTimeKey.count + 1))
             : rhs
           return (baseLHS, lhsHasPrefix ? 1 : 0) < (baseRHS, rhsHasPrefix ? 1 : 0)
         }
@@ -60,11 +60,10 @@
         ]
           + keys
           .map {
-            $0.hasPrefix(CKRecord.userModificationDateKey)
+            $0.hasPrefix(CKRecord.userModificationTimeKey)
               ? (
-                String($0.dropFirst(CKRecord.userModificationDateKey.count + 1)) + "🗓️",
-                (self.encryptedValues[$0] as? Date).map(\.timeIntervalSince1970).map(Int.init)
-                  as Any
+                String($0.dropFirst(CKRecord.userModificationTimeKey.count + 1)) + "🗓️",
+                (self.encryptedValues[$0] as? Int64) as Any
               )
               : (
                 $0,


### PR DESCRIPTION
We were getting reports that sometimes a change would save locally, but didn't seem to sync to CloudKit and other devices. It seems there is a rare occasion where a timestamp comparison can fail when it shouldn't due to what we think is lossy formatting of doubles into ISO8601 and back into doubles.

So, this PR revamps the timestamps to be an `Int64` that is computed from `clock_gettime_nsec_np(CLOCK_REALTIME)`.