### PR TITLE
Use TabularData to improve CloudKit logging.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "32a0b9db128d9e5f29bd4495238ec304eafe64f2e75d45e792189c983fbdc49c",
+  "originHash" : "db9c89e7bb7f76ee5dca9af154033bbf2d5eb991871a1f1598ea2cbba41dff61",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -134,15 +134,6 @@
       "state" : {
         "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
         "version" : "601.0.1"
-      }
-    },
-    {
-      "identity" : "swift-tagged",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-tagged",
-      "state" : {
-        "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
-        "version" : "0.10.0"
       }
     },
     {

--- a/Sources/SQLiteData/CloudKit/Internal/Logging.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Logging.swift
@@ -144,10 +144,6 @@
         let deletedZoneIDs,
         let failedZoneDeletes
       ):
-        //        savedZones: [CKRecordZone],
-        //        failedZoneSaves: [(zone: CKRecordZone, error: CKError)],
-        //        deletedZoneIDs: [CKRecordZone.ID],
-        //        failedZoneDeletes: [CKRecordZone.ID: CKError]
         for savedZone in savedZones {
           actions.append("✅ Saved")
           zoneNames.append(savedZone.zoneID.zoneName)
@@ -268,84 +264,46 @@
   extension CKError.Code {
     fileprivate var loggingDescription: String {
       switch self {
-      case .internalError:
-        "internalError"
-      case .partialFailure:
-        "partialFailure"
-      case .networkUnavailable:
-        "networkUnavailable"
-      case .networkFailure:
-        "networkFailure"
-      case .badContainer:
-        "badContainer"
-      case .serviceUnavailable:
-        "serviceUnavailable"
-      case .requestRateLimited:
-        "requestRateLimited"
-      case .missingEntitlement:
-        "missingEntitlement"
-      case .notAuthenticated:
-        "notAuthenticated"
-      case .permissionFailure:
-        "permissionFailure"
-      case .unknownItem:
-        "unknownItem"
-      case .invalidArguments:
-        "invalidArguments"
-      case .resultsTruncated:
-        "resultsTruncated"
-      case .serverRecordChanged:
-        "serverRecordChanged"
-      case .serverRejectedRequest:
-        "serverRejectedRequest"
-      case .assetFileNotFound:
-        "assetFileNotFound"
-      case .assetFileModified:
-        "assetFileModified"
-      case .incompatibleVersion:
-        "incompatibleVersion"
-      case .constraintViolation:
-        "constraintViolation"
-      case .operationCancelled:
-        "operationCancelled"
-      case .changeTokenExpired:
-        "changeTokenExpired"
-      case .batchRequestFailed:
-        "batchRequestFailed"
-      case .zoneBusy:
-        "zoneBusy"
-      case .badDatabase:
-        "badDatabase"
-      case .quotaExceeded:
-        "quotaExceeded"
-      case .zoneNotFound:
-        "zoneNotFound"
-      case .limitExceeded:
-        "limitExceeded"
-      case .userDeletedZone:
-        "userDeletedZone"
-      case .tooManyParticipants:
-        "tooManyParticipants"
-      case .alreadyShared:
-        "alreadyShared"
-      case .referenceViolation:
-        "referenceViolation"
-      case .managedAccountRestricted:
-        "managedAccountRestricted"
-      case .participantMayNeedVerification:
-        "participantMayNeedVerification"
-      case .serverResponseLost:
-        "serverResponseLost"
-      case .assetNotAvailable:
-        "assetNotAvailable"
-      case .accountTemporarilyUnavailable:
-        "accountTemporarilyUnavailable"
+      case .internalError: "internalError"
+      case .partialFailure: "partialFailure"
+      case .networkUnavailable: "networkUnavailable"
+      case .networkFailure: "networkFailure"
+      case .badContainer: "badContainer"
+      case .serviceUnavailable: "serviceUnavailable"
+      case .requestRateLimited: "requestRateLimited"
+      case .missingEntitlement: "missingEntitlement"
+      case .notAuthenticated: "notAuthenticated"
+      case .permissionFailure: "permissionFailure"
+      case .unknownItem: "unknownItem"
+      case .invalidArguments: "invalidArguments"
+      case .resultsTruncated: "resultsTruncated"
+      case .serverRecordChanged: "serverRecordChanged"
+      case .serverRejectedRequest: "serverRejectedRequest"
+      case .assetFileNotFound: "assetFileNotFound"
+      case .assetFileModified: "assetFileModified"
+      case .incompatibleVersion: "incompatibleVersion"
+      case .constraintViolation: "constraintViolation"
+      case .operationCancelled: "operationCancelled"
+      case .changeTokenExpired: "changeTokenExpired"
+      case .batchRequestFailed: "batchRequestFailed"
+      case .zoneBusy: "zoneBusy"
+      case .badDatabase: "badDatabase"
+      case .quotaExceeded: "quotaExceeded"
+      case .zoneNotFound: "zoneNotFound"
+      case .limitExceeded: "limitExceeded"
+      case .userDeletedZone: "userDeletedZone"
+      case .tooManyParticipants: "tooManyParticipants"
+      case .alreadyShared: "alreadyShared"
+      case .referenceViolation: "referenceViolation"
+      case .managedAccountRestricted: "managedAccountRestricted"
+      case .participantMayNeedVerification: "participantMayNeedVerification"
+      case .serverResponseLost: "serverResponseLost"
+      case .assetNotAvailable: "assetNotAvailable"
+      case .accountTemporarilyUnavailable: "accountTemporarilyUnavailable"
       #if canImport(FoundationModels)
-        case .participantAlreadyInvited:
-          "participantAlreadyInvited"
+        case .participantAlreadyInvited: "participantAlreadyInvited"
       #endif
-      @unknown default:
-        "(unknown error)"
+      @unknown default: "(unknown error)"
       }
     }
   }
@@ -354,14 +312,10 @@
   extension CKDatabase.DatabaseChange.Deletion.Reason {
     fileprivate var loggingDescription: String {
       switch self {
-      case .deleted:
-        "deleted"
-      case .purged:
-        "purged"
-      case .encryptedDataReset:
-        "encryptedDataReset"
-      @unknown default:
-        "(unknown reason: \(self))"
+      case .deleted: "deleted"
+      case .purged: "purged"
+      case .encryptedDataReset: "encryptedDataReset"
+      @unknown default: "(unknown reason: \(self))"
       }
     }
   }

--- a/Sources/SQLiteData/CloudKit/Internal/Logging.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Logging.swift
@@ -6,7 +6,7 @@
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension Logger {
     func log(_ event: SyncEngine.Event, syncEngine: any SyncEngineProtocol) {
-      let prefix = "[\(syncEngine.database.databaseScope.label)] handleEvent:"
+      let prefix = "SQLiteData (\(syncEngine.database.databaseScope.label).db)"
       var actions: [String] = []
       var recordTypes: [String] = []
       var recordNames: [String] = []
@@ -240,10 +240,10 @@
         )
       case .didFetchChanges:
         debug("\(prefix) didFetchChanges")
-      case .willSendChanges(let context):
-        debug("\(prefix) willSendChanges: \(context.reason.description)")
-      case .didSendChanges(let context):
-        debug("\(prefix) didSendChanges: \(context.reason.description)")
+      case .willSendChanges:
+        debug("\(prefix) willSendChanges")
+      case .didSendChanges:
+        debug("\(prefix) didSendChanges")
       @unknown default:
         warning("\(prefix) ⚠️ unknown event: \(event.description)")
       }
@@ -253,7 +253,7 @@
   extension CKDatabase.Scope {
     var label: String {
       switch self {
-      case .public: "public"
+      case .public: "global"
       case .private: "private"
       case .shared: "shared"
       @unknown default: "unknown"

--- a/Sources/SQLiteData/CloudKit/Internal/Logging.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Logging.swift
@@ -1,11 +1,65 @@
-#if canImport(CloudKit)
+#if DEBUG && canImport(CloudKit)
   import CloudKit
+  import TabularData
   import os
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension Logger {
     func log(_ event: SyncEngine.Event, syncEngine: any SyncEngineProtocol) {
       let prefix = "[\(syncEngine.database.databaseScope.label)] handleEvent:"
+      var actions: [String] = []
+      var recordTypes: [String] = []
+      var recordNames: [String] = []
+      var zoneNames: [String] = []
+      var ownerNames: [String] = []
+      var errors: [String] = []
+      var reasons: [String] = []
+      var tabularDescription: String {
+        var dataFrame: DataFrame = [:]
+        if !actions.isEmpty {
+          dataFrame.append(column: Column<String>(name: "action", contents: actions))
+        }
+        if !recordTypes.isEmpty {
+          dataFrame.append(column: Column<String>(name: "recordType", contents: recordTypes))
+        }
+        if !recordNames.isEmpty {
+          dataFrame.append(column: Column<String>(name: "recordName", contents: recordNames))
+        }
+        if !zoneNames.isEmpty {
+          dataFrame.append(column: Column<String>(name: "zoneName", contents: zoneNames))
+        }
+        if !ownerNames.isEmpty {
+          dataFrame.append(column: Column<String>(name: "ownerName", contents: ownerNames))
+        }
+        if !errors.isEmpty {
+          dataFrame.append(column: Column<String>(name: "error", contents: errors))
+        }
+        if !reasons.isEmpty {
+          dataFrame.append(column: Column<String>(name: "reason", contents: reasons))
+        }
+        if !recordTypes.isEmpty {
+          dataFrame.sort(
+            on: ColumnID("action", String.self),
+            ColumnID("recordType", String.self),
+            ColumnID("recordName", String.self)
+          )
+        } else {
+          dataFrame.sort(on: ColumnID("action", String.self))
+        }
+        var formattingOptions = FormattingOptions(
+          maximumLineWidth: 120,
+          maximumCellWidth: 80,
+          maximumRowCount: 50,
+          includesColumnTypes: false
+        )
+        formattingOptions.includesRowAndColumnCounts = false
+        formattingOptions.includesRowIndices = false
+        return
+          dataFrame
+          .description(options: formattingOptions)
+          .replacing("\n", with: "\n  ")
+      }
+
       switch event {
       case .stateUpdate:
         debug("\(prefix) stateUpdate")
@@ -36,50 +90,52 @@
         @unknown default:
           debug("unknown")
         }
-      case .fetchedDatabaseChanges(_, let deletions):
-        let deletions =
-          deletions.isEmpty
-          ? "⚪️ No deletions"
-          : "✅ Zones deleted (\(deletions.count)): "
-            + deletions
-            .map { $0.zoneID.zoneName + ":" + $0.zoneID.ownerName }
-            .sorted()
-            .joined(separator: ", ")
+      case .fetchedDatabaseChanges(let modifications, let deletions):
+        for modification in modifications {
+          actions.append("✅ Modified")
+          zoneNames.append(modification.zoneName)
+          ownerNames.append(modification.ownerName)
+          if !deletions.isEmpty {
+            reasons.append("")
+          }
+        }
+        for (deletedZoneID, reason) in deletions {
+          actions.append("🗑️ Deleted")
+          zoneNames.append(deletedZoneID.zoneName)
+          ownerNames.append(deletedZoneID.ownerName)
+          reasons.append(reason.loggingDescription)
+        }
         debug(
           """
           \(prefix) fetchedDatabaseChanges
-            \(deletions)
+            \(tabularDescription)
           """
         )
       case .fetchedRecordZoneChanges(let modifications, let deletions):
-        let deletionsByRecordType = Dictionary(
-          grouping: deletions,
-          by: \.recordType
-        )
-        let recordTypeDeletions = deletionsByRecordType.keys.sorted()
-          .map { recordType in "\(recordType) (\(deletionsByRecordType[recordType]!.count))" }
-          .joined(separator: ", ")
-        let deletions =
-          deletions.isEmpty
-          ? "⚪️ No deletions" : "✅ Records deleted (\(deletions.count)): \(recordTypeDeletions)"
-
-        let modificationsByRecordType = Dictionary(
-          grouping: modifications,
-          by: \.recordType
-        )
-        let recordTypeModifications = modificationsByRecordType.keys.sorted()
-          .map { recordType in "\(recordType) (\(modificationsByRecordType[recordType]!.count))" }
-          .joined(separator: ", ")
-        let modifications =
-          modifications.isEmpty
-          ? "⚪️ No modifications"
-          : "✅ Records modified (\(modifications.count)): \(recordTypeModifications)"
-
+        for modification in modifications {
+          actions.append("✅ Modified")
+          recordTypes.append(modification.recordType)
+          recordNames.append(modification.recordID.recordName)
+        }
+        if modifications.isEmpty {
+          actions.append("⚪️ Modified")
+          recordTypes.append("(none)")
+          recordNames.append("(none)")
+        }
+        for (deletedRecordID, deletedRecordType) in deletions {
+          actions.append("🗑️ Deleted")
+          recordTypes.append(deletedRecordType)
+          recordNames.append(deletedRecordID.recordName)
+        }
+        if deletions.isEmpty {
+          actions.append("⚪️ Deleted")
+          recordTypes.append("(none)")
+          recordNames.append("(none)")
+        }
         debug(
           """
           \(prefix) fetchedRecordZoneChanges
-            \(modifications)
-            \(deletions)
+            \(tabularDescription)
           """
         )
       case .sentDatabaseChanges(
@@ -88,52 +144,42 @@
         let deletedZoneIDs,
         let failedZoneDeletes
       ):
-        let savedZoneNames =
-          savedZones
-          .map { $0.zoneID.zoneName + ":" + $0.zoneID.ownerName }
-          .sorted()
-          .joined(separator: ", ")
-        let savedZones =
-          savedZones.isEmpty
-          ? "⚪️ No saved zones" : "✅ Saved zones (\(savedZones.count)): \(savedZoneNames)"
-
-        let deletedZoneNames =
-          deletedZoneIDs
-          .map { $0.zoneName }
-          .sorted()
-          .joined(separator: ", ")
-        let deletedZones =
-          deletedZoneIDs.isEmpty
-          ? "⚪️ No deleted zones"
-          : "✅ Deleted zones (\(deletedZoneIDs.count)): \(deletedZoneNames)"
-
-        let failedZoneSaveNames =
-          failedZoneSaves
-          .map { $0.zone.zoneID.zoneName + ":" + $0.zone.zoneID.ownerName }
-          .sorted()
-          .joined(separator: ", ")
-        let failedZoneSaves =
-          failedZoneSaves.isEmpty
-          ? "⚪️ No failed saved zones"
-          : "🛑 Failed zone saves (\(failedZoneSaves.count)): \(failedZoneSaveNames)"
-
-        let failedZoneDeleteNames = failedZoneDeletes
-          .keys
-          .map { $0.zoneName }
-          .sorted()
-          .joined(separator: ", ")
-        let failedZoneDeletes =
-          failedZoneDeletes.isEmpty
-          ? "⚪️ No failed deleted zones"
-          : "🛑 Failed zone delete (\(failedZoneDeletes.count)): \(failedZoneDeleteNames)"
-
+        //        savedZones: [CKRecordZone],
+        //        failedZoneSaves: [(zone: CKRecordZone, error: CKError)],
+        //        deletedZoneIDs: [CKRecordZone.ID],
+        //        failedZoneDeletes: [CKRecordZone.ID: CKError]
+        for savedZone in savedZones {
+          actions.append("✅ Saved")
+          zoneNames.append(savedZone.zoneID.zoneName)
+          ownerNames.append(savedZone.zoneID.ownerName)
+          if !failedZoneSaves.isEmpty || !failedZoneDeletes.isEmpty {
+            errors.append("")
+          }
+        }
+        for (failedSaveZone, error) in failedZoneSaves {
+          actions.append("🛑 Failed save")
+          zoneNames.append(failedSaveZone.zoneID.zoneName)
+          ownerNames.append(failedSaveZone.zoneID.ownerName)
+          errors.append(error.code.loggingDescription)
+        }
+        for deletedZoneID in deletedZoneIDs {
+          actions.append("🗑️ Deleted")
+          zoneNames.append(deletedZoneID.zoneName)
+          ownerNames.append(deletedZoneID.ownerName)
+          if !failedZoneSaves.isEmpty || !failedZoneDeletes.isEmpty {
+            errors.append("")
+          }
+        }
+        for (failedDeleteZoneID, error) in failedZoneDeletes {
+          actions.append("🛑 Failed delete")
+          zoneNames.append(failedDeleteZoneID.zoneName)
+          ownerNames.append(failedDeleteZoneID.ownerName)
+          errors.append(error.code.loggingDescription)
+        }
         debug(
           """
           \(prefix) sentDatabaseChanges
-            \(savedZones)
-            \(deletedZones) 
-            \(failedZoneSaves)
-            \(failedZoneDeletes)
+            \(tabularDescription)
           """
         )
       case .sentRecordZoneChanges(
@@ -142,31 +188,46 @@
         let deletedRecordIDs,
         let failedRecordDeletes
       ):
-        let savedRecordsByRecordType = Dictionary(
-          grouping: savedRecords,
-          by: \.recordType
-        )
-        let savedRecords = savedRecordsByRecordType.keys
-          .sorted()
-          .map { "\($0) (\(savedRecordsByRecordType[$0]!.count))" }
-          .joined(separator: ", ")
-
-        let failedRecordSavesByZoneName = Dictionary(
-          grouping: failedRecordSaves,
-          by: { $0.record.recordID.zoneID.zoneName + ":" + $0.record.recordID.zoneID.ownerName }
-        )
-        let failedRecordSaves = failedRecordSavesByZoneName.keys
-          .sorted()
-          .map { "\($0) (\(failedRecordSavesByZoneName[$0]!.count))" }
-          .joined(separator: ", ")
-
+        for savedRecord in savedRecords {
+          actions.append("✅ Saved")
+          recordTypes.append(savedRecord.recordType)
+          recordNames.append(savedRecord.recordID.recordName)
+          if !failedRecordSaves.isEmpty || !failedRecordDeletes.isEmpty {
+            errors.append("")
+          }
+        }
+        if savedRecords.isEmpty {
+          actions.append("⚪️ Saved")
+          recordTypes.append("(none)")
+          recordNames.append("(none)")
+          if !failedRecordSaves.isEmpty || !failedRecordDeletes.isEmpty {
+            errors.append("")
+          }
+        }
+        for (failedRecord, error) in failedRecordSaves {
+          actions.append("🛑 Save failed")
+          recordTypes.append(failedRecord.recordType)
+          recordNames.append(failedRecord.recordID.recordName)
+          errors.append("\(error.code.loggingDescription) (\(error.errorCode))")
+        }
+        for deletedRecordID in deletedRecordIDs {
+          actions.append("🗑️ Deleted")
+          recordTypes.append("")
+          recordNames.append(deletedRecordID.recordName)
+          if !failedRecordSaves.isEmpty || !failedRecordDeletes.isEmpty {
+            errors.append("")
+          }
+        }
+        for (failedDeleteRecordID, error) in failedRecordDeletes {
+          actions.append("🛑 Delete failed")
+          recordTypes.append("")
+          recordNames.append(failedDeleteRecordID.recordName)
+          errors.append("\(error.code.loggingDescription) (\(error.errorCode))")
+        }
         debug(
           """
           \(prefix) sentRecordZoneChanges
-            \(savedRecordsByRecordType.isEmpty ? "⚪️ No records saved" : "✅ Saved records: \(savedRecords)")
-            \(deletedRecordIDs.isEmpty ? "⚪️ No records deleted" : "✅ Deleted records (\(deletedRecordIDs.count))")
-            \(failedRecordSavesByZoneName.isEmpty ? "⚪️ No records failed save" : "🛑 Records failed save: \(failedRecordSaves)")
-            \(failedRecordDeletes.isEmpty ? "⚪️ No records failed delete" : "🛑 Records failed delete (\(failedRecordDeletes.count))")
+            \(tabularDescription)
           """
         )
       case .willFetchChanges:
@@ -174,52 +235,7 @@
       case .willFetchRecordZoneChanges(let zoneID):
         debug("\(prefix) willFetchRecordZoneChanges: \(zoneID.zoneName)")
       case .didFetchRecordZoneChanges(let zoneID, let error):
-        let errorType = error.map {
-          switch $0.code {
-          case .internalError: "internalError"
-          case .partialFailure: "partialFailure"
-          case .networkUnavailable: "networkUnavailable"
-          case .networkFailure: "networkFailure"
-          case .badContainer: "badContainer"
-          case .serviceUnavailable: "serviceUnavailable"
-          case .requestRateLimited: "requestRateLimited"
-          case .missingEntitlement: "missingEntitlement"
-          case .notAuthenticated: "notAuthenticated"
-          case .permissionFailure: "permissionFailure"
-          case .unknownItem: "unknownItem"
-          case .invalidArguments: "invalidArguments"
-          case .resultsTruncated: "resultsTruncated"
-          case .serverRecordChanged: "serverRecordChanged"
-          case .serverRejectedRequest: "serverRejectedRequest"
-          case .assetFileNotFound: "assetFileNotFound"
-          case .assetFileModified: "assetFileModified"
-          case .incompatibleVersion: "incompatibleVersion"
-          case .constraintViolation: "constraintViolation"
-          case .operationCancelled: "operationCancelled"
-          case .changeTokenExpired: "changeTokenExpired"
-          case .batchRequestFailed: "batchRequestFailed"
-          case .zoneBusy: "zoneBusy"
-          case .badDatabase: "badDatabase"
-          case .quotaExceeded: "quotaExceeded"
-          case .zoneNotFound: "zoneNotFound"
-          case .limitExceeded: "limitExceeded"
-          case .userDeletedZone: "userDeletedZone"
-          case .tooManyParticipants: "tooManyParticipants"
-          case .alreadyShared: "alreadyShared"
-          case .referenceViolation: "referenceViolation"
-          case .managedAccountRestricted: "managedAccountRestricted"
-          case .participantMayNeedVerification: "participantMayNeedVerification"
-          case .serverResponseLost: "serverResponseLost"
-          case .assetNotAvailable: "assetNotAvailable"
-          case .accountTemporarilyUnavailable: "accountTemporarilyUnavailable"
-          #if canImport(FoundationModels)
-            case .participantAlreadyInvited:
-              "participantAlreadyInvited"
-          #endif
-          @unknown default: "unknown"
-          }
-        }
-        let error = errorType.map { "\n  ❌ \($0)" } ?? ""
+        let error = (error?.code.loggingDescription).map { "\n  ❌ \($0)" } ?? ""
         debug(
           """
           \(prefix) willFetchRecordZoneChanges
@@ -245,6 +261,107 @@
       case .private: "private"
       case .shared: "shared"
       @unknown default: "unknown"
+      }
+    }
+  }
+
+  extension CKError.Code {
+    fileprivate var loggingDescription: String {
+      switch self {
+      case .internalError:
+        "internalError"
+      case .partialFailure:
+        "partialFailure"
+      case .networkUnavailable:
+        "networkUnavailable"
+      case .networkFailure:
+        "networkFailure"
+      case .badContainer:
+        "badContainer"
+      case .serviceUnavailable:
+        "serviceUnavailable"
+      case .requestRateLimited:
+        "requestRateLimited"
+      case .missingEntitlement:
+        "missingEntitlement"
+      case .notAuthenticated:
+        "notAuthenticated"
+      case .permissionFailure:
+        "permissionFailure"
+      case .unknownItem:
+        "unknownItem"
+      case .invalidArguments:
+        "invalidArguments"
+      case .resultsTruncated:
+        "resultsTruncated"
+      case .serverRecordChanged:
+        "serverRecordChanged"
+      case .serverRejectedRequest:
+        "serverRejectedRequest"
+      case .assetFileNotFound:
+        "assetFileNotFound"
+      case .assetFileModified:
+        "assetFileModified"
+      case .incompatibleVersion:
+        "incompatibleVersion"
+      case .constraintViolation:
+        "constraintViolation"
+      case .operationCancelled:
+        "operationCancelled"
+      case .changeTokenExpired:
+        "changeTokenExpired"
+      case .batchRequestFailed:
+        "batchRequestFailed"
+      case .zoneBusy:
+        "zoneBusy"
+      case .badDatabase:
+        "badDatabase"
+      case .quotaExceeded:
+        "quotaExceeded"
+      case .zoneNotFound:
+        "zoneNotFound"
+      case .limitExceeded:
+        "limitExceeded"
+      case .userDeletedZone:
+        "userDeletedZone"
+      case .tooManyParticipants:
+        "tooManyParticipants"
+      case .alreadyShared:
+        "alreadyShared"
+      case .referenceViolation:
+        "referenceViolation"
+      case .managedAccountRestricted:
+        "managedAccountRestricted"
+      case .participantMayNeedVerification:
+        "participantMayNeedVerification"
+      case .serverResponseLost:
+        "serverResponseLost"
+      case .assetNotAvailable:
+        "assetNotAvailable"
+      case .accountTemporarilyUnavailable:
+        "accountTemporarilyUnavailable"
+      #if canImport(FoundationModels)
+        case .participantAlreadyInvited:
+          "participantAlreadyInvited"
+      #endif
+      @unknown default:
+        "(unknown error)"
+      }
+    }
+  }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension CKDatabase.DatabaseChange.Deletion.Reason {
+    fileprivate var loggingDescription: String {
+      switch self {
+      case .deleted:
+        "deleted"
+      case .purged:
+        "purged"
+      case .encryptedDataReset:
+        "encryptedDataReset"
+      @unknown default:
+        "(unknown reason: \(self))"
       }
     }
   }

--- a/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
@@ -7,12 +7,6 @@
     logger: Logger,
     url: URL
   ) throws -> any DatabaseWriter {
-    var configuration = Configuration()
-    configuration.prepareDatabase { [logger] db in
-      db.trace {
-        logger.trace("\($0.expandedDescription)")
-      }
-    }
     logger.debug(
       """
       Metadatabase connection:
@@ -33,15 +27,9 @@
 
     let metadatabase: any DatabaseWriter =
       if url.isInMemory {
-        try DatabaseQueue(
-          path: url.absoluteString,
-          configuration: configuration
-        )
+        try DatabaseQueue(path: url.absoluteString)
       } else {
-        try DatabasePool(
-          path: url.path(percentEncoded: false),
-          configuration: configuration
-        )
+        try DatabasePool(path: url.path(percentEncoded: false))
       }
     try migrate(metadatabase: metadatabase)
     return metadatabase

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -768,7 +768,9 @@
     }
 
     package func handleEvent(_ event: Event, syncEngine: any SyncEngineProtocol) async {
-      logger.log(event, syncEngine: syncEngine)
+      #if DEBUG
+        logger.log(event, syncEngine: syncEngine)
+      #endif
 
       switch event {
       case .accountChange(let changeType):

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -7,6 +7,7 @@
   import Observation
   import StructuredQueriesCore
   import SwiftData
+  import TabularData
 
   #if canImport(UIKit)
     import UIKit
@@ -860,57 +861,19 @@
       }
 
       #if DEBUG
-        struct State {
-          var missingTables: [CKRecord.ID] = []
-          var missingRecords: [CKRecord.ID] = []
-          var sentRecords: [CKRecord.ID] = []
-        }
-        let state = LockIsolated(State())
+        let state = LockIsolated(NextRecordZoneChangeBatchLoggingState())
         defer {
           let state = state.withValue(\.self)
-          let missingTables = Dictionary(grouping: state.missingTables, by: \.zoneID.zoneName)
-            .reduce(into: [String]()) {
-              strings,
-              keyValue in strings += ["\(keyValue.key) (\(keyValue.value.count))"]
-            }
-            .joined(separator: ", ")
-          let missingRecords = Dictionary(grouping: state.missingRecords, by: \.zoneID.zoneName)
-            .reduce(into: [String]()) {
-              strings,
-              keyValue in strings += ["\(keyValue.key) (\(keyValue.value.count))"]
-            }
-            .joined(separator: ", ")
-          let sentRecords = Dictionary(grouping: state.sentRecords, by: \.zoneID.zoneName)
-            .reduce(into: [String]()) {
-              strings,
-              keyValue in strings += ["\(keyValue.key) (\(keyValue.value.count))"]
-            }
-            .joined(separator: ", ")
           logger.debug(
             """
             [\(syncEngine.database.databaseScope.label)] nextRecordZoneChangeBatch: \(reason)
-              \(state.missingTables.isEmpty ? "⚪️ No missing tables" : "⚠️ Missing tables: \(missingTables)")
-              \(state.missingRecords.isEmpty ? "⚪️ No missing records" : "⚠️ Missing records: \(missingRecords)")
-              \(state.sentRecords.isEmpty ? "⚪️ No sent records" : "✅ Sent records: \(sentRecords)")
+              \(state.tabularDescription)
             """
           )
         }
       #endif
 
       let batch = await syncEngine.recordZoneChangeBatch(pendingChanges: changes) { recordID in
-        var missingTable: CKRecord.ID?
-        var missingRecord: CKRecord.ID?
-        var sentRecord: CKRecord.ID?
-        #if DEBUG
-          defer {
-            state.withValue { [missingTable, missingRecord, sentRecord] in
-              if let missingTable { $0.missingTables.append(missingTable) }
-              if let missingRecord { $0.missingRecords.append(missingRecord) }
-              if let sentRecord { $0.sentRecords.append(sentRecord) }
-            }
-          }
-        #endif
-
         guard
           let (metadata, allFields) = await withErrorReporting(
             .sqliteDataCloudKitFailure,
@@ -928,6 +891,32 @@
           syncEngine.state.remove(pendingRecordZoneChanges: [.saveRecord(recordID)])
           return nil
         }
+
+        var missingTable: CKRecord.ID?
+        var missingRecord: CKRecord.ID?
+        var sentRecord: CKRecord.ID?
+        #if DEBUG
+          defer {
+            state.withValue { [missingTable, missingRecord, sentRecord] in
+              if let missingTable {
+                $0.events.append("⚠️ Missing table")
+                $0.recordTypes.append(metadata.recordType)
+                $0.recordNames.append(missingTable.recordName)
+              }
+              if let missingRecord {
+                $0.events.append("⚠️ Missing record")
+                $0.recordTypes.append(metadata.recordType)
+                $0.recordNames.append(missingRecord.recordName)
+              }
+              if let sentRecord {
+                $0.events.append("✅ Sent record")
+                $0.recordTypes.append(metadata.recordType)
+                $0.recordNames.append(sentRecord.recordName)
+              }
+            }
+          }
+        #endif
+
         guard let table = tablesByName[metadata.recordType]
         else {
           syncEngine.state.remove(pendingRecordZoneChanges: [.saveRecord(recordID)])
@@ -2137,4 +2126,37 @@
   func currentOwnerName() -> String? {
     _currentZoneID?.ownerName
   }
+
+  #if DEBUG
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    private struct NextRecordZoneChangeBatchLoggingState {
+      var events: [String] = []
+      var recordTypes: [String] = []
+      var recordNames: [String] = []
+      var tabularDescription: String {
+        var dataFrame: DataFrame = [
+          "event": events,
+          "recordType": recordTypes,
+          "recordName": recordNames,
+        ]
+        dataFrame.sort(
+          on: ColumnID("event", String.self),
+          ColumnID("recordType", String.self),
+          ColumnID("recordName", String.self)
+        )
+        var formattingOptions = FormattingOptions(
+          maximumLineWidth: 120,
+          maximumCellWidth: 80,
+          maximumRowCount: 50,
+          includesColumnTypes: false
+        )
+        formattingOptions.includesRowAndColumnCounts = false
+        formattingOptions.includesRowIndices = false
+        return
+          dataFrame
+          .description(options: formattingOptions)
+          .replacing("\n", with: "\n  ")
+      }
+    }
+  #endif
 #endif

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -864,12 +864,14 @@
         let state = LockIsolated(NextRecordZoneChangeBatchLoggingState())
         defer {
           let state = state.withValue(\.self)
-          logger.debug(
-            """
-            [\(syncEngine.database.databaseScope.label)] nextRecordZoneChangeBatch: \(reason)
-              \(state.tabularDescription)
-            """
-          )
+          if let tabularDescription = state.tabularDescription {
+            logger.debug(
+              """
+              [\(syncEngine.database.databaseScope.label)] nextRecordZoneChangeBatch: \(reason)
+                \(tabularDescription)
+              """
+            )
+          }
         }
       #endif
 
@@ -2133,7 +2135,9 @@
       var events: [String] = []
       var recordTypes: [String] = []
       var recordNames: [String] = []
-      var tabularDescription: String {
+      var tabularDescription: String? {
+        guard !events.isEmpty
+        else { return nil }
         var dataFrame: DataFrame = [
           "event": events,
           "recordType": recordTypes,

--- a/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
@@ -192,7 +192,6 @@ extension SyncEngine {
 }
 
 extension MockSyncEngine {
-
   package func assertFetchChangesScopes(
     _ scopes: [CKSyncEngine.FetchChangesOptions.Scope],
     fileID: StaticString = #fileID,


### PR DESCRIPTION
Right now we have decent logging for CloudKit, but it can definitely be better. I took a stab at using the [TabularData](https://developer.apple.com/documentation/tabulardata) framework from Apple to produce logs like this:

```
[private] handleEvent: fetchedDatabaseChanges
  ┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
  ┃ action      ┃ zoneName                            ┃ ownerName        ┃
  ┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
  │ ✅ Modified │ co.pointfree.SQLiteData.defaultZone │ __defaultOwner__ │
  └─────────────┴─────────────────────────────────────┴──────────────────┘

[shared] handleEvent: fetchedDatabaseChanges
  ┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
  ┃ action     ┃ zoneName                            ┃ ownerName                         ┃ reason  ┃
  ┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
  │ 🗑️ Deleted │ co.pointfree.SQLiteData.defaultZone │ _c4e747a56bd9a1ee2c8dd9dc495ea73b │ deleted │
  └────────────┴─────────────────────────────────────┴───────────────────────────────────┴─────────┘

[private] handleEvent: fetchedRecordZoneChanges
  ┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃ action      ┃ recordType          ┃ recordName                                                ┃
  ┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
  │ ✅ Modified │ cloudkit.share      │ share-bd5fb134-43ac-4a42-84b0-e83e42284c1d:remindersLists │
  │ ✅ Modified │ reminders           │ 532f89bd-a169-4ab6-87f6-328032ef76e0:reminders            │
  │ ✅ Modified │ remindersListAssets │ 483f854c-d4b7-4ffc-b2d0-579bf16e2b0c:remindersListAssets  │
  │ ✅ Modified │ remindersListAssets │ ebdcdc41-5c52-48a4-843e-5a8fa23887d6:remindersListAssets  │
  │ ✅ Modified │ remindersListAssets │ bd5fb134-43ac-4a42-84b0-e83e42284c1d:remindersListAssets  │
  │ ✅ Modified │ remindersLists      │ ebdcdc41-5c52-48a4-843e-5a8fa23887d6:remindersLists       │
  │ ✅ Modified │ remindersLists      │ bd5fb134-43ac-4a42-84b0-e83e42284c1d:remindersLists       │
  │ ✅ Modified │ remindersLists      │ 483f854c-d4b7-4ffc-b2d0-579bf16e2b0c:remindersLists       │
  │ 🗑️ Deleted  │ cloudkit.share      │ share-5a2ada22-716f-4f04-ba24-34370914c2c1:remindersLists │
  │ 🗑️ Deleted  │ cloudkit.share      │ share-483f854c-d4b7-4ffc-b2d0-579bf16e2b0c:remindersLists │
  │ 🗑️ Deleted  │ cloudkit.share      │ share-ebdcdc41-5c52-48a4-843e-5a8fa23887d6:remindersLists │
  │ 🗑️ Deleted  │ reminders           │ e5d2cf0f-8fad-4f88-85d0-9bb326c1e58c:reminders            │
  │ 🗑️ Deleted  │ reminders           │ 99c6238a-33ab-4386-9737-7edd646ee908:reminders            │
  │ 🗑️ Deleted  │ reminders           │ 5645c4f2-ad42-4cc8-816b-cfa5cdc693b6:reminders            │
  │ 🗑️ Deleted  │ reminders           │ 3a1a1f64-63f5-4586-af0c-4a774b81f3a8:reminders            │
  └─────────────┴─────────────────────┴───────────────────────────────────────────────────────────┘

[private] nextRecordZoneChangeBatch: scheduled
  ┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃ event          ┃ recordType ┃ recordName                                     ┃
  ┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
  │ ✅ Sent record │ reminders  │ 532f89bd-a169-4ab6-87f6-328032ef76e0:reminders │
  │ ✅ Sent record │ reminders  │ 15cc0909-0e37-4bfa-85aa-f112e8d33643:reminders │
  └────────────────┴────────────┴────────────────────────────────────────────────┘

[private] handleEvent: sentRecordZoneChanges
  ┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃ action         ┃ recordType ┃ recordName                                     ┃ error                    ┃
  ┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
  │ ⚪️ Saved       │ (none)     │ (none)                                         │                          │
  │ 🛑 Save failed │ reminders  │ 532f89bd-a169-4ab6-87f6-328032ef76e0:reminders │ serverRecordChanged (14) │
  └────────────────┴────────────┴────────────────────────────────────────────────┴──────────────────────────┘
```