### PR TITLE
Build SPI docs on default platform (macOS)

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -4,4 +4,3 @@ builder:
   - documentation_targets:
     - SQLiteData
     custom_documentation_parameters: [--enable-experimental-overloaded-symbol-presentation]
-    platform: ios


### PR DESCRIPTION
Alternative platforms use Xcode to build docs, which has a bug that introduces symbols from all exported modules.