### PR TITLE
Clean up sync metadata when unrecognizable table is deleted.

### DIFF
--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -1242,6 +1242,14 @@
           }
         } else {
           // NB: Deleting a record from a table we do not currently recognize.
+          await withErrorReporting(.sqliteDataCloudKitFailure) {
+            try await userDatabase.write { db in
+              try SyncMetadata
+                .findAll(recordIDs)
+                .delete()
+                .execute(db)
+            }
+          }
         }
       }
 


### PR DESCRIPTION
Right now we save records for unrecognized tables in `SyncMetadata` because we will need to use those records later to insert into the user database once the app updates to the newest version of the schema. But, if those unrecognized records are later deleted from CloudKit, we are not deleting the sync metadata on the local device. This PR fixes that.