### PR TITLE
CI: Don't cancel in-flight builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,6 @@ on:
       - '*'
   workflow_dispatch:
 
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   library:
     name: macOS


### PR DESCRIPTION
I wish we could keep this setting, as it's wasteful to have multiple runners going at a time, but GitHub erroneously reports canceled builds as "failed" and badges the entire repo for that, which is not great for first impressions.

I've reported the issue here, so maybe we can revert this if they agree that this is incorrect behavior and address it: https://github.com/actions/runner/issues/4047