### PR TITLE
UIApplication is not available on watchOS

### DIFF
--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -255,7 +255,7 @@
         tables: allTables,
         tablesByName: tablesByName
       )
-      #if canImport(UIKit)
+      #if os(iOS)
         @Dependency(\.defaultNotificationCenter) var defaultNotificationCenter
         notificationsObserver.withValue {
           $0 = defaultNotificationCenter.addObserver(


### PR DESCRIPTION
Only reference `UIApplication` on iOS, watchOS fails to build otherwise.

Possibly too simplistic, didn't have a lot of time to look at it.