### PR TITLE
Add injectable logger support for CloudKit sync operations

### DIFF
--- a/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
@@ -1,10 +1,9 @@
 #if canImport(CloudKit)
   import Foundation
-  import os
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   func defaultMetadatabase(
-    logger: Logger,
+    logger: any SyncEngineLogger,
     url: URL
   ) throws -> any DatabaseWriter {
     logger.debug(

--- a/Sources/SQLiteData/CloudKit/Loggers/AppleLoggerAdapter.swift
+++ b/Sources/SQLiteData/CloudKit/Loggers/AppleLoggerAdapter.swift
@@ -1,4 +1,4 @@
-#if DEBUG && canImport(CloudKit)
+#if canImport(CloudKit)
   import CloudKit
   import TabularData
   import os

--- a/Sources/SQLiteData/CloudKit/Loggers/CompositeLogger.swift
+++ b/Sources/SQLiteData/CloudKit/Loggers/CompositeLogger.swift
@@ -1,0 +1,41 @@
+#if canImport(CloudKit)
+  import CloudKit
+
+  /// A logger that forwards events to multiple underlying loggers.
+  ///
+  /// This allows you to use multiple logging backends simultaneously,
+  /// such as logging to both Apple's Console.app and a third-party
+  /// crash reporting service.
+  ///
+  /// Example:
+  /// ```swift
+  /// let logger = CompositeLogger(loggers: [
+  ///     AppleLoggerAdapter(),
+  ///     MySentryLogger(),
+  ///     MyDataDogLogger()
+  /// ])
+  /// ```
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  public struct CompositeLogger: SyncEngineLogger {
+    private let loggers: [any SyncEngineLogger]
+
+    /// Creates a new composite logger with the specified loggers.
+    ///
+    /// - Parameter loggers: An array of loggers to forward events to.
+    public init(loggers: [any SyncEngineLogger]) {
+      self.loggers = loggers
+    }
+
+    public func log(_ event: SyncEngine.Event, databaseScope: String) {
+      for logger in loggers {
+        logger.log(event, databaseScope: databaseScope)
+      }
+    }
+
+    public func debug(_ message: String) {
+      for logger in loggers {
+        logger.debug(message)
+      }
+    }
+  }
+#endif

--- a/Sources/SQLiteData/CloudKit/Loggers/DisabledLogger.swift
+++ b/Sources/SQLiteData/CloudKit/Loggers/DisabledLogger.swift
@@ -1,0 +1,21 @@
+#if canImport(CloudKit)
+  import CloudKit
+
+  /// A no-op logger implementation that discards all log messages.
+  ///
+  /// This logger is used when logging is disabled, providing a lightweight
+  /// implementation that doesn't perform any actual logging operations.
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  public struct DisabledLogger: SyncEngineLogger {
+    /// Creates a new disabled logger instance.
+    public init() {}
+
+    public func log(_ event: SyncEngine.Event, databaseScope: String) {
+      // No-op: logging is disabled
+    }
+
+    public func debug(_ message: String) {
+      // No-op: logging is disabled
+    }
+  }
+#endif

--- a/Sources/SQLiteData/CloudKit/SyncEngine.Event.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.Event.swift
@@ -3,7 +3,7 @@
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension SyncEngine {
-    package enum Event: CustomStringConvertible, Sendable {
+    public enum Event: CustomStringConvertible, Sendable {
       case stateUpdate(stateSerialization: CKSyncEngine.State.Serialization)
       case accountChange(changeType: CKSyncEngine.Event.AccountChange.ChangeType)
       case fetchedDatabaseChanges(
@@ -82,7 +82,7 @@
         }
       }
 
-      package var description: String {
+      public var description: String {
         switch self {
         case .stateUpdate: "stateUpdate"
         case .accountChange: "accountChange"

--- a/Sources/SQLiteData/CloudKit/SyncEngineLogger.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngineLogger.swift
@@ -1,0 +1,23 @@
+#if canImport(CloudKit)
+  import CloudKit
+
+  /// A protocol that defines logging requirements for CloudKit sync operations.
+  ///
+  /// This protocol allows for injectable logging implementations, enabling
+  /// custom logging backends while maintaining compatibility with the existing
+  /// Apple Logger implementation.
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  public protocol SyncEngineLogger: Sendable {
+    /// Logs a CloudKit sync event.
+    ///
+    /// - Parameters:
+    ///   - event: The sync engine event to log.
+    ///   - databaseScope: The database scope label (e.g., "private", "shared", "global").
+    func log(_ event: SyncEngine.Event, databaseScope: String)
+
+    /// Logs a debug message.
+    ///
+    /// - Parameter message: The debug message to log.
+    func debug(_ message: String)
+  }
+#endif

--- a/Tests/SQLiteDataTests/Internal/BaseCloudKitTests.swift
+++ b/Tests/SQLiteDataTests/Internal/BaseCloudKitTests.swift
@@ -4,7 +4,6 @@ import OrderedCollections
 import SQLiteData
 import SnapshotTesting
 import Testing
-import os
 
 @Suite(
   .snapshots(record: .missing),
@@ -209,7 +208,7 @@ extension SyncEngine {
         )
       },
       userDatabase: userDatabase,
-      logger: Logger(.disabled),
+      logger: DisabledLogger(),
       tables: tables,
       privateTables: privateTables
     )


### PR DESCRIPTION
Add injectable logger support for CloudKit sync operations

  Introduces a protocol-based logging abstraction that allows custom logging backends while maintaining backward
  compatibility.

  Changes

  - Added SyncEngineLogger protocol for dependency injection
  - Implemented AppleLoggerAdapter to preserve existing logging behavior
  - Added DisabledLogger for testing and CompositeLogger for multiple backends
  - Made SyncEngine.Event public to support custom logger implementations
  - Updated SyncEngine to accept injectable logger (defaults to AppleLoggerAdapter)

  Usage
```
  // Default behavior (unchanged)
  let engine = SyncEngine(...)

  // Custom logger
  let engine = SyncEngine(..., logger: MySentryLogger())

  // Multiple loggers
  let engine = SyncEngine(..., logger: CompositeLogger(loggers: [
      AppleLoggerAdapter(),
      MySentryLogger()
  ]))
```