### PR TITLE
Don't execute `@FetchOne` queries for `_Selection`s.

### DIFF
--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "branch" : "table-expression",
-        "revision" : "366138aecbd1ff7cb5b900b10d9cb3aea725b07c"
+        "revision" : "603bcbf0bd5818437ff975e37cf5a1ea6867c41e",
+        "version" : "0.22.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "aa08712b6e4d98c42fa70796152947592436878adb73972e6a2d9a9e254a38ff",
+  "originHash" : "340515fb3c95004c514a8f6e91bf8d07b5ea24f9094d67bede294a125b46a3ba",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "49ce85d88f3b39fa8b9bc07de437af83358cbc74",
-        "version" : "0.22.0"
+        "branch" : "optional-selections",
+        "revision" : "1d5ecf1fe482eceae5c147d77e37049f55077456"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.4"),
     .package(
       url: "https://github.com/pointfreeco/swift-structured-queries",
-      from: "0.22.0",
+      branch: "optional-selections",
       traits: [
         .trait(name: "StructuredQueriesTagged", condition: .when(traits: ["SQLiteDataTagged"]))
       ]

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -28,7 +28,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.9.0"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", from: "2.3.0"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.4"),
-    .package(url: "https://github.com/pointfreeco/swift-structured-queries", from: "0.22.0"),
+    .package(url: "https://github.com/pointfreeco/swift-structured-queries", branch: "optional-selections"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.5.0"),
   ],
   targets: [

--- a/Sources/SQLiteData/FetchOne.swift
+++ b/Sources/SQLiteData/FetchOne.swift
@@ -121,6 +121,18 @@ public struct FetchOne<Value: Sendable>: Sendable {
     )
   }
 
+  /// Initializes this property with a wrapped value.
+  ///
+  /// - Parameter wrappedValue: A default value to associate with this property.
+  public init(wrappedValue: sending Value)
+  where
+    Value: _OptionalProtocol,
+    Value: _Selection,
+    Value.QueryOutput == Value
+  {
+    sharedReader = SharedReader(value: wrappedValue)
+  }
+
   /// Initializes this property with a query associated with the wrapped value.
   ///
   /// - Parameters:


### PR DESCRIPTION
We added an overload to handle `@FetchAll`, but we missed this one.