### PR TITLE
Fix Swift 6.0 builds

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.0
 
 import PackageDescription
 


### PR DESCRIPTION
We had the wrong tools version, probably from a bad merge while preparing for the major release.