### PR TITLE
Fix 1.1.0 `@FetchAll` regression

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "340515fb3c95004c514a8f6e91bf8d07b5ea24f9094d67bede294a125b46a3ba",
+  "originHash" : "41f93013537f670f4fe1a235c318bee33b54528c76e4b1dd2a7675bea6c0bcde",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "branch" : "optional-selections",
-        "revision" : "1d5ecf1fe482eceae5c147d77e37049f55077456"
+        "revision" : "9bbfc44d18f6fbbfc500676df55738db8800f5a3",
+        "version" : "0.22.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.4"),
     .package(
       url: "https://github.com/pointfreeco/swift-structured-queries",
-      branch: "optional-selections",
+      from: "0.22.3",
       traits: [
         .trait(name: "StructuredQueriesTagged", condition: .when(traits: ["SQLiteDataTagged"]))
       ]

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -28,7 +28,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.9.0"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", from: "2.3.0"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.4"),
-    .package(url: "https://github.com/pointfreeco/swift-structured-queries", branch: "optional-selections"),
+    .package(url: "https://github.com/pointfreeco/swift-structured-queries", from: "0.22.3"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.5.0"),
   ],
   targets: [

--- a/Sources/SQLiteData/FetchAll.swift
+++ b/Sources/SQLiteData/FetchAll.swift
@@ -87,6 +87,12 @@ public struct FetchAll<Element: Sendable>: Sendable {
   }
 
   /// Initializes this property with a default value.
+  @_disfavoredOverload
+  public init(wrappedValue: [Element] = []) {
+    sharedReader = SharedReader(value: wrappedValue)
+  }
+
+  /// Initializes this property with a default value.
   public init(wrappedValue: [Element] = [])
   where Element: StructuredQueriesCore._Selection, Element.QueryOutput == Element {
     sharedReader = SharedReader(value: wrappedValue)

--- a/Tests/SQLiteDataTests/CompileTimeTests.swift
+++ b/Tests/SQLiteDataTests/CompileTimeTests.swift
@@ -1,0 +1,9 @@
+import SQLiteData
+
+private final class Model {
+  @FetchAll var titles: [String]
+
+  init() {
+    _titles = FetchAll(Reminder.select(\.title))
+  }
+}


### PR DESCRIPTION
An initializer was lost when introducing an initializer for selections.