### PR TITLE
More explicit dependencies 

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		CA5E47072DECEF0F0069E0F8 /* InlineSnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = CA5E47062DECEF0F0069E0F8 /* InlineSnapshotTesting */; };
 		CA5E47092DECEFC80069E0F8 /* SnapshotTestingCustomDump in Frameworks */ = {isa = PBXBuildFile; productRef = CA5E47082DECEFC80069E0F8 /* SnapshotTestingCustomDump */; };
 		CA5E470B2DECF0280069E0F8 /* DependenciesTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = CA5E470A2DECF0280069E0F8 /* DependenciesTestSupport */; };
+		CAC608AE2E82FBC500AA619D /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = CAC608AD2E82FBC500AA619D /* Dependencies */; };
+		CAC608B02E82FC9C00AA619D /* SQLiteDataTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = CAC608AF2E82FC9C00AA619D /* SQLiteDataTestSupport */; };
 		CAD001872D874F1F00FA977A /* DependenciesTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = CAD001862D874F1F00FA977A /* DependenciesTestSupport */; };
 		DC5FA7482D4C63D60082743E /* DependenciesMacros in Frameworks */ = {isa = PBXBuildFile; productRef = DC5FA7472D4C63D60082743E /* DependenciesMacros */; };
 		DCBE8A142D4842BF0071F499 /* CasePaths in Frameworks */ = {isa = PBXBuildFile; productRef = DCBE8A132D4842BF0071F499 /* CasePaths */; };
@@ -158,6 +160,7 @@
 			files = (
 				CA5E47092DECEFC80069E0F8 /* SnapshotTestingCustomDump in Frameworks */,
 				CA5E47072DECEF0F0069E0F8 /* InlineSnapshotTesting in Frameworks */,
+				CAC608B02E82FC9C00AA619D /* SQLiteDataTestSupport in Frameworks */,
 				CA5E470B2DECF0280069E0F8 /* DependenciesTestSupport in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -193,6 +196,7 @@
 				CA2BDE2E2E71C479000974D3 /* SQLiteData in Frameworks */,
 				CA14DBC92DA884C400E36852 /* CasePaths in Frameworks */,
 				CA5E46912DEBB8570069E0F8 /* SwiftUINavigation in Frameworks */,
+				CAC608AE2E82FBC500AA619D /* Dependencies in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -295,6 +299,7 @@
 				CA5E47062DECEF0F0069E0F8 /* InlineSnapshotTesting */,
 				CA5E47082DECEFC80069E0F8 /* SnapshotTestingCustomDump */,
 				CA5E470A2DECF0280069E0F8 /* DependenciesTestSupport */,
+				CAC608AF2E82FC9C00AA619D /* SQLiteDataTestSupport */,
 			);
 			productName = RemindersTests;
 			productReference = CA5E46962DEBFE410069E0F8 /* RemindersTests.xctest */;
@@ -391,6 +396,7 @@
 				CA14DBC82DA884C400E36852 /* CasePaths */,
 				CA5E46902DEBB8570069E0F8 /* SwiftUINavigation */,
 				CA2BDE2D2E71C479000974D3 /* SQLiteData */,
+				CAC608AD2E82FBC500AA619D /* Dependencies */,
 			);
 			productName = Reminders;
 			productReference = CAF836D82D4735AB0047AEB5 /* Reminders.app */;
@@ -686,6 +692,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.RemindersTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Reminders.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Reminders";
@@ -703,6 +710,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.RemindersTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Reminders.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Reminders";
@@ -1242,6 +1250,15 @@
 			isa = XCSwiftPackageProductDependency;
 			package = DC5FA7462D4C63D60082743E /* XCRemoteSwiftPackageReference "swift-dependencies" */;
 			productName = DependenciesTestSupport;
+		};
+		CAC608AD2E82FBC500AA619D /* Dependencies */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DC5FA7462D4C63D60082743E /* XCRemoteSwiftPackageReference "swift-dependencies" */;
+			productName = Dependencies;
+		};
+		CAC608AF2E82FC9C00AA619D /* SQLiteDataTestSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SQLiteDataTestSupport;
 		};
 		CAD001862D874F1F00FA977A /* DependenciesTestSupport */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -17,8 +17,6 @@
 		CA5E47072DECEF0F0069E0F8 /* InlineSnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = CA5E47062DECEF0F0069E0F8 /* InlineSnapshotTesting */; };
 		CA5E47092DECEFC80069E0F8 /* SnapshotTestingCustomDump in Frameworks */ = {isa = PBXBuildFile; productRef = CA5E47082DECEFC80069E0F8 /* SnapshotTestingCustomDump */; };
 		CA5E470B2DECF0280069E0F8 /* DependenciesTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = CA5E470A2DECF0280069E0F8 /* DependenciesTestSupport */; };
-		CAC608AE2E82FBC500AA619D /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = CAC608AD2E82FBC500AA619D /* Dependencies */; };
-		CAC608B02E82FC9C00AA619D /* SQLiteDataTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = CAC608AF2E82FC9C00AA619D /* SQLiteDataTestSupport */; };
 		CAD001872D874F1F00FA977A /* DependenciesTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = CAD001862D874F1F00FA977A /* DependenciesTestSupport */; };
 		DC5FA7482D4C63D60082743E /* DependenciesMacros in Frameworks */ = {isa = PBXBuildFile; productRef = DC5FA7472D4C63D60082743E /* DependenciesMacros */; };
 		DCBE8A142D4842BF0071F499 /* CasePaths in Frameworks */ = {isa = PBXBuildFile; productRef = DCBE8A132D4842BF0071F499 /* CasePaths */; };
@@ -160,7 +158,6 @@
 			files = (
 				CA5E47092DECEFC80069E0F8 /* SnapshotTestingCustomDump in Frameworks */,
 				CA5E47072DECEF0F0069E0F8 /* InlineSnapshotTesting in Frameworks */,
-				CAC608B02E82FC9C00AA619D /* SQLiteDataTestSupport in Frameworks */,
 				CA5E470B2DECF0280069E0F8 /* DependenciesTestSupport in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -196,7 +193,6 @@
 				CA2BDE2E2E71C479000974D3 /* SQLiteData in Frameworks */,
 				CA14DBC92DA884C400E36852 /* CasePaths in Frameworks */,
 				CA5E46912DEBB8570069E0F8 /* SwiftUINavigation in Frameworks */,
-				CAC608AE2E82FBC500AA619D /* Dependencies in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -299,7 +295,6 @@
 				CA5E47062DECEF0F0069E0F8 /* InlineSnapshotTesting */,
 				CA5E47082DECEFC80069E0F8 /* SnapshotTestingCustomDump */,
 				CA5E470A2DECF0280069E0F8 /* DependenciesTestSupport */,
-				CAC608AF2E82FC9C00AA619D /* SQLiteDataTestSupport */,
 			);
 			productName = RemindersTests;
 			productReference = CA5E46962DEBFE410069E0F8 /* RemindersTests.xctest */;
@@ -396,7 +391,6 @@
 				CA14DBC82DA884C400E36852 /* CasePaths */,
 				CA5E46902DEBB8570069E0F8 /* SwiftUINavigation */,
 				CA2BDE2D2E71C479000974D3 /* SQLiteData */,
-				CAC608AD2E82FBC500AA619D /* Dependencies */,
 			);
 			productName = Reminders;
 			productReference = CAF836D82D4735AB0047AEB5 /* Reminders.app */;
@@ -692,7 +686,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.RemindersTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Reminders.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Reminders";
@@ -710,7 +703,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.RemindersTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Reminders.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Reminders";
@@ -1250,15 +1242,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = DC5FA7462D4C63D60082743E /* XCRemoteSwiftPackageReference "swift-dependencies" */;
 			productName = DependenciesTestSupport;
-		};
-		CAC608AD2E82FBC500AA619D /* Dependencies */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = DC5FA7462D4C63D60082743E /* XCRemoteSwiftPackageReference "swift-dependencies" */;
-			productName = Dependencies;
-		};
-		CAC608AF2E82FC9C00AA619D /* SQLiteDataTestSupport */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SQLiteDataTestSupport;
 		};
 		CAD001862D874F1F00FA977A /* DependenciesTestSupport */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift", from: "7.6.0"),
+    .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.9.0"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", from: "2.3.0"),
@@ -47,6 +48,7 @@ let package = Package(
     .target(
       name: "SQLiteData",
       dependencies: [
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "Dependencies", package: "swift-dependencies"),
         .product(name: "GRDB", package: "GRDB.swift"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
@@ -64,7 +66,9 @@ let package = Package(
       name: "SQLiteDataTestSupport",
       dependencies: [
         "SQLiteData",
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
+        .product(name: "Dependencies", package: "swift-dependencies"),
         .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
         .product(name: "StructuredQueriesTestSupport", package: "swift-structured-queries"),
       ]

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -23,6 +23,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift", from: "7.6.0"),
+    .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.9.0"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", from: "2.3.0"),
@@ -34,6 +35,7 @@ let package = Package(
     .target(
       name: "SQLiteData",
       dependencies: [
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "Dependencies", package: "swift-dependencies"),
         .product(name: "GRDB", package: "GRDB.swift"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
@@ -46,7 +48,9 @@ let package = Package(
       name: "SQLiteDataTestSupport",
       dependencies: [
         "SQLiteData",
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
+        .product(name: "Dependencies", package: "swift-dependencies"),
         .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
         .product(name: "StructuredQueriesTestSupport", package: "swift-structured-queries"),
       ]

--- a/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
@@ -1,7 +1,6 @@
 #if canImport(CloudKit)
   import CloudKit
   import CryptoKit
-  import CustomDump
   import StructuredQueriesCore
 
   extension _CKRecord where Self == CKRecord {

--- a/Sources/SQLiteData/CloudKit/Internal/Logging.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Logging.swift
@@ -212,6 +212,10 @@
           case .serverResponseLost: "serverResponseLost"
           case .assetNotAvailable: "assetNotAvailable"
           case .accountTemporarilyUnavailable: "accountTemporarilyUnavailable"
+          #if canImport(FoundationModels)
+            case .participantAlreadyInvited:
+              "participantAlreadyInvited"
+          #endif
           @unknown default: "unknown"
           }
         }

--- a/Sources/SQLiteData/CloudKit/Internal/MockCloudContainer.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockCloudContainer.swift
@@ -1,8 +1,7 @@
 import CloudKit
-import CustomDump
 
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-package final class MockCloudContainer: CloudContainer, CustomDumpReflectable {
+package final class MockCloudContainer: CloudContainer {
   package let _accountStatus: LockIsolated<CKAccountStatus>
   package let containerIdentifier: String?
   package let privateCloudDatabase: MockCloudDatabase
@@ -102,17 +101,6 @@ package final class MockCloudContainer: CloudContainer, CustomDumpReflectable {
 
   package func hash(into hasher: inout Hasher) {
     hasher.combine(ObjectIdentifier(self))
-  }
-
-  package var customDumpMirror: Mirror {
-    Mirror(
-      self,
-      children: [
-        ("privateCloudDatabase", privateCloudDatabase),
-        ("sharedCloudDatabase", sharedCloudDatabase),
-      ],
-      displayStyle: .struct
-    )
   }
 }
 

--- a/Sources/SQLiteData/CloudKit/Internal/MockCloudDatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockCloudDatabase.swift
@@ -1,5 +1,4 @@
 import CloudKit
-import CustomDump
 import IssueReporting
 
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
@@ -285,25 +284,6 @@ package final class MockCloudDatabase: CloudDatabase {
 
   package nonisolated func hash(into hasher: inout Hasher) {
     hasher.combine(ObjectIdentifier(self))
-  }
-}
-
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-extension MockCloudDatabase: CustomDumpReflectable {
-  package var customDumpMirror: Mirror {
-    Mirror(
-      self,
-      children: [
-        "databaseScope": databaseScope,
-        "storage": storage
-          .value
-          .flatMap { _, value in value.values }
-          .sorted {
-            ($0.recordType, $0.recordID.recordName) < ($1.recordType, $1.recordID.recordName)
-          },
-      ],
-      displayStyle: .struct
-    )
   }
 }
 

--- a/Sources/SQLiteData/CloudKit/Internal/MockSyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockSyncEngine.swift
@@ -1,5 +1,4 @@
 import CloudKit
-import CustomDump
 import OrderedCollections
 
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
@@ -95,52 +94,12 @@ package final class MockSyncEngine: SyncEngineProtocol {
     )
   }
 
-  package func assertFetchChangesScopes(
-    _ scopes: [CKSyncEngine.FetchChangesOptions.Scope],
-    fileID: StaticString = #fileID,
-    filePath: StaticString = #filePath,
-    line: UInt = #line,
-    column: UInt = #column
-  ) {
-    _fetchChangesScopes.withValue {
-      expectNoDifference(
-        scopes,
-        $0,
-        fileID: fileID,
-        filePath: filePath,
-        line: line,
-        column: column
-      )
-      $0.removeAll()
-    }
-  }
-
-  package func assertAcceptedShareMetadata(
-    _ sharedMetadata: Set<ShareMetadata>,
-    fileID: StaticString = #fileID,
-    filePath: StaticString = #filePath,
-    line: UInt = #line,
-    column: UInt = #column
-  ) {
-    _acceptedShareMetadata.withValue {
-      expectNoDifference(
-        sharedMetadata,
-        $0,
-        fileID: fileID,
-        filePath: filePath,
-        line: line,
-        column: column
-      )
-      $0.removeAll()
-    }
-  }
-
   package func cancelOperations() async {
   }
 }
 
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-package final class MockSyncEngineState: CKSyncEngineStateProtocol, CustomDumpReflectable {
+package final class MockSyncEngineState: CKSyncEngineStateProtocol {
   private let _pendingRecordZoneChanges = LockIsolated<
     OrderedSet<CKSyncEngine.PendingRecordZoneChange>
   >([]
@@ -163,46 +122,6 @@ package final class MockSyncEngineState: CKSyncEngineStateProtocol, CustomDumpRe
     self.filePath = filePath
     self.line = line
     self.column = column
-  }
-
-  package func assertPendingRecordZoneChanges(
-    _ changes: OrderedSet<CKSyncEngine.PendingRecordZoneChange>,
-    fileID: StaticString = #fileID,
-    filePath: StaticString = #filePath,
-    line: UInt = #line,
-    column: UInt = #column
-  ) {
-    _pendingRecordZoneChanges.withValue {
-      expectNoDifference(
-        Set(changes),
-        Set($0),
-        fileID: fileID,
-        filePath: filePath,
-        line: line,
-        column: column
-      )
-      $0.removeAll()
-    }
-  }
-
-  package func assertPendingDatabaseChanges(
-    _ changes: OrderedSet<CKSyncEngine.PendingDatabaseChange>,
-    fileID: StaticString = #fileID,
-    filePath: StaticString = #filePath,
-    line: UInt = #line,
-    column: UInt = #column
-  ) {
-    _pendingDatabaseChanges.withValue {
-      expectNoDifference(
-        Set(changes),
-        Set($0),
-        fileID: fileID,
-        filePath: filePath,
-        line: line,
-        column: column
-      )
-      $0.removeAll()
-    }
   }
 
   package var pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange] {
@@ -240,26 +159,6 @@ package final class MockSyncEngineState: CKSyncEngineStateProtocol, CustomDumpRe
     self._pendingDatabaseChanges.withValue {
       $0.subtract(pendingDatabaseChanges)
     }
-  }
-
-  package var customDumpMirror: Mirror {
-    return Mirror(
-      self,
-      children: [
-        (
-          "pendingRecordZoneChanges",
-          _pendingRecordZoneChanges.withValue(\.self)
-            .sorted(by: comparePendingRecordZoneChange)
-            as Any
-        ),
-        (
-          "pendingDatabaseChanges",
-          _pendingDatabaseChanges.withValue(\.self)
-            .sorted(by: comparePendingDatabaseChange) as Any
-        ),
-      ],
-      displayStyle: .struct
-    )
   }
 }
 

--- a/Sources/SQLiteData/CloudKit/Internal/MockSyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockSyncEngine.swift
@@ -6,8 +6,8 @@ package final class MockSyncEngine: SyncEngineProtocol {
   package let database: MockCloudDatabase
   package let parentSyncEngine: SyncEngine
   private let _state: LockIsolated<MockSyncEngineState>
-  private let _fetchChangesScopes = LockIsolated<[CKSyncEngine.FetchChangesOptions.Scope]>([])
-  private let _acceptedShareMetadata = LockIsolated<Set<ShareMetadata>>([])
+  package let _fetchChangesScopes = LockIsolated<[CKSyncEngine.FetchChangesOptions.Scope]>([])
+  package let _acceptedShareMetadata = LockIsolated<Set<ShareMetadata>>([])
 
   package init(
     database: MockCloudDatabase,
@@ -100,11 +100,11 @@ package final class MockSyncEngine: SyncEngineProtocol {
 
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
 package final class MockSyncEngineState: CKSyncEngineStateProtocol {
-  private let _pendingRecordZoneChanges = LockIsolated<
+  package let _pendingRecordZoneChanges = LockIsolated<
     OrderedSet<CKSyncEngine.PendingRecordZoneChange>
   >([]
   )
-  private let _pendingDatabaseChanges = LockIsolated<
+  package let _pendingDatabaseChanges = LockIsolated<
     OrderedSet<CKSyncEngine.PendingDatabaseChange>
   >([])
   private let fileID: StaticString
@@ -159,43 +159,6 @@ package final class MockSyncEngineState: CKSyncEngineStateProtocol {
     self._pendingDatabaseChanges.withValue {
       $0.subtract(pendingDatabaseChanges)
     }
-  }
-}
-
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-private func comparePendingRecordZoneChange(
-  _ lhs: CKSyncEngine.PendingRecordZoneChange,
-  _ rhs: CKSyncEngine.PendingRecordZoneChange
-) -> Bool {
-  switch (lhs, rhs) {
-  case (.saveRecord(let lhs), .saveRecord(let rhs)),
-    (.deleteRecord(let lhs), .deleteRecord(let rhs)):
-    lhs.recordName < rhs.recordName
-  case (.deleteRecord, .saveRecord):
-    true
-  case (.saveRecord, .deleteRecord):
-    false
-  default:
-    false
-  }
-}
-
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-private func comparePendingDatabaseChange(
-  _ lhs: CKSyncEngine.PendingDatabaseChange,
-  _ rhs: CKSyncEngine.PendingDatabaseChange
-) -> Bool {
-  switch (lhs, rhs) {
-  case (.saveZone(let lhs), .saveZone(let rhs)):
-    lhs.zoneID.zoneName < rhs.zoneID.zoneName
-  case (.deleteZone(let lhs), .deleteZone(let rhs)):
-    lhs.zoneName < rhs.zoneName
-  case (.deleteZone, .saveZone):
-    true
-  case (.saveZone, .deleteZone):
-    false
-  default:
-    false
   }
 }
 

--- a/Sources/SQLiteData/CloudKit/Internal/RecordType.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/RecordType.swift
@@ -1,4 +1,3 @@
-import CustomDump
 
 @Table("sqlitedata_icloud_recordTypes")
 package struct RecordType: Hashable {
@@ -7,18 +6,4 @@ package struct RecordType: Hashable {
   package let schema: String
   @Column(as: Set<TableInfo>.JSONRepresentation.self)
   package let tableInfo: Set<TableInfo>
-}
-
-extension RecordType: CustomDumpReflectable {
-  package var customDumpMirror: Mirror {
-    Mirror(
-      self,
-      children: [
-        ("tableName", tableName as Any),
-        ("schema", schema),
-        ("tableInfo", tableInfo.sorted(by: { $0.name < $1.name })),
-      ],
-      displayStyle: .struct
-    )
-  }
 }

--- a/Sources/SQLiteData/CloudKit/Internal/TableInfo.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/TableInfo.swift
@@ -4,7 +4,7 @@ import StructuredQueriesCore
 package struct TableInfo: Codable, Hashable, QueryDecodable, QueryRepresentable {
   let defaultValue: String?
   let isPrimaryKey: Bool
-  let name: String
+  package let name: String
   let isNotNull: Bool
   let type: String
 }

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -1,7 +1,6 @@
 #if canImport(CloudKit)
   import CloudKit
   import ConcurrencyExtras
-  import CustomDump
   import Dependencies
   import OrderedCollections
   import OSLog
@@ -1492,6 +1491,10 @@
           .alreadyShared, .managedAccountRestricted, .participantMayNeedVerification,
           .serverResponseLost, .assetNotAvailable, .accountTemporarilyUnavailable:
           continue
+        #if canImport(FoundationModels)
+          case .participantAlreadyInvited:
+            continue
+        #endif
         @unknown default:
           continue
         }

--- a/Tests/SQLiteDataTests/Internal/CloudKit+CustomDump.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKit+CustomDump.swift
@@ -155,4 +155,74 @@
       "CKRecordZone.ID(\(zoneName)/\(ownerName))"
     }
   }
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension MockSyncEngineState: CustomDumpReflectable {
+  package var customDumpMirror: Mirror {
+    return Mirror(
+      self,
+      children: [
+        (
+          "pendingRecordZoneChanges",
+          _pendingRecordZoneChanges.withValue(\.self)
+            .sorted(by: comparePendingRecordZoneChange)
+          as Any
+        ),
+        (
+          "pendingDatabaseChanges",
+          _pendingDatabaseChanges.withValue(\.self)
+            .sorted(by: comparePendingDatabaseChange) as Any
+        ),
+      ],
+      displayStyle: .struct
+    )
+  }
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension MockCloudContainer: CustomDumpReflectable {
+  package var customDumpMirror: Mirror {
+    Mirror(
+      self,
+      children: [
+        ("privateCloudDatabase", privateCloudDatabase),
+        ("sharedCloudDatabase", sharedCloudDatabase),
+      ],
+      displayStyle: .struct
+    )
+  }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension MockCloudDatabase: CustomDumpReflectable {
+    package var customDumpMirror: Mirror {
+      Mirror(
+        self,
+        children: [
+          "databaseScope": databaseScope,
+          "storage": storage
+            .value
+            .flatMap { _, value in value.values }
+            .sorted {
+              ($0.recordType, $0.recordID.recordName) < ($1.recordType, $1.recordID.recordName)
+            },
+        ],
+        displayStyle: .struct
+      )
+    }
+  }
+
+  extension RecordType: CustomDumpReflectable {
+    package var customDumpMirror: Mirror {
+      Mirror(
+        self,
+        children: [
+          ("tableName", tableName as Any),
+          ("schema", schema),
+          ("tableInfo", tableInfo.sorted(by: { $0.name < $1.name })),
+        ],
+        displayStyle: .struct
+      )
+    }
+  }
+
 #endif

--- a/Tests/SQLiteDataTests/Internal/CloudKit+CustomDump.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKit+CustomDump.swift
@@ -156,40 +156,78 @@
     }
   }
 
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-extension MockSyncEngineState: CustomDumpReflectable {
-  package var customDumpMirror: Mirror {
-    return Mirror(
-      self,
-      children: [
-        (
-          "pendingRecordZoneChanges",
-          _pendingRecordZoneChanges.withValue(\.self)
-            .sorted(by: comparePendingRecordZoneChange)
-          as Any
-        ),
-        (
-          "pendingDatabaseChanges",
-          _pendingDatabaseChanges.withValue(\.self)
-            .sorted(by: comparePendingDatabaseChange) as Any
-        ),
-      ],
-      displayStyle: .struct
-    )
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension MockSyncEngineState: CustomDumpReflectable {
+    package var customDumpMirror: Mirror {
+      return Mirror(
+        self,
+        children: [
+          (
+            "pendingRecordZoneChanges",
+            _pendingRecordZoneChanges.withValue(\.self)
+              .sorted(by: comparePendingRecordZoneChange)
+              as Any
+          ),
+          (
+            "pendingDatabaseChanges",
+            _pendingDatabaseChanges.withValue(\.self)
+              .sorted(by: comparePendingDatabaseChange) as Any
+          ),
+        ],
+        displayStyle: .struct
+      )
+    }
   }
-}
 
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-extension MockCloudContainer: CustomDumpReflectable {
-  package var customDumpMirror: Mirror {
-    Mirror(
-      self,
-      children: [
-        ("privateCloudDatabase", privateCloudDatabase),
-        ("sharedCloudDatabase", sharedCloudDatabase),
-      ],
-      displayStyle: .struct
-    )
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  private func comparePendingRecordZoneChange(
+    _ lhs: CKSyncEngine.PendingRecordZoneChange,
+    _ rhs: CKSyncEngine.PendingRecordZoneChange
+  ) -> Bool {
+    switch (lhs, rhs) {
+    case (.saveRecord(let lhs), .saveRecord(let rhs)),
+      (.deleteRecord(let lhs), .deleteRecord(let rhs)):
+      lhs.recordName < rhs.recordName
+    case (.deleteRecord, .saveRecord):
+      true
+    case (.saveRecord, .deleteRecord):
+      false
+    default:
+      false
+    }
+  }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  private func comparePendingDatabaseChange(
+    _ lhs: CKSyncEngine.PendingDatabaseChange,
+    _ rhs: CKSyncEngine.PendingDatabaseChange
+  ) -> Bool {
+    switch (lhs, rhs) {
+    case (.saveZone(let lhs), .saveZone(let rhs)):
+      lhs.zoneID.zoneName < rhs.zoneID.zoneName
+    case (.deleteZone(let lhs), .deleteZone(let rhs)):
+      lhs.zoneName < rhs.zoneName
+    case (.deleteZone, .saveZone):
+      true
+    case (.saveZone, .deleteZone):
+      false
+    default:
+      false
+    }
+  }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension MockCloudContainer: CustomDumpReflectable {
+    package var customDumpMirror: Mirror {
+      Mirror(
+        self,
+        children: [
+          ("privateCloudDatabase", privateCloudDatabase),
+          ("sharedCloudDatabase", sharedCloudDatabase),
+        ],
+        displayStyle: .struct
+      )
+    }
   }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)

--- a/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
@@ -190,3 +190,90 @@ extension SyncEngine {
       )
   }
 }
+
+extension MockSyncEngine {
+
+  package func assertFetchChangesScopes(
+    _ scopes: [CKSyncEngine.FetchChangesOptions.Scope],
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) {
+    _fetchChangesScopes.withValue {
+      expectNoDifference(
+        scopes,
+        $0,
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
+      )
+      $0.removeAll()
+    }
+  }
+
+  package func assertAcceptedShareMetadata(
+    _ sharedMetadata: Set<ShareMetadata>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) {
+    _acceptedShareMetadata.withValue {
+      expectNoDifference(
+        sharedMetadata,
+        $0,
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
+      )
+      $0.removeAll()
+    }
+  }
+
+}
+
+extension MockSyncEngineState {
+  package func assertPendingRecordZoneChanges(
+    _ changes: OrderedSet<CKSyncEngine.PendingRecordZoneChange>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) {
+    _pendingRecordZoneChanges.withValue {
+      expectNoDifference(
+        Set(changes),
+        Set($0),
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
+      )
+      $0.removeAll()
+    }
+  }
+
+  package func assertPendingDatabaseChanges(
+    _ changes: OrderedSet<CKSyncEngine.PendingDatabaseChange>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) {
+    _pendingDatabaseChanges.withValue {
+      expectNoDifference(
+        Set(changes),
+        Set($0),
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
+      )
+      $0.removeAll()
+    }
+  }
+
+}


### PR DESCRIPTION
We had a few implicit dependencies sneak in, and that prevented the SQLiteDataTestSupport library from being usable. I also moved some CustomDump conformances to the test target where it's needed.