### PR TITLE
Add option to drop unique constraints inside SyncEngine.migratePrimaryKeys

### DIFF
--- a/Sources/SQLiteData/CloudKit/PrimaryKeyMigration.swift
+++ b/Sources/SQLiteData/CloudKit/PrimaryKeyMigration.swift
@@ -436,7 +436,7 @@
         || parseKeyword("CHECK")
         || parseKeywords(["FOREIGN", "KEY"])
       {
-        try parseBalanced(upTo: ",")
+        try parseBalanced { [",", ")"].contains($0.first) }
         return true
       } else {
         return false

--- a/Sources/SQLiteData/CloudKit/PrimaryKeyMigration.swift
+++ b/Sources/SQLiteData/CloudKit/PrimaryKeyMigration.swift
@@ -525,14 +525,6 @@
       return true
     }
 
-    mutating func parseKeyword() -> String? {
-      parseTrivia()
-      let prefix = prefix(while: \.isLetter)
-      guard !prefix.isEmpty else { return nil }
-      removeFirst(prefix.count)
-      return String(prefix)
-    }
-
     @discardableResult
     mutating func parseTrivia() -> String {
       var trivia = ""

--- a/Tests/SQLiteDataTests/PrimaryKeyMigrationTests.swift
+++ b/Tests/SQLiteDataTests/PrimaryKeyMigrationTests.swift
@@ -340,6 +340,61 @@ struct PrimaryKeyMigrationTests {
     }
   }
 
+
+  @Table("users") struct PrimaryKeyNamedUnique {
+    @Column(primaryKey: true)
+    let unique: UUID
+    var title = ""
+  }
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  @Test func primaryKeyNamedUnique() throws {
+    try database.write { db in
+      try #sql(
+        """
+        CREATE TABLE "users" (
+          "unique" INTEGER,
+          "title" TEXT NOT NULL,
+          PRIMARY KEY("unique")
+        ) STRICT
+        """
+      )
+      .execute(db)
+    }
+
+    try database.writeWithoutTransaction { db in
+      try #sql("PRAGMA foreign_keys = OFF").execute(db)
+      do {
+        try db.inTransaction {
+          try SyncEngine.migratePrimaryKeys(
+            db,
+            tables: PrimaryKeyNamedUnique.self,
+            dropUniqueConstraints: true,
+            uuid: $uuid
+          )
+          return .commit
+        }
+      }
+      try #sql("PRAGMA foreign_keys = ON").execute(db)
+    }
+
+    assertQuery(SQLiteSchema.default, database: database) {
+      #"""
+      ┌────────────────────────────────────────────────────────────────────────────────┐
+      │ SQLiteSchema(                                                                  │
+      │   type: .table,                                                                │
+      │   name: "users",                                                               │
+      │   tableName: "users",                                                          │
+      │   sql: """                                                                     │
+      │   CREATE TABLE "users" (                                                       │
+      │     "unique" TEXT PRIMARY KEY NOT NULL ON CONFLICT REPLACE DEFAULT ("uuid"()), │
+      │     "title" TEXT NOT NULL) STRICT                                              │
+      │   """                                                                          │
+      │ )                                                                              │
+      └────────────────────────────────────────────────────────────────────────────────┘
+      """#
+    }
+  }
+
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   @Test func columnConstraints() throws {
     try database.write { db in


### PR DESCRIPTION
### Summary
This PR add an option to allow user drop unique constraints when migrating with **SyncEngine.migratePrimaryKeys**.

### Motivation
Current migrate method only convert primary key to UUID, unique constraints has not been dealt with.

### Changes
- Added dropUniqueConstraints to SyncEngine.migratePrimaryKeys
- Added parseUniqueConstraintRange func in `PrimaryKeyMigration`

### Testing
- Added uniqueConstraintsDrop in `PrimaryKeyMigrationTests`, test schema for column and table unique constraints

