### PR TITLE
Support lazy database initialization

### DIFF
--- a/Tests/SQLiteDataTests/DefaultDatabaseTests.swift
+++ b/Tests/SQLiteDataTests/DefaultDatabaseTests.swift
@@ -1,0 +1,54 @@
+import SQLiteData
+import Testing
+
+@Suite struct DefaultDatabaseTests {
+  @Test func dependenciesWorkTogether() throws {
+    let db1 = try DatabaseQueue(named: "db1")
+    withDependencies {
+      $0.getDefaultDatabase = { db1 }
+    } operation: {
+      @Dependency(\.defaultDatabase) var defaultDatabase
+      #expect(defaultDatabase === db1)
+    }
+
+    let db2 = try DatabaseQueue(named: "db2")
+    withDependencies {
+      $0.defaultDatabase = db2
+    } operation: {
+      @Dependency(\.getDefaultDatabase) var getDefaultDatabase
+      #expect(getDefaultDatabase() === db2)
+    }
+  }
+
+  @Test func getDefaultIsNotCached() throws {
+    let useDB2 = LockIsolated(false)
+    let db1 = try DatabaseQueue(named: "db1")
+    let db2 = try DatabaseQueue(named: "db2")
+
+    withDependencies {
+      $0.getDefaultDatabase = { useDB2.value ? db2 : db1 }
+    } operation: {
+      @Dependency(\.defaultDatabase) var defaultDatabase
+      #expect(defaultDatabase === db1)
+      useDB2.setValue(true)
+      #expect(defaultDatabase === db2)
+    }
+  }
+
+  @Test func getDefaultIsLazy() throws {
+    let hasEvaluated = LockIsolated(false)
+    let db = try DatabaseQueue()
+
+    withDependencies {
+      $0.getDefaultDatabase = {
+        hasEvaluated.setValue(true)
+        return db
+      }
+    } operation: {
+      @Dependency(\.defaultDatabase) var defaultDatabase
+      #expect(!hasEvaluated.value)
+      _ = defaultDatabase
+      #expect(hasEvaluated.value)
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a `DependencyValues.getDefaultDatabase` which can be set to a closure that's invoked each time `defaultDatabase` is accessed. Further, `defaultDatabase` is updated to use `getDefaultDatabase` under the hood.

This enables a couple of use cases:

### Lazy Initialization

Having to (generally) set `defaultDatabase` in `prepareDependencies` means that you currently have to initialize the DB very early in the app's lifecycle. By using `getDefaultDatabase` instead, it's possible to split up the "configuration" (`prepareDependencies`) and "initialization" (first access of `defaultDatabase`) into separate steps. This is especially useful if the DB isn't needed until some point later in the app's lifecycle.

```swift
@main
struct MyApp: App {
  // Lazily creates database connection and run migrations on first use
  private static let database = try! appDatabase()

  init() {
    prepareDependencies {
      $0.getDefaultDatabase = { Self.database }
    }
  }
  // ...
}
```


### Side Effects

In some cases, you might want to warn/error-out if something tries to access the DB. For example, if you only support the database in your main app target and want to `fatalError` if any code in an app extension target attempts to access the database. Currently, one way to do this is to simply not assign `defaultDatabase` at all, at which point accessing it will trigger `reportIssue`, which can forward to a custom issue reporter if you so wish. But that's a pretty wide net (there can be other issues you don't want to `fatalError` on). Instead, it's much nicer to be able to do something like

```swift
prepareDependencies {
  if isMainTarget {
    $0.defaultDatabase = try! appDatabase()
  } else {
    $0.getDefaultDatabase = { fatalError("Cannot access DB from an App Extension") }
  }
}
```