### PR TITLE
SyncEngine access shouldn't crash Xcode previews

### DIFF
--- a/Sources/SQLiteData/CloudKit/DefaultSyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/DefaultSyncEngine.swift
@@ -49,8 +49,16 @@
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension SyncEngine: TestDependencyKey {
-    public static var testValue: SyncEngine {
+    public static var previewValue: SyncEngine {
       try! SyncEngine(for: DatabaseQueue())
+    }
+
+    public static var testValue: SyncEngine {
+      try! SyncEngine(
+        for: DatabasePool(
+          path: URL.temporaryDirectory.appending(path: "\(UUID().uuidString).sqlite").path()
+        )
+      )
     }
   }
 #endif

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -105,7 +105,8 @@
       }
       let userDatabase = UserDatabase(database: database)
 
-      guard !isTesting
+      @Dependency(\.context) var context
+      guard context == .live
       else {
         let privateDatabase = MockCloudDatabase(databaseScope: .private)
         let sharedDatabase = MockCloudDatabase(databaseScope: .shared)

--- a/Tests/SQLiteDataTests/AssertQueryTests.swift
+++ b/Tests/SQLiteDataTests/AssertQueryTests.swift
@@ -89,6 +89,7 @@ struct AssertQueryTests {
   }
 
   @Test(.snapshots(record: .never))
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   func assertQueryFailsNoResultsNonEmptySnapshot() {
     withKnownIssue {
       assertQuery(

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineTests.swift
@@ -100,11 +100,13 @@
     try DatabaseQueue()
   }
 
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   @Test func testSyncEngine() throws {
     @Dependency(\.defaultSyncEngine) var syncEngine
     _ = syncEngine
   }
 
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   @Test(.dependency(\.context, .preview)) func previewSyncEngine() throws {
     @Dependency(\.defaultSyncEngine) var syncEngine
     _ = syncEngine

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineTests.swift
@@ -100,6 +100,11 @@
     try DatabaseQueue()
   }
 
+  @Test func testSyncEngine() throws {
+    @Dependency(\.defaultSyncEngine) var syncEngine
+    _ = syncEngine
+  }
+
   @Test(.dependency(\.context, .preview)) func previewSyncEngine() throws {
     @Dependency(\.defaultSyncEngine) var syncEngine
     _ = syncEngine

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineTests.swift
@@ -99,4 +99,9 @@
   private func databaseWithForeignKeys() throws -> any DatabaseWriter {
     try DatabaseQueue()
   }
+
+  @Test(.dependency(\.context, .preview)) func previewSyncEngine() throws {
+    @Dependency(\.defaultSyncEngine) var syncEngine
+    _ = syncEngine
+  }
 #endif


### PR DESCRIPTION
Reported on Slack.