### PR TITLE
Fix tvOS builds

### DIFF
--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -204,7 +204,7 @@
     }
   }
 
-  #if canImport(UIKit) && !os(watchOS)
+  #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
     /// A view that presents standard screens for adding and removing people from a CloudKit share \
     /// record.
     ///


### PR DESCRIPTION
`UICloudSharingController` is not available on tvOS or watchOS.