### PR TITLE
AppKit Demo

### DIFF
--- a/Examples/AppKitDemo/App.swift
+++ b/Examples/AppKitDemo/App.swift
@@ -1,0 +1,18 @@
+import CasePaths
+import Observation
+
+@Observable
+final class AppModel {
+
+  var destination: Destination?
+
+  init(destination: Destination? = nil) {
+    self.destination = destination
+  }
+
+  @CasePathable
+  enum Destination {
+    case reminder(ReminderDetailModel)
+    case remindersList(RemindersListDetailModel)
+  }
+}

--- a/Examples/AppKitDemo/App.swift
+++ b/Examples/AppKitDemo/App.swift
@@ -10,6 +10,14 @@ final class AppModel {
     self.destination = destination
   }
 
+  func reminderSelectedInOutline(_ reminder: Reminder) {
+    self.destination = .reminder(ReminderDetailModel(reminder: reminder))
+  }
+
+  func remindersListSelectedInOutline(_ remindersList: RemindersList) {
+    self.destination = .remindersList(RemindersListDetailModel(remindersList: remindersList))
+  }
+
   @CasePathable
   enum Destination {
     case reminder(ReminderDetailModel)

--- a/Examples/AppKitDemo/AppDelegate.swift
+++ b/Examples/AppKitDemo/AppDelegate.swift
@@ -66,7 +66,7 @@ final class DemoWindowController: NSWindowController {
 
     super.init(window: window)
 
-    window.contentView = NSHostingView(rootView: Color.red)
+    window.contentViewController = RootViewController()
   }
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")

--- a/Examples/AppKitDemo/AppDelegate.swift
+++ b/Examples/AppKitDemo/AppDelegate.swift
@@ -1,0 +1,79 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+public final class AppDelegate: NSObject, NSApplicationDelegate {
+  private var windowControllers: [DemoWindowController] = []
+
+  public func applicationWillFinishLaunching(_ notification: Notification) {
+    let appMenu = NSMenuItem()
+    appMenu.submenu = NSMenu()
+    appMenu.submenu?.items = [
+      NSMenuItem(
+        title: "New Window",
+        action: #selector(AppDelegate.newDemoWindow),
+        keyEquivalent: "n"
+      ),
+      NSMenuItem(
+        title: "Close Window",
+        action: #selector(NSWindow.performClose(_:)),
+        keyEquivalent: "w"
+      ),
+      NSMenuItem(
+        title: "Quit",
+        action: #selector(NSApplication.terminate(_:)),
+        keyEquivalent: "q"
+      ),
+    ]
+    let mainMenu = NSMenu()
+    mainMenu.items = [appMenu]
+    NSApplication.shared.mainMenu = mainMenu
+  }
+  public func applicationDidFinishLaunching(_ notification: Notification) {
+    newDemoWindow()
+  }
+}
+
+extension AppDelegate {
+  @objc func newDemoWindow() {
+    let windowController = DemoWindowController()
+    windowController.showWindow(nil)
+    windowControllers.append(windowController)
+  }
+  func removeWindowController(_ controller: DemoWindowController) {
+    windowControllers.removeAll { $0 === controller }
+  }
+}
+
+final class DemoWindowController: NSWindowController {
+  init() {
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+      styleMask: [
+        .fullSizeContentView,
+        .closable,
+        .miniaturizable,
+        .resizable,
+        .titled,
+      ],
+      backing: .buffered,
+      defer: false
+    )
+
+    window.titleVisibility = .visible
+    window.toolbarStyle = .unified
+    window.center()
+
+    super.init(window: window)
+
+    window.contentView = NSHostingView(rootView: Color.red)
+  }
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  public func windowWillClose(_ notification: Notification) {
+    if let appDelegate = NSApp.delegate as? AppDelegate {
+      appDelegate.removeWindowController(self)
+    }
+  }
+}

--- a/Examples/AppKitDemo/AppDelegate.swift
+++ b/Examples/AppKitDemo/AppDelegate.swift
@@ -1,6 +1,6 @@
 import AppKit
 import Dependencies
-import SwiftUI
+import SQLiteData
 
 @MainActor
 public final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -33,6 +33,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
   public func applicationDidFinishLaunching(_ notification: Notification) {
     try! prepareDependencies {
       try $0.bootstrapDatabase()
+    }
+    @Dependency(\.defaultDatabase) var database
+    try! database.write { db in
+      try db.seedSampleData()
     }
     newDemoWindow()
   }

--- a/Examples/AppKitDemo/AppDelegate.swift
+++ b/Examples/AppKitDemo/AppDelegate.swift
@@ -74,7 +74,9 @@ final class DemoWindowController: NSWindowController {
 
     super.init(window: window)
 
-    window.contentViewController = RootViewController()
+    window.contentViewController = RootViewController(
+      model: AppModel()
+    )
   }
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")

--- a/Examples/AppKitDemo/AppDelegate.swift
+++ b/Examples/AppKitDemo/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Dependencies
 import SwiftUI
 
 @MainActor
@@ -30,6 +31,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     NSApplication.shared.mainMenu = mainMenu
   }
   public func applicationDidFinishLaunching(_ notification: Notification) {
+    try! prepareDependencies {
+      try $0.bootstrapDatabase()
+    }
     newDemoWindow()
   }
 }

--- a/Examples/AppKitDemo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Examples/AppKitDemo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/AppKitDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/AppKitDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/AppKitDemo/Assets.xcassets/Contents.json
+++ b/Examples/AppKitDemo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/AppKitDemo/DetailViewController.swift
+++ b/Examples/AppKitDemo/DetailViewController.swift
@@ -1,8 +1,12 @@
 import AppKit
+import CasePaths
+import SQLiteData
 import SwiftUI
 
 final class DetailViewController: NSViewController {
-  init() {
+  let model: AppModel
+  init(model: AppModel) {
+    self.model = model
     super.init(nibName: nil, bundle: nil)
   }
   required init?(coder: NSCoder) {
@@ -10,7 +14,7 @@ final class DetailViewController: NSViewController {
   }
   override func loadView() {
     let hostingView = FullSizeHostingView(
-      rootView: DetailView()
+      rootView: DetailView(model: model)
         .frame(
           minWidth: 600,
           maxWidth: .infinity,
@@ -27,12 +31,67 @@ final class DetailViewController: NSViewController {
   }
 }
 
-struct DetailView: View {
+private struct DetailView: View {
+  let model: AppModel
   var body: some View {
-    Color.blue
+    switch model.destination {
+    case .remindersList(let model):
+      RemindersListDetailView(model: model)
+    case .reminder(let model):
+      ReminderDetailView(model: model)
+    case .none:
+      ContentUnavailableView(
+        "Choose a reminder or list",
+        systemImage: "list.bullet"
+      )
+    }
   }
 }
 
-#Preview {
-  DetailViewController()
+#Preview("Empty") {
+  let remindersList = try! prepareDependencies {
+    try $0.bootstrapDatabase()
+    return try $0.defaultDatabase.read { db in
+      try RemindersList.all.fetchOne(db)!
+    }
+  }
+  DetailViewController(
+    model: AppModel()
+  )
+}
+
+#Preview("RemindersList") {
+  let remindersList = try! prepareDependencies {
+    try $0.bootstrapDatabase()
+    return try $0.defaultDatabase.read { db in
+      try RemindersList.all.fetchOne(db)!
+    }
+  }
+  DetailViewController(
+    model: AppModel(
+      destination: .remindersList(
+        RemindersListDetailModel(
+          remindersList: remindersList
+        )
+      )
+    )
+  )
+}
+
+#Preview("Reminder") {
+  let reminder = try! prepareDependencies {
+    try $0.bootstrapDatabase()
+    return try $0.defaultDatabase.read { db in
+      try Reminder.all.fetchOne(db)!
+    }
+  }
+  DetailViewController(
+    model: AppModel(
+      destination: .reminder(
+        ReminderDetailModel(
+          reminder: reminder
+        )
+      )
+    )
+  )
 }

--- a/Examples/AppKitDemo/DetailViewController.swift
+++ b/Examples/AppKitDemo/DetailViewController.swift
@@ -1,0 +1,38 @@
+import AppKit
+import SwiftUI
+
+final class DetailViewController: NSViewController {
+  init() {
+    super.init(nibName: nil, bundle: nil)
+  }
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  override func loadView() {
+    let hostingView = FullSizeHostingView(
+      rootView: DetailView()
+        .frame(
+          minWidth: 600,
+          maxWidth: .infinity,
+          minHeight: 500,
+          maxHeight: .infinity
+        )
+    )
+    self.view = hostingView
+  }
+  class FullSizeHostingView<Content: View>: NSHostingView<Content> {
+    override var intrinsicContentSize: NSSize {
+      return NSSize(width: NSView.noIntrinsicMetric, height: NSView.noIntrinsicMetric)
+    }
+  }
+}
+
+struct DetailView: View {
+  var body: some View {
+    Color.blue
+  }
+}
+
+#Preview {
+  DetailViewController()
+}

--- a/Examples/AppKitDemo/ReminderDetail.swift
+++ b/Examples/AppKitDemo/ReminderDetail.swift
@@ -16,7 +16,6 @@ final class ReminderDetailModel {
 struct ReminderDetailView: View {
   let model: ReminderDetailModel
   var body: some View {
-    Text("REMIN")
     Text(model.reminder.title)
   }
 }

--- a/Examples/AppKitDemo/ReminderDetail.swift
+++ b/Examples/AppKitDemo/ReminderDetail.swift
@@ -1,0 +1,36 @@
+import SQLiteData
+import SwiftUI
+
+@MainActor
+@Observable
+final class ReminderDetailModel {
+  @ObservationIgnored @FetchOne var reminder: Reminder
+  init(reminder: Reminder) {
+    _reminder = FetchOne(
+      wrappedValue: reminder,
+      Reminder.find(reminder.id)
+    )
+  }
+}
+
+struct ReminderDetailView: View {
+  let model: ReminderDetailModel
+  var body: some View {
+    Text("REMIN")
+    Text(model.reminder.title)
+  }
+}
+
+#Preview("Reminder") {
+  let reminder = try! prepareDependencies {
+    try $0.bootstrapDatabase()
+    return try $0.defaultDatabase.read { db in
+      try Reminder.all.fetchOne(db)!
+    }
+  }
+  ReminderDetailView(
+    model: ReminderDetailModel(
+      reminder: reminder
+    )
+  )
+}

--- a/Examples/AppKitDemo/RemindersListDetail.swift
+++ b/Examples/AppKitDemo/RemindersListDetail.swift
@@ -1,0 +1,36 @@
+import SQLiteData
+import SwiftUI
+
+@MainActor
+@Observable
+final class RemindersListDetailModel {
+  @ObservationIgnored @FetchOne var remindersList: RemindersList
+  init(remindersList: RemindersList) {
+    _remindersList = FetchOne(
+      wrappedValue: remindersList,
+      RemindersList.find(remindersList.id)
+    )
+  }
+}
+
+struct RemindersListDetailView: View {
+  let model: RemindersListDetailModel
+  var body: some View {
+    Text("LIST")
+    Text(model.remindersList.title)
+  }
+}
+
+#Preview {
+  let remindersList = try! prepareDependencies {
+    try $0.bootstrapDatabase()
+    return try $0.defaultDatabase.read { db in
+      try RemindersList.all.fetchOne(db)!
+    }
+  }
+  RemindersListDetailView(
+    model: RemindersListDetailModel(
+      remindersList: remindersList
+    )
+  )
+}

--- a/Examples/AppKitDemo/RemindersListDetail.swift
+++ b/Examples/AppKitDemo/RemindersListDetail.swift
@@ -5,10 +5,19 @@ import SwiftUI
 @Observable
 final class RemindersListDetailModel {
   @ObservationIgnored @FetchOne var remindersList: RemindersList
+  @ObservationIgnored @FetchAll var reminders: [Reminder]
+  var editableRemindersList: RemindersList.Draft?
   init(remindersList: RemindersList) {
     _remindersList = FetchOne(
       wrappedValue: remindersList,
       RemindersList.find(remindersList.id)
+    )
+    _reminders = FetchAll(
+      Reminder.all
+        .where { $0.remindersListID.eq(remindersList.id) }
+        .order {
+          ($0.isCompleted, $0.title)
+        }
     )
   }
 }
@@ -16,8 +25,15 @@ final class RemindersListDetailModel {
 struct RemindersListDetailView: View {
   let model: RemindersListDetailModel
   var body: some View {
-    Text("LIST")
-    Text(model.remindersList.title)
+    List {
+      ForEach(model.reminders) { reminder in
+        Text(reminder.title)
+      }
+    }
+    .safeAreaInset(edge: .top) {
+      Text(model.remindersList.title)
+        .font(.headline)
+    }
   }
 }
 

--- a/Examples/AppKitDemo/RootViewController.swift
+++ b/Examples/AppKitDemo/RootViewController.swift
@@ -33,6 +33,10 @@ final class SidebarViewController: NSViewController {
   }
 }
 
+final class OutlineView: NSTreeController {
+  
+}
+
 final class ContentViewController: NSViewController {
   init() {
     super.init(nibName: nil, bundle: nil)

--- a/Examples/AppKitDemo/RootViewController.swift
+++ b/Examples/AppKitDemo/RootViewController.swift
@@ -6,27 +6,17 @@ final class RootViewController: NSSplitViewController {
     super.init(nibName: nil, bundle: nil)
 
     let sidebarViewController = SidebarViewController()
-    let contentViewController = ContentViewController()
+    let detailViewController = DetailViewController()
 
     let sidebarItem = NSSplitViewItem(sidebarWithViewController: sidebarViewController)
-    let detailItem = NSSplitViewItem(viewController: contentViewController)
+    let detailItem = NSSplitViewItem(viewController: detailViewController)
 
+    sidebarItem.canCollapse = false
     sidebarItem.minimumThickness = 250
     sidebarItem.maximumThickness = 350
 
     self.addSplitViewItem(sidebarItem)
     self.addSplitViewItem(detailItem)
-  }
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-}
-
-final class ContentViewController: NSViewController {
-  init() {
-    super.init(nibName: nil, bundle: nil)
-    self.view.wantsLayer = true
-    self.view.layer?.backgroundColor = .white
   }
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")

--- a/Examples/AppKitDemo/RootViewController.swift
+++ b/Examples/AppKitDemo/RootViewController.swift
@@ -1,0 +1,45 @@
+import AppKit
+import SQLiteData
+
+final class RootViewController: NSSplitViewController {
+  init() {
+    super.init(nibName: nil, bundle: nil)
+
+    let sidebarViewController = SidebarViewController()
+    let contentViewController = ContentViewController()
+
+    let sidebarItem = NSSplitViewItem(sidebarWithViewController: sidebarViewController)
+    let detailItem = NSSplitViewItem(viewController: contentViewController)
+
+    sidebarItem.minimumThickness = 250
+    sidebarItem.maximumThickness = 350
+
+    self.addSplitViewItem(sidebarItem)
+    self.addSplitViewItem(detailItem)
+  }
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+final class SidebarViewController: NSViewController {
+  init() {
+    super.init(nibName: nil, bundle: nil)
+    self.view.wantsLayer = true
+    self.view.layer?.backgroundColor = .black
+  }
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+final class ContentViewController: NSViewController {
+  init() {
+    super.init(nibName: nil, bundle: nil)
+    self.view.wantsLayer = true
+    self.view.layer?.backgroundColor = .white
+  }
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/Examples/AppKitDemo/RootViewController.swift
+++ b/Examples/AppKitDemo/RootViewController.swift
@@ -22,21 +22,6 @@ final class RootViewController: NSSplitViewController {
   }
 }
 
-final class SidebarViewController: NSViewController {
-  init() {
-    super.init(nibName: nil, bundle: nil)
-    self.view.wantsLayer = true
-    self.view.layer?.backgroundColor = .black
-  }
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-}
-
-final class OutlineView: NSTreeController {
-  
-}
-
 final class ContentViewController: NSViewController {
   init() {
     super.init(nibName: nil, bundle: nil)

--- a/Examples/AppKitDemo/RootViewController.swift
+++ b/Examples/AppKitDemo/RootViewController.swift
@@ -1,12 +1,13 @@
 import AppKit
-import SQLiteData
 
 final class RootViewController: NSSplitViewController {
-  init() {
+  let model: AppModel
+  init(model: AppModel) {
+    self.model = model
     super.init(nibName: nil, bundle: nil)
 
-    let sidebarViewController = SidebarViewController()
-    let detailViewController = DetailViewController()
+    let sidebarViewController = SidebarViewController(model: model)
+    let detailViewController = DetailViewController(model: model)
 
     let sidebarItem = NSSplitViewItem(sidebarWithViewController: sidebarViewController)
     let detailItem = NSSplitViewItem(viewController: detailViewController)

--- a/Examples/AppKitDemo/Schema.swift
+++ b/Examples/AppKitDemo/Schema.swift
@@ -18,7 +18,7 @@ struct RemindersList: Hashable, Identifiable {
 extension RemindersList.Draft: Identifiable {}
 
 @Table
-struct Reminder: Hashable, Identifiable {
+struct Reminder: Hashable, Identifiable, Codable {
   let id: UUID
   var remindersListID: RemindersList.ID
   var title = ""

--- a/Examples/AppKitDemo/Schema.swift
+++ b/Examples/AppKitDemo/Schema.swift
@@ -1,0 +1,186 @@
+import Dependencies
+import Foundation
+import IssueReporting
+import OSLog
+import SQLiteData
+import SwiftUI
+import Synchronization
+
+@Table
+struct RemindersList: Hashable, Identifiable {
+  let id: UUID
+  var title = ""
+
+  static var defaultColor: Color { Color(red: 0x4a / 255, green: 0x99 / 255, blue: 0xef / 255) }
+  static var defaultTitle: String { "Personal" }
+}
+
+extension RemindersList.Draft: Identifiable {}
+
+@Table
+struct Reminder: Hashable, Identifiable {
+  let id: UUID
+  var remindersListID: RemindersList.ID
+  var title = ""
+  var isCompleted: Bool = false
+}
+
+extension Reminder.Draft: Identifiable {}
+
+extension DependencyValues {
+  mutating func bootstrapDatabase() throws {
+    defaultDatabase = try AppKitDemo.appDatabase()
+    //    defaultSyncEngine = try SyncEngine(
+    //      for: defaultDatabase,
+    //      tables: RemindersList.self,
+    //      Reminder.self,
+    //    )
+  }
+}
+
+func appDatabase() throws -> any DatabaseWriter {
+  @Dependency(\.context) var context
+  var configuration = Configuration()
+  configuration.foreignKeysEnabled = true
+  configuration.prepareDatabase { db in
+    //try db.attachMetadatabase()
+    #if DEBUG
+      db.trace(options: .profile) {
+        if context == .live {
+          logger.debug("\($0.expandedDescription)")
+        } else {
+          print("\($0.expandedDescription)")
+        }
+      }
+    #endif
+  }
+  let database = try SQLiteData.defaultDatabase(configuration: configuration)
+  logger.debug(
+    """
+    App database:
+    open "\(database.path)"
+    """
+  )
+  var migrator = DatabaseMigrator()
+  #if DEBUG
+    migrator.eraseDatabaseOnSchemaChange = true
+  #endif
+  migrator.registerMigration("Create initial tables") { db in
+    try #sql(
+      """
+      CREATE TABLE "remindersLists" (
+        "id" TEXT PRIMARY KEY NOT NULL ON CONFLICT REPLACE DEFAULT (uuid()),
+        "title" TEXT NOT NULL ON CONFLICT REPLACE DEFAULT ''
+      ) STRICT
+      """
+    )
+    .execute(db)
+    try #sql(
+      """
+      CREATE TABLE "reminders" (
+        "id" TEXT PRIMARY KEY NOT NULL ON CONFLICT REPLACE DEFAULT (uuid()),
+        "remindersListID" TEXT NOT NULL REFERENCES "remindersLists"("id") ON DELETE CASCADE,
+        "isCompleted" INTEGER NOT NULL DEFAULT 0,
+        "title" TEXT NOT NULL ON CONFLICT REPLACE DEFAULT ''
+      ) STRICT
+      """
+    )
+    .execute(db)
+  }
+
+  try migrator.migrate(database)
+
+  try database.write { db in
+
+    if context != .live {
+      try db.seedSampleData()
+    }
+  }
+
+  return database
+}
+
+private let logger = Logger(subsystem: "Reminders", category: "Database")
+
+#if DEBUG
+  extension Database {
+    func seedSampleData() throws {
+      @Dependency(\.date.now) var now
+      @Dependency(\.uuid) var uuid
+      let remindersListIDs = (0...2).map { _ in uuid() }
+      let reminderIDs = (0...10).map { _ in uuid() }
+      try seed {
+        RemindersList(
+          id: remindersListIDs[0],
+          title: "Personal"
+        )
+        RemindersList(
+          id: remindersListIDs[1],
+          title: "Family"
+        )
+        RemindersList(
+          id: remindersListIDs[2],
+          title: "Business"
+        )
+        Reminder(
+          id: reminderIDs[0],
+          remindersListID: remindersListIDs[0],
+          title: "Groceries"
+        )
+        Reminder(
+          id: reminderIDs[1],
+          remindersListID: remindersListIDs[0],
+          title: "Haircut"
+        )
+        Reminder(
+          id: reminderIDs[2],
+          remindersListID: remindersListIDs[0],
+          title: "Doctor appointment"
+        )
+        Reminder(
+          id: reminderIDs[3],
+          remindersListID: remindersListIDs[0],
+          title: "Take a walk",
+          isCompleted: true,
+        )
+        Reminder(
+          id: reminderIDs[4],
+          remindersListID: remindersListIDs[0],
+          title: "Buy concert tickets"
+        )
+        Reminder(
+          id: reminderIDs[5],
+          remindersListID: remindersListIDs[1],
+          title: "Pick up kids from school"
+        )
+        Reminder(
+          id: reminderIDs[6],
+          remindersListID: remindersListIDs[1],
+          title: "Get laundry",
+          isCompleted: true,
+        )
+        Reminder(
+          id: reminderIDs[7],
+          remindersListID: remindersListIDs[1],
+          title: "Take out trash"
+        )
+        Reminder(
+          id: reminderIDs[8],
+          remindersListID: remindersListIDs[2],
+          title: "Call accountant"
+        )
+        Reminder(
+          id: reminderIDs[9],
+          remindersListID: remindersListIDs[2],
+          title: "Send weekly emails",
+          isCompleted: true,
+        )
+        Reminder(
+          id: reminderIDs[10],
+          remindersListID: remindersListIDs[2],
+          title: "Prepare for WWDC"
+        )
+      }
+    }
+  }
+#endif

--- a/Examples/AppKitDemo/SidebarViewController.swift
+++ b/Examples/AppKitDemo/SidebarViewController.swift
@@ -1,0 +1,116 @@
+import AppKit
+
+final class SidebarViewController: NSViewController {
+  private var outlineView: NSOutlineView!
+  private var scrollView: NSScrollView!
+  private let dataSource = OutlineDataSource()
+
+  init() {
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func loadView() {
+    self.view = NSView()
+
+    scrollView = NSScrollView()
+    scrollView.autoresizingMask = [.width, .height]
+    scrollView.hasVerticalScroller = true
+    scrollView.hasHorizontalScroller = true
+
+    outlineView = NSOutlineView()
+    outlineView.autoresizingMask = [.width, .height]
+
+    outlineView.dataSource = dataSource
+    outlineView.delegate = self
+
+    let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("OutlineColumn"))
+    column.title = "Schema"
+    outlineView.addTableColumn(column)
+    outlineView.outlineTableColumn = column
+
+    //outlineView.headerView = nil
+
+    scrollView.documentView = outlineView
+    self.view.addSubview(scrollView)
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    outlineView.reloadData()
+  }
+}
+
+extension SidebarViewController: NSOutlineViewDelegate {
+  func outlineView(_ outlineView: NSOutlineView, viewFor tableColumn: NSTableColumn?, item: Any) -> NSView? {
+    guard let item = item as? OutlineDataSource.OutlineItem else { return nil }
+
+    let cellView = NSTableCellView()
+
+    let textField = NSTextField(labelWithString: item.title)
+    textField.translatesAutoresizingMaskIntoConstraints = false
+
+    cellView.addSubview(textField)
+    cellView.textField = textField
+
+    NSLayoutConstraint.activate([
+      textField.leadingAnchor.constraint(equalTo: cellView.leadingAnchor, constant: 5),
+      textField.trailingAnchor.constraint(equalTo: cellView.trailingAnchor),
+      textField.centerYAnchor.constraint(equalTo: cellView.centerYAnchor),
+    ])
+
+    return cellView
+  }
+}
+
+final class OutlineDataSource: NSObject, NSOutlineViewDataSource {
+
+  struct OutlineItem {
+    let title: String
+    let children: [OutlineItem]?
+  }
+
+  // Sample data
+  private let outlineData: [OutlineItem] = [
+    OutlineItem(
+      title: "Tables",
+      children: [
+        OutlineItem(title: "Users", children: nil),
+        OutlineItem(title: "Posts", children: nil),
+        OutlineItem(title: "Comments", children: nil),
+      ]
+    ),
+    OutlineItem(
+      title: "Views",
+      children: [
+        OutlineItem(title: "User Posts", children: nil),
+        OutlineItem(title: "Popular Posts", children: nil),
+      ]
+    ),
+    OutlineItem(title: "Indexes", children: nil),
+  ]
+
+  func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
+    if let item = item as? OutlineItem {
+      return item.children?.count ?? 0
+    }
+    return outlineData.count
+  }
+
+  func outlineView(_ outlineView: NSOutlineView, child index: Int, ofItem item: Any?) -> Any {
+    if let item = item as? OutlineItem {
+      return item.children![index]
+    }
+    return outlineData[index]
+  }
+
+  func outlineView(_ outlineView: NSOutlineView, isItemExpandable item: Any) -> Bool {
+    if let item = item as? OutlineItem {
+      return item.children != nil && !item.children!.isEmpty
+    }
+    return false
+  }
+}

--- a/Examples/AppKitDemo/SidebarViewController.swift
+++ b/Examples/AppKitDemo/SidebarViewController.swift
@@ -63,8 +63,8 @@ final class SidebarViewController: NSViewController {
     outlineView.dataSource = self
     outlineView.delegate = self
 
-    let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("OutlineColumn"))
-    column.title = "Schema"
+    let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("RemindersColumn"))
+    column.title = "Reminders"
     outlineView.addTableColumn(column)
     outlineView.outlineTableColumn = column
 

--- a/Examples/AppKitDemo/SidebarViewController.swift
+++ b/Examples/AppKitDemo/SidebarViewController.swift
@@ -3,6 +3,7 @@ import AppKitNavigation
 import SQLiteData
 
 final class SidebarViewController: NSViewController {
+  private let model: AppModel
   private var outlineView: NSOutlineView!
   private var scrollView: NSScrollView!
   private var outlineItems: [OutlineItem] = []
@@ -15,7 +16,8 @@ final class SidebarViewController: NSViewController {
     let reminderTitles: [String]
   }
 
-  init() {
+  init(model: AppModel) {
+    self.model = model
     super.init(nibName: nil, bundle: nil)
 
     $rows = FetchAll(

--- a/Examples/AppKitDemo/main.swift
+++ b/Examples/AppKitDemo/main.swift
@@ -1,0 +1,10 @@
+import AppKit
+
+MainActor.assumeIsolated {
+  let app = NSApplication.shared
+  let delegate = AppDelegate()
+  app.delegate = delegate
+  app.setActivationPolicy(.regular)
+}
+
+_ = NSApplicationMain(CommandLine.argc, CommandLine.unsafeArgv)

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C404E30F2E88A5F5000D23D2 /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = C404E30E2E88A5F5000D23D2 /* SQLiteData */; };
 		CA14DBC92DA884C400E36852 /* CasePaths in Frameworks */ = {isa = PBXBuildFile; productRef = CA14DBC82DA884C400E36852 /* CasePaths */; };
 		CA2908C92D4AF70E003F165F /* UIKitNavigation in Frameworks */ = {isa = PBXBuildFile; productRef = CA2908C82D4AF70E003F165F /* UIKitNavigation */; };
 		CA2BDE2A2E71C469000974D3 /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = CA2BDE292E71C469000974D3 /* SQLiteData */; };
@@ -49,6 +50,7 @@
 
 /* Begin PBXFileReference section */
 		C4CD9A252E88A20900172F37 /* AppKitDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppKitDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C4CD9BE72E88A57D00172F37 /* sqlite-data */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "sqlite-data"; path = "/Users/rcarver/Code/OpenSource/sqlite-data"; sourceTree = "<absolute>"; };
 		CA2BDD9D2E71C30B000974D3 /* CloudKitDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CloudKitDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA2BDE272E71C42B000974D3 /* sqlite-data */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "sqlite-data"; path = "/Users/brandon/projects/sqlite-data"; sourceTree = "<absolute>"; };
 		CA5E46962DEBFE410069E0F8 /* RemindersTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RemindersTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -154,6 +156,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C404E30F2E88A5F5000D23D2 /* SQLiteData in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -258,6 +261,7 @@
 		CAF837022D4735C00047AEB5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C4CD9BE72E88A57D00172F37 /* sqlite-data */,
 				CA2BDE272E71C42B000974D3 /* sqlite-data */,
 			);
 			name = Frameworks;
@@ -283,6 +287,7 @@
 			);
 			name = AppKitDemo;
 			packageProductDependencies = (
+				C404E30E2E88A5F5000D23D2 /* SQLiteData */,
 			);
 			productName = AppKitDemo;
 			productReference = C4CD9A252E88A20900172F37 /* AppKitDemo.app */;
@@ -1322,6 +1327,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		C404E30E2E88A5F5000D23D2 /* SQLiteData */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SQLiteData;
+		};
 		CA14DBC82DA884C400E36852 /* CasePaths */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = DCBE8A122D4842BF0071F499 /* XCRemoteSwiftPackageReference "swift-case-paths" */;

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		C4CD9A252E88A20900172F37 /* AppKitDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppKitDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA2BDD9D2E71C30B000974D3 /* CloudKitDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CloudKitDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA2BDE272E71C42B000974D3 /* sqlite-data */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "sqlite-data"; path = "/Users/brandon/projects/sqlite-data"; sourceTree = "<absolute>"; };
 		CA5E46962DEBFE410069E0F8 /* RemindersTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RemindersTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -94,6 +95,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		C4CD9A262E88A20900172F37 /* AppKitDemo */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = AppKitDemo;
+			sourceTree = "<group>";
+		};
 		CA2BDD9E2E71C30B000974D3 /* CloudKitDemo */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -144,6 +150,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		C4CD9A222E88A20900172F37 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA2BDD9A2E71C30B000974D3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -221,6 +234,7 @@
 				DCBE89CD2D483FB90071F499 /* SyncUps */,
 				CAD0017E2D874E6F00FA977A /* SyncUpTests */,
 				CA2BDD9E2E71C30B000974D3 /* CloudKitDemo */,
+				C4CD9A262E88A20900172F37 /* AppKitDemo */,
 				CAF837022D4735C00047AEB5 /* Frameworks */,
 				CAF836992D4735620047AEB5 /* Products */,
 			);
@@ -236,6 +250,7 @@
 				CAD0017D2D874E6F00FA977A /* SyncUpTests.xctest */,
 				CA5E46962DEBFE410069E0F8 /* RemindersTests.xctest */,
 				CA2BDD9D2E71C30B000974D3 /* CloudKitDemo.app */,
+				C4CD9A252E88A20900172F37 /* AppKitDemo.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -251,6 +266,28 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		C4CD9A242E88A20900172F37 /* AppKitDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C4CD9A2F2E88A20A00172F37 /* Build configuration list for PBXNativeTarget "AppKitDemo" */;
+			buildPhases = (
+				C4CD9A212E88A20900172F37 /* Sources */,
+				C4CD9A222E88A20900172F37 /* Frameworks */,
+				C4CD9A232E88A20900172F37 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				C4CD9A262E88A20900172F37 /* AppKitDemo */,
+			);
+			name = AppKitDemo;
+			packageProductDependencies = (
+			);
+			productName = AppKitDemo;
+			productReference = C4CD9A252E88A20900172F37 /* AppKitDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
 		CA2BDD9C2E71C30B000974D3 /* CloudKitDemo */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = CA2BDDA72E71C30D000974D3 /* Build configuration list for PBXNativeTarget "CloudKitDemo" */;
@@ -429,9 +466,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1640;
+				LastSwiftUpdateCheck = 2600;
 				LastUpgradeCheck = 1620;
 				TargetAttributes = {
+					C4CD9A242E88A20900172F37 = {
+						CreatedOnToolsVersion = 26.0;
+					};
 					CA2BDD9C2E71C30B000974D3 = {
 						CreatedOnToolsVersion = 16.4;
 					};
@@ -486,11 +526,19 @@
 				DCBE89CB2D483FB90071F499 /* SyncUps */,
 				CAD0017C2D874E6F00FA977A /* SyncUpTests */,
 				CA2BDD9C2E71C30B000974D3 /* CloudKitDemo */,
+				C4CD9A242E88A20900172F37 /* AppKitDemo */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		C4CD9A232E88A20900172F37 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA2BDD9B2E71C30B000974D3 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -543,6 +591,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		C4CD9A212E88A20900172F37 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA2BDD992E71C30B000974D3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -613,6 +668,70 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		C4CD9A2D2E88A20A00172F37 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.7;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.AppKitDemo.AppKitDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		C4CD9A2E2E88A20A00172F37 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.7;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.AppKitDemo.AppKitDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		CA2BDDA52E71C30D000974D3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1077,6 +1196,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		C4CD9A2F2E88A20A00172F37 /* Build configuration list for PBXNativeTarget "AppKitDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C4CD9A2D2E88A20A00172F37 /* Debug */,
+				C4CD9A2E2E88A20A00172F37 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		CA2BDDA72E71C30D000974D3 /* Build configuration list for PBXNativeTarget "CloudKitDemo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		C404E30F2E88A5F5000D23D2 /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = C404E30E2E88A5F5000D23D2 /* SQLiteData */; };
+		C43A01E72E88FDB800E5168E /* AppKitNavigation in Frameworks */ = {isa = PBXBuildFile; productRef = C43A01E62E88FDB800E5168E /* AppKitNavigation */; };
 		CA14DBC92DA884C400E36852 /* CasePaths in Frameworks */ = {isa = PBXBuildFile; productRef = CA14DBC82DA884C400E36852 /* CasePaths */; };
 		CA2908C92D4AF70E003F165F /* UIKitNavigation in Frameworks */ = {isa = PBXBuildFile; productRef = CA2908C82D4AF70E003F165F /* UIKitNavigation */; };
 		CA2BDE2A2E71C469000974D3 /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = CA2BDE292E71C469000974D3 /* SQLiteData */; };
@@ -157,6 +158,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C404E30F2E88A5F5000D23D2 /* SQLiteData in Frameworks */,
+				C43A01E72E88FDB800E5168E /* AppKitNavigation in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -288,6 +290,7 @@
 			name = AppKitDemo;
 			packageProductDependencies = (
 				C404E30E2E88A5F5000D23D2 /* SQLiteData */,
+				C43A01E62E88FDB800E5168E /* AppKitNavigation */,
 			);
 			productName = AppKitDemo;
 			productReference = C4CD9A252E88A20900172F37 /* AppKitDemo.app */;
@@ -1330,6 +1333,11 @@
 		C404E30E2E88A5F5000D23D2 /* SQLiteData */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SQLiteData;
+		};
+		C43A01E62E88FDB800E5168E /* AppKitNavigation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DCF267372D48437300B680BE /* XCRemoteSwiftPackageReference "swift-navigation" */;
+			productName = AppKitNavigation;
 		};
 		CA14DBC82DA884C400E36852 /* CasePaths */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		C404E30F2E88A5F5000D23D2 /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = C404E30E2E88A5F5000D23D2 /* SQLiteData */; };
 		C43A01E72E88FDB800E5168E /* AppKitNavigation in Frameworks */ = {isa = PBXBuildFile; productRef = C43A01E62E88FDB800E5168E /* AppKitNavigation */; };
+		C43A02052E8999C100E5168E /* CasePaths in Frameworks */ = {isa = PBXBuildFile; productRef = C43A02042E8999C100E5168E /* CasePaths */; };
 		CA14DBC92DA884C400E36852 /* CasePaths in Frameworks */ = {isa = PBXBuildFile; productRef = CA14DBC82DA884C400E36852 /* CasePaths */; };
 		CA2908C92D4AF70E003F165F /* UIKitNavigation in Frameworks */ = {isa = PBXBuildFile; productRef = CA2908C82D4AF70E003F165F /* UIKitNavigation */; };
 		CA2BDE2A2E71C469000974D3 /* SQLiteData in Frameworks */ = {isa = PBXBuildFile; productRef = CA2BDE292E71C469000974D3 /* SQLiteData */; };
@@ -159,6 +160,7 @@
 			files = (
 				C404E30F2E88A5F5000D23D2 /* SQLiteData in Frameworks */,
 				C43A01E72E88FDB800E5168E /* AppKitNavigation in Frameworks */,
+				C43A02052E8999C100E5168E /* CasePaths in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -291,6 +293,7 @@
 			packageProductDependencies = (
 				C404E30E2E88A5F5000D23D2 /* SQLiteData */,
 				C43A01E62E88FDB800E5168E /* AppKitNavigation */,
+				C43A02042E8999C100E5168E /* CasePaths */,
 			);
 			productName = AppKitDemo;
 			productReference = C4CD9A252E88A20900172F37 /* AppKitDemo.app */;
@@ -1338,6 +1341,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = DCF267372D48437300B680BE /* XCRemoteSwiftPackageReference "swift-navigation" */;
 			productName = AppKitNavigation;
+		};
+		C43A02042E8999C100E5168E /* CasePaths */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DCBE8A122D4842BF0071F499 /* XCRemoteSwiftPackageReference "swift-case-paths" */;
+			productName = CasePaths;
 		};
 		CA14DBC82DA884C400E36852 /* CasePaths */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1a549785266ada7e3202edc79fe44d94e238bd6e6494c714e09a66c2d74bc59f",
+  "originHash" : "c0c3d5ab113340382333da4987204cf76d535b45abf7b597fe71ed3662386803",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -71,24 +71,6 @@
       "state" : {
         "revision" : "a501eebe552fd23691c560adf474fca2169ad8aa",
         "version" : "1.9.4"
-      }
-    },
-    {
-      "identity" : "swift-docc-plugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
-      "state" : {
-        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
-        "version" : "1.4.5"
-      }
-    },
-    {
-      "identity" : "swift-docc-symbolkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
-      "state" : {
-        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
-        "version" : "1.0.0"
       }
     },
     {

--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c0c3d5ab113340382333da4987204cf76d535b45abf7b597fe71ed3662386803",
+  "originHash" : "5b6a9f5c8c2b757451c31f80c25e528163092e701c82d5f6f1c82ca48fb617dc",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -71,6 +71,24 @@
       "state" : {
         "revision" : "a501eebe552fd23691c560adf474fca2169ad8aa",
         "version" : "1.9.4"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
+        "version" : "1.4.5"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -30,3 +30,7 @@ project. To work on each example app individually, select its scheme in Xcode.
 
 [scrumdinger]: https://developer.apple.com/tutorials/app-dev-training/getting-started-with-scrumdinger
 [reminders-app-store]: https://apps.apple.com/us/app/reminders/id1108187841
+
+* **AppKitDemo**
+  <br> This application is a simplified Reminders app built with AppKit + SwiftUI. It shows basic patterns
+  for fetching, observing, and modifying data.


### PR DESCRIPTION
This adds `AppKitDemo` to the Examples project

Current setup:

* Uses a simplified schema from `Reminders` (but it could be the full schema)
* Uses similar patterns as other demos for Observable models and views
* `NSSplitViewController` at the app root for sidebar/detail 
* `NSOutlineView` driven by observation of `FetchAll` for the sidebar
* Detail shows the selected item. Right now I used SwiftUI just to keep it simple.

Possible features to add:
* [ ] Sort and/or filter completed reminders in sidebar
* [ ] Mark reminder completed in detail
* [ ] Edit reminders list title in detail (and/or sidebar)
* [ ] Edit reminder title in detail (and/or sidebar)
* [ ] Add new reminder to list
* [ ] Add new reminders list
* [ ] Start with empty database, allow to seed like Reminders

From there we'd get into replicating more advanced features of Reminders, and I'm 

### Open Questions

* Is the scope of the demo good? I didn't want to get into replicating Reminders completely, but rather just to show a few ways to interact with AppKit. We could also use a totally different domain model.
* Should it be pure AppKit or is a mix of SwiftUI ok or even desirable?

