### PR TITLE
Fixes with sharing records

### DIFF
--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -146,7 +146,7 @@
 
       var existingShare: CKShare? {
         get async throws {
-          let share = try await userDatabase.read { db in
+          let share = try await metadatabase.read { db in
             try SyncMetadata
               .find(rootRecord.recordID)
               .select(\.share)
@@ -183,9 +183,7 @@
 
       let savedShare = try saveResults.values.compactMap { result in
         let record = try result.get()
-        return record.recordID == sharedRecord.recordID
-        ? record as? CKShare
-        : nil
+        return record.recordID == sharedRecord.recordID ? record as? CKShare : nil
       }
       .first
       let savedRootRecord = try saveResults.values.compactMap { result in
@@ -204,7 +202,7 @@
             """
         )
       }
-      try await userDatabase.write { db in
+      try await metadatabase.write { db in
         try SyncMetadata
           .where { $0.recordName.eq(recordName) }
           .update {

--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -152,7 +152,7 @@
               .select(\.share)
               .fetchOne(db) ?? nil
           }
-          guard let shareRecordID = share?.recordID  // = rootRecord.share?.recordID
+          guard let shareRecordID = share?.recordID
           else {
             return nil
           }

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -872,19 +872,31 @@
         )
 
       case .willFetchRecordZoneChanges:
-        fetchingChangesCount += 1
+        await MainActor.run {
+          fetchingChangesCount += 1
+        }
       case .didFetchRecordZoneChanges:
-        fetchingChangesCount -= 1
+        await MainActor.run {
+          fetchingChangesCount -= 1
+        }
 
       case .willFetchChanges:
-        fetchingChangesCount += 1
+        await MainActor.run {
+          fetchingChangesCount += 1
+        }
       case .didFetchChanges:
-        fetchingChangesCount -= 1
+        await MainActor.run {
+          fetchingChangesCount -= 1
+        }
 
       case .willSendChanges:
-        sendingChangesCount += 1
+        await MainActor.run {
+          sendingChangesCount += 1
+        }
       case .didSendChanges:
-        sendingChangesCount -= 1
+        await MainActor.run {
+          sendingChangesCount -= 1
+        }
 
       @unknown default:
         break

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -644,6 +644,23 @@
         }
       }
 
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func shareTwice() async throws {
+        let remindersList = RemindersList(id: 1, title: "Personal")
+        try await userDatabase.userWrite { db in
+          try db.seed {
+            remindersList
+          }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        let _ = try await syncEngine.share(record: remindersList, configure: { _ in })
+        let _ = try await syncEngine.share(record: remindersList, configure: { _ in })
+
+        assertQuery(SyncMetadata.select(\.share), database: syncEngine.metadatabase)
+        assertInlineSnapshot(of: container, as: .customDump)
+      }
+
       // NB: Swift 6.2 cannot currently compile this:
       //     Pattern that the region based isolation checker does not understand how to check.
       //     Please file a bug.

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -657,8 +657,45 @@
         let _ = try await syncEngine.share(record: remindersList, configure: { _ in })
         let _ = try await syncEngine.share(record: remindersList, configure: { _ in })
 
-        assertQuery(SyncMetadata.select(\.share), database: syncEngine.metadatabase)
-        assertInlineSnapshot(of: container, as: .customDump)
+        assertQuery(SyncMetadata.select(\.share), database: syncEngine.metadatabase) {
+          """
+          ┌────────────────────────────────────────────────────────────────────────┐
+          │ CKRecord(                                                              │
+          │   recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__), │
+          │   recordType: "cloudkit.share",                                        │
+          │   parent: nil,                                                         │
+          │   share: nil                                                           │
+          │ )                                                                      │
+          └────────────────────────────────────────────────────────────────────────┘
+          """
+        }
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__),
+                  recordType: "cloudkit.share",
+                  parent: nil,
+                  share: nil
+                ),
+                [1]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__))
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
       }
 
       // NB: Swift 6.2 cannot currently compile this:

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -654,8 +654,12 @@
         }
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-        let _ = try await syncEngine.share(record: remindersList, configure: { _ in })
-        let _ = try await syncEngine.share(record: remindersList, configure: { _ in })
+        let _ = try await syncEngine.share(record: remindersList, configure: {
+          $0[CKShare.SystemFieldKey.title] = "Join my list!"
+        })
+        let _ = try await syncEngine.share(record: remindersList, configure: {
+          $0[CKShare.SystemFieldKey.title] = "Please join my list!"
+        })
 
         assertQuery(SyncMetadata.select(\.share), database: syncEngine.metadatabase) {
           """
@@ -679,7 +683,8 @@
                   recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__),
                   recordType: "cloudkit.share",
                   parent: nil,
-                  share: nil
+                  share: nil,
+                  cloudkit.title: "Please join my list!"
                 ),
                 [1]: CKRecord(
                   recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),


### PR DESCRIPTION
Right now we don't cache the newest server records when creating a share, which means if you share again we may use old records with old `recordChangeTag`s. This PR now refreshes server records whenever sharing a record.