### PR TITLE
Customizable iCloud logout behavior

### DIFF
--- a/Examples/Reminders/RemindersApp.swift
+++ b/Examples/Reminders/RemindersApp.swift
@@ -42,7 +42,7 @@ struct RemindersApp: App {
           Text(
             """
             You are no longer logged into iCloud. Would you like to reset your local data to the \
-            defaults? This will not affect your iCloud data.
+            defaults? This will not affect your data in iCloud.
             """
           )
         }

--- a/Examples/Reminders/RemindersApp.swift
+++ b/Examples/Reminders/RemindersApp.swift
@@ -30,19 +30,21 @@ struct RemindersApp: App {
           RemindersListsView(model: Self.model)
         }
         .alert(
-          "Clear local data?",
+          "Reset local data?",
           isPresented: $syncEngineDelegate.isDeleteLocalDataAlertPresented
         ) {
-          Button("Delete local data", role: .destructive) {
+          Button("Reset", role: .destructive) {
             Task {
               try await syncEngine.deleteLocalData()
             }
           }
         } message: {
-          Text("""
-              You have logged out of your previous iCloud account. Do you want to delete all of \
-              your local data? This will not delete the data from iCloud.
-              """)
+          Text(
+            """
+            You are no longer logged into iCloud. Would you like to reset your local data to the \
+            defaults? This will not affect your iCloud data.
+            """
+          )
         }
       }
     }

--- a/Examples/Reminders/Schema.swift
+++ b/Examples/Reminders/Schema.swift
@@ -136,6 +136,7 @@ func appDatabase() throws -> any DatabaseWriter {
   configuration.foreignKeysEnabled = true
   configuration.prepareDatabase { db in
     try db.attachMetadatabase()
+    db.add(function: $createDefaultRemindersList)
     db.add(function: $handleReminderStatusUpdate)
     #if DEBUG
       db.trace(options: .profile) {
@@ -364,7 +365,7 @@ nonisolated func handleReminderStatusUpdate() {
 }
 
 @DatabaseFunction
-func createDefaultRemindersList() {
+nonisolated func createDefaultRemindersList() {
   Task {
     @Dependency(\.defaultDatabase) var database
     try await database.write { db in

--- a/Examples/Reminders/SearchReminders.swift
+++ b/Examples/Reminders/SearchReminders.swift
@@ -164,7 +164,7 @@ class SearchRemindersModel {
     }
   }
 
-  struct Token: Hashable, Identifiable {
+  nonisolated struct Token: Hashable, Identifiable {
     enum Kind {
       case near
       case tag
@@ -264,7 +264,7 @@ struct SearchRemindersView: View {
   }
 }
 
-fileprivate func baseQuery(
+nonisolated fileprivate func baseQuery(
   searchText: String,
   searchTokens: [SearchRemindersModel.Token]
 ) -> SelectOf<ReminderText, Reminder> {
@@ -291,7 +291,7 @@ fileprivate func baseQuery(
 }
 
 extension String {
-  fileprivate func quoted() -> String {
+  nonisolated fileprivate func quoted() -> String {
     split(separator: " ")
       .map { #""\#($0.replacingOccurrences(of: #"""#, with: #""""#))""# }
       .joined(separator: " ")

--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -55,7 +55,7 @@
     /// * The table the `record` belongs to is not synchronized to CloudKit.
     /// * The `record` has any foreign keys. Only root records are shareable in CloudKit.
     /// * The table the `record` belongs to is a "private" table as determined by the
-    /// [`SyncEngine` initializer](<doc:SyncEngine/init(for:tables:privateTables:containerIdentifier:defaultZone:startImmediately:logger:)>).
+    /// [`SyncEngine` initializer](<doc:SyncEngine/init(for:tables:privateTables:containerIdentifier:defaultZone:startImmediately:delegate:logger:)>).
     /// * The `record` is being shared before it has been synchronized to CloudKit.
     /// * Any of the CloudKit APIs invoked throw an error.
     ///

--- a/Sources/SQLiteData/CloudKit/Internal/Logging.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Logging.swift
@@ -47,9 +47,9 @@
           dataFrame.sort(on: ColumnID("action", String.self))
         }
         var formattingOptions = FormattingOptions(
-          maximumLineWidth: 120,
+          maximumLineWidth: 300,
           maximumCellWidth: 80,
-          maximumRowCount: 50,
+          maximumRowCount: 1000,
           includesColumnTypes: false
         )
         formattingOptions.includesRowAndColumnCounts = false

--- a/Sources/SQLiteData/CloudKit/Internal/SyncEngineProtocol.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/SyncEngineProtocol.swift
@@ -2,16 +2,6 @@
   import CloudKit
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  package protocol SyncEngineDelegate: AnyObject, Sendable {
-    func handleEvent(_ event: SyncEngine.Event, syncEngine: any SyncEngineProtocol) async
-    func nextRecordZoneChangeBatch(
-      reason: CKSyncEngine.SyncReason,
-      options: CKSyncEngine.SendChangesOptions,
-      syncEngine: any SyncEngineProtocol
-    ) async -> CKSyncEngine.RecordZoneChangeBatch?
-  }
-
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   package protocol SyncEngineProtocol<Database, State>: AnyObject, Sendable {
     associatedtype State: CKSyncEngineStateProtocol
     associatedtype Database: CloudDatabase

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -1204,6 +1204,7 @@
         await withErrorReporting {
           try await enqueueUnknownRecordsForCloudKit()
         }
+        await delegate?.syncEngine(self, accountChanged: changeType)
       case .signOut, .switchAccounts:
         guard let delegate
         else {

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -38,8 +38,8 @@
     private let notificationsObserver = LockIsolated<(any NSObjectProtocol)?>(nil)
     private let activityCounts = LockIsolated(ActivityCounts())
 
-    /// The error message used when a write occurs to a record for which the current user
-    /// does not have permission.
+    /// The error message used when a write occurs to a record for which the current user does not
+    /// have permission.
     ///
     /// This error is thrown from any database write to a row for which the current user does
     /// not have permissions to write, as determined by its `CKShare` (if applicable). To catch
@@ -66,16 +66,17 @@
     /// - Parameters:
     ///   - database: The database to synchronize to CloudKit.
     ///   - tables: A list of tables that you want to synchronize _and_ that you want to be
-    ///   shareable with other users on CloudKit.
+    ///     shareable with other users on CloudKit.
     ///   - privateTables: A list of tables that you want to synchronize to CloudKit but that
-    ///   you do not want to be shareable with other users.
+    ///     you do not want to be shareable with other users.
     ///   - containerIdentifier: The container identifier in CloudKit to synchronize to. If omitted
-    ///   the container will be determined from the entitlements of your app.
+    ///     the container will be determined from the entitlements of your app.
     ///   - defaultZone: The zone for all records to be stored in.
     ///   - startImmediately: Determines if the sync engine starts right away or requires an
-    ///   explicit call to ``start()``. By default this argument is `true`.
+    ///     explicit call to ``start()``. By default this argument is `true`.
+    ///   - delegate: A delegate object that can override default sync engine behavior.
     ///   - logger: The logger used to log events in the sync engine. By default a `.disabled`
-    ///   logger is used, which means logs are not printed.
+    ///     logger is used, which means logs are not printed.
     public convenience init<
       each T1: PrimaryKeyedTable & _SendableMetatype,
       each T2: PrimaryKeyedTable & _SendableMetatype
@@ -626,7 +627,15 @@
       try migrate(metadatabase: metadatabase)
     }
 
-    // TODO: docs
+    // Deletes synchronized data locally on device and restarts the sync engine.
+    //
+    // This method is called automatically by the sync engine when it detects the device's iCloud
+    // account has logged out or changed. To customize this behavior, provide a
+    // ``SyncEngineDelegate`` to the sync engine and implement
+    // ``SyncEngineDelegate/syncEngine(_:accountChanged:)``.
+    //
+    // > Important: It is only appropriate to call this method when the device's iCloud account
+    // > logs out or changes.
     public func deleteLocalData() async throws {
       stop()
       try tearDownSyncEngine()

--- a/Sources/SQLiteData/CloudKit/SyncEngineDelegate.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngineDelegate.swift
@@ -86,8 +86,15 @@
       _ syncEngine: SyncEngine,
       accountChanged changeType: CKSyncEngine.Event.AccountChange.ChangeType
     ) async {
-      await withErrorReporting {
-        try await syncEngine.deleteLocalData()
+      switch changeType {
+      case .signOut, .switchAccounts:
+        await withErrorReporting {
+          try await syncEngine.deleteLocalData()
+        }
+      case .signIn:
+        break
+      @unknown default:
+        break
       }
     }
   }

--- a/Sources/SQLiteData/CloudKit/SyncEngineDelegate.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngineDelegate.swift
@@ -2,9 +2,19 @@
   import CloudKit
   import CustomDump
 
-  // TODO: docs
+  /// An interface for customizing ``SyncEngine`` behavior.
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   public protocol SyncEngineDelegate: AnyObject, Sendable {
+    /// An event indicating a change to the device's iCloud account.
+    ///
+    /// By default, a sync engine will clear out local data when detecting a logout or account
+    /// change. To override this behavior, _e.g._ if you want to prompt the user and let them decide
+    /// if they want to clear their local data or not, implement this method, and explicitly call
+    /// ``SyncEngine/deleteLocalData()`` if/when the data should be cleared.
+    ///
+    /// - Parameters:
+    ///   - syncEngine: The sync engine that generates the event.
+    ///   - changeType: The iCloud account's change type.
     func syncEngine(
       _ syncEngine: SyncEngine,
       accountChanged changeType: CKSyncEngine.Event.AccountChange.ChangeType

--- a/Sources/SQLiteData/CloudKit/SyncEngineDelegate.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngineDelegate.swift
@@ -12,6 +12,65 @@
     /// if they want to clear their local data or not, implement this method, and explicitly call
     /// ``SyncEngine/deleteLocalData()`` if/when the data should be cleared.
     ///
+    /// For example, an observable model could override this method to set up some alert state:
+    ///
+    /// ```swift
+    /// @MainActor
+    /// @Observable
+    /// class MySyncEngineDelegate: SyncEngineDelegate {
+    ///   var isResetDataAlertPresented = false
+    ///
+    ///   func syncEngine(
+    ///     _ syncEngine: SyncEngine,
+    ///     accountChanged changeType: CKSyncEngine.Event.AccountChange.ChangeType
+    ///   ) {
+    ///     switch changeType {
+    ///     case .signOut, .switchAccounts:
+    ///       isResetDataAlertPresented = true
+    ///     case .signIn:
+    ///       break
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// And then SwiftUI could drive an alert with this state:
+    ///
+    /// ```swift
+    /// struct MyApp: App {
+    ///   @State var syncEngineDelegate = MySyncEngineDelegate()
+    ///
+    ///   init() {
+    ///     prepareDependencies {
+    ///       try! $0.bootstrapDatabase(syncEngineDelegate: syncEngineDelegate)
+    ///     }
+    ///   }
+    ///
+    ///   var body: some Scene {
+    ///     WindowGroup {
+    ///       MyRootView()
+    ///         .alert(
+    ///           "Reset local data?",
+    ///           isPresented: $syncEngineDelegate.isDeleteLocalDataAlertPresented
+    ///         ) {
+    ///           Button("Reset", role: .destructive) {
+    ///             Task {
+    ///               try await syncEngine.deleteLocalData()
+    ///             }
+    ///           }
+    ///         } message: {
+    ///           Text(
+    ///             """
+    ///             You are no longer logged into iCloud. Would you like to reset your local data \
+    ///             to the defaults? This will not affect your data in iCloud.
+    ///             """
+    ///           )
+    ///         }
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    ///
     /// - Parameters:
     ///   - syncEngine: The sync engine that generates the event.
     ///   - changeType: The iCloud account's change type.

--- a/Sources/SQLiteData/CloudKit/SyncEngineDelegate.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngineDelegate.swift
@@ -2,7 +2,7 @@
   import CloudKit
   import CustomDump
 
-  /// An interface for customizing ``SyncEngine`` behavior.
+  /// An interface for observing ``SyncEngine`` events and customizing ``SyncEngine`` behavior.
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   public protocol SyncEngineDelegate: AnyObject, Sendable {
     /// An event indicating a change to the device's iCloud account.

--- a/Sources/SQLiteData/CloudKit/SyncEngineDelegate.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngineDelegate.swift
@@ -1,0 +1,25 @@
+#if canImport(CloudKit)
+  import CloudKit
+  import CustomDump
+
+  // TODO: docs
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  public protocol SyncEngineDelegate: AnyObject, Sendable {
+    func syncEngine(
+      _ syncEngine: SyncEngine,
+      accountChanged changeType: CKSyncEngine.Event.AccountChange.ChangeType
+    ) async
+  }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension SyncEngineDelegate {
+    public func syncEngine(
+      _ syncEngine: SyncEngine,
+      accountChanged changeType: CKSyncEngine.Event.AccountChange.ChangeType
+    ) async {
+      await withErrorReporting {
+        try await syncEngine.deleteLocalData()
+      }
+    }
+  }
+#endif

--- a/Sources/SQLiteData/Documentation.docc/Articles/CloudKit.md
+++ b/Sources/SQLiteData/Documentation.docc/Articles/CloudKit.md
@@ -670,7 +670,7 @@ struct MySuite {
 }
 ```
 
-And in preivews you can use it like so:
+And in previews you can use it like so:
 
 ```swift
 #Preview {
@@ -680,6 +680,24 @@ And in preivews you can use it like so:
   // ...
 }
 ```
+
+> Tip: If you configure your ``SyncEngine`` with a ``SyncEngineDelegate``, you can pass it to the
+> bootstrap function for configuration:
+>
+> ```diff
+>  extension DependencyValues {
+>    mutating func bootstrapDatabase(
+> +    syncEngineDelegate: (any SyncEngineDelegate)? = nil
+>    ) throws {
+>      defaultDatabase = try Reminders.appDatabase()
+>      defaultSyncEngine = try SyncEngine(
+>        for: defaultDatabase,
+>        tables: // ...
+> +      delegate: syncEngineDelegate
+>      )
+>    }
+>  }
+> ```
 
 ## Preparing an existing schema for synchronization
 

--- a/Sources/SQLiteData/Documentation.docc/Articles/CloudKit.md
+++ b/Sources/SQLiteData/Documentation.docc/Articles/CloudKit.md
@@ -87,7 +87,7 @@ struct MyApp: App {
 ```
 
 The `SyncEngine`
-[initializer](<doc:SyncEngine/init(for:tables:privateTables:containerIdentifier:defaultZone:startImmediately:logger:)>)
+[initializer](<doc:SyncEngine/init(for:tables:privateTables:containerIdentifier:defaultZone:startImmediately:delegate:logger:)>)
 has more options you may be interested in configuring.
 
 > Important: You must explicitly provide all tables that you want to synchronize. We do this so that
@@ -483,7 +483,7 @@ See <doc:CloudKitSharing> for more information.
 
 ## Assets
 
-> TL;DR: The library packages all BLOB columns in a table into `CKAsset`s and seamlessly decodes
+> TL;DR: The library packages all `BLOB` columns in a table into `CKAsset`s and seamlessly decodes
 > `CKAsset`s back into your tables. We recommend putting large binary blobs of data in their own
 > tables.
 

--- a/Sources/SQLiteData/Documentation.docc/Extensions/IdentifierStringConvertible.md
+++ b/Sources/SQLiteData/Documentation.docc/Extensions/IdentifierStringConvertible.md
@@ -4,26 +4,7 @@
 
 ### Conformances
 
-- ``Swift/Bool``
-- ``Swift/Character``
-- ``Swift/Double``
-- ``Swift/Float``
-- ``Swift/Float16``
-- ``Swift/Int``
-- ``Swift/Int128``
-- ``Swift/Int16``
-- ``Swift/Int32``
-- ``Swift/Int64``
-- ``Swift/Int8``
 - ``Swift/String``
 - ``Swift/Substring``
-- ``Swift/UInt``
-- ``Swift/UInt128``
-- ``Swift/UInt16``
-- ``Swift/UInt32``
-- ``Swift/UInt64``
-- ``Swift/UInt8``
-- ``Swift/Optional``
-- ``Swift/Unicode/Scalar``
 - ``Foundation/UUID``
 - ``Tagged/Tagged``

--- a/Sources/SQLiteData/Documentation.docc/SQLiteData.md
+++ b/Sources/SQLiteData/Documentation.docc/SQLiteData.md
@@ -313,6 +313,7 @@ with SQLite to take full advantage of GRDB and SQLiteData.
 - <doc:CloudKit>
 - <doc:CloudKitSharing>
 - ``SyncEngine``
+- ``SyncEngineDelegate``
 - ``Dependencies/DependencyValues/defaultSyncEngine``
 - ``IdentifierStringConvertible``
 - ``SyncMetadata``

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineDelegateTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineDelegateTests.swift
@@ -171,7 +171,7 @@
         try await syncEngine.processPendingDatabaseChanges(scope: .private)
       }
 
-      @Test(.syncEngineDelegate(NoopDelegate()))
+      @Test(.syncEngineDelegate(DefaultImplementationDelegate()))
       func accountChanged_DefaultImplementation() async throws {
         try await userDatabase.userWrite { db in
           try db.seed {
@@ -230,16 +230,12 @@
     deinit {
       guard wasCalled.withValue(\.self)
       else {
-        reportIssue(
-          """
-          TODO
-          """
-        )
+        Issue.record("Delegate method 'syncEngine(_:accountChanged:)' was not called.")
         return
       }
     }
   }
 
-  final class NoopDelegate: SyncEngineDelegate {
+  final class DefaultImplementationDelegate: SyncEngineDelegate {
   }
 #endif

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineDelegateTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineDelegateTests.swift
@@ -1,0 +1,245 @@
+#if canImport(CloudKit)
+  import CloudKit
+  import CustomDump
+  import DependenciesTestSupport
+  import Foundation
+  import InlineSnapshotTesting
+  import SQLiteData
+  import SQLiteDataTestSupport
+  import SnapshotTestingCustomDump
+  import Testing
+
+  extension BaseCloudKitTests {
+    @MainActor
+    final class SyncEngineDelegateTests: BaseCloudKitTests, @unchecked Sendable {
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+
+      @Test(.syncEngineDelegate(MyDelegate()))
+      func accountChanged() async throws {
+        try await userDatabase.userWrite { db in
+          try db.seed {
+            RemindersList(id: 1, title: "Personal")
+          }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        await signOut()
+
+        assertQuery(RemindersList.all, database: userDatabase.database) {
+          """
+          ┌─────────────────────┐
+          │ RemindersList(      │
+          │   id: 1,            │
+          │   title: "Personal" │
+          │ )                   │
+          └─────────────────────┘
+          """
+        }
+        assertQuery(SyncMetadata.all, database: syncEngine.metadatabase) {
+          """
+          ┌────────────────────────────────────────────────────────────────────┐
+          │ SyncMetadata(                                                      │
+          │   recordPrimaryKey: "1",                                           │
+          │   recordType: "remindersLists",                                    │
+          │   zoneName: "zone",                                                │
+          │   ownerName: "__defaultOwner__",                                   │
+          │   recordName: "1:remindersLists",                                  │
+          │   parentRecordPrimaryKey: nil,                                     │
+          │   parentRecordType: nil,                                           │
+          │   parentRecordName: nil,                                           │
+          │   lastKnownServerRecord: CKRecord(                                 │
+          │     recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__), │
+          │     recordType: "remindersLists",                                  │
+          │     parent: nil,                                                   │
+          │     share: nil                                                     │
+          │   ),                                                               │
+          │   _lastKnownServerRecordAllFields: CKRecord(                       │
+          │     recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__), │
+          │     recordType: "remindersLists",                                  │
+          │     parent: nil,                                                   │
+          │     share: nil,                                                    │
+          │     id: 1,                                                         │
+          │     title: "Personal"                                              │
+          │   ),                                                               │
+          │   share: nil,                                                      │
+          │   _isDeleted: false,                                               │
+          │   hasLastKnownServerRecord: true,                                  │
+          │   isShared: false,                                                 │
+          │   userModificationTime: 0                                          │
+          │ )                                                                  │
+          └────────────────────────────────────────────────────────────────────┘
+          """
+        }
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  title: "Personal"
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+
+        try await userDatabase.userWrite { db in
+          try RemindersList.find(1).update { $0.title = "My stuff" }.execute(db)
+        }
+
+        assertQuery(RemindersList.all, database: userDatabase.database) {
+          """
+          ┌─────────────────────┐
+          │ RemindersList(      │
+          │   id: 1,            │
+          │   title: "My stuff" │
+          │ )                   │
+          └─────────────────────┘
+          """
+        }
+        assertQuery(SyncMetadata.all, database: syncEngine.metadatabase) {
+          """
+          ┌────────────────────────────────────────────────────────────────────┐
+          │ SyncMetadata(                                                      │
+          │   recordPrimaryKey: "1",                                           │
+          │   recordType: "remindersLists",                                    │
+          │   zoneName: "zone",                                                │
+          │   ownerName: "__defaultOwner__",                                   │
+          │   recordName: "1:remindersLists",                                  │
+          │   parentRecordPrimaryKey: nil,                                     │
+          │   parentRecordType: nil,                                           │
+          │   parentRecordName: nil,                                           │
+          │   lastKnownServerRecord: CKRecord(                                 │
+          │     recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__), │
+          │     recordType: "remindersLists",                                  │
+          │     parent: nil,                                                   │
+          │     share: nil                                                     │
+          │   ),                                                               │
+          │   _lastKnownServerRecordAllFields: CKRecord(                       │
+          │     recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__), │
+          │     recordType: "remindersLists",                                  │
+          │     parent: nil,                                                   │
+          │     share: nil,                                                    │
+          │     id: 1,                                                         │
+          │     title: "Personal"                                              │
+          │   ),                                                               │
+          │   share: nil,                                                      │
+          │   _isDeleted: false,                                               │
+          │   hasLastKnownServerRecord: true,                                  │
+          │   isShared: false,                                                 │
+          │   userModificationTime: 0                                          │
+          │ )                                                                  │
+          └────────────────────────────────────────────────────────────────────┘
+          """
+        }
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  title: "Personal"
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+
+        await signIn()
+        try await syncEngine.processPendingDatabaseChanges(scope: .private)
+      }
+
+      @Test(.syncEngineDelegate(NoopDelegate()))
+      func accountChanged_DefaultImplementation() async throws {
+        try await userDatabase.userWrite { db in
+          try db.seed {
+            RemindersList(id: 1, title: "Personal")
+          }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        await signOut()
+
+        assertQuery(RemindersList.all, database: userDatabase.database) {
+          """
+          (No results)
+          """
+        }
+        assertQuery(SyncMetadata.all, database: syncEngine.metadatabase) {
+          """
+          (No results)
+          """
+        }
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  title: "Personal"
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+    }
+  }
+
+  final class MyDelegate: SyncEngineDelegate {
+    let wasCalled = LockIsolated(false)
+    func syncEngine(
+      _ syncEngine: SQLiteData.SyncEngine,
+      accountChanged changeType: CKSyncEngine.Event.AccountChange.ChangeType
+    ) async {
+      wasCalled.withValue { $0 = true }
+    }
+    deinit {
+      guard wasCalled.withValue(\.self)
+      else {
+        reportIssue(
+          """
+          TODO
+          """
+        )
+        return
+      }
+    }
+  }
+
+  final class NoopDelegate: SyncEngineDelegate {
+  }
+#endif

--- a/Tests/SQLiteDataTests/Internal/BaseCloudKitTests.swift
+++ b/Tests/SQLiteDataTests/Internal/BaseCloudKitTests.swift
@@ -55,6 +55,7 @@ class BaseCloudKitTests: @unchecked Sendable {
     _syncEngine = try await SyncEngine(
       container: container,
       userDatabase: self.userDatabase,
+      delegate: _SyncEngineDelegateTrait.syncEngineDelegate,
       tables: Reminder.self,
       RemindersList.self,
       RemindersListAsset.self,
@@ -158,6 +159,7 @@ extension SyncEngine {
   >(
     container: any CloudContainer,
     userDatabase: UserDatabase,
+    delegate: (any SyncEngineDelegate)? = nil,
     tables: repeat (each T1).Type,
     privateTables: repeat (each T2).Type,
     startImmediately: Bool = true
@@ -179,6 +181,7 @@ extension SyncEngine {
     try await self.init(
       container: container,
       userDatabase: userDatabase,
+      delegate: delegate,
       tables: allTables,
       privateTables: allPrivateTables,
       startImmediately: startImmediately
@@ -187,6 +190,7 @@ extension SyncEngine {
   convenience init(
     container: any CloudContainer,
     userDatabase: UserDatabase,
+    delegate: (any SyncEngineDelegate)? = nil,
     tables: [any SynchronizableTable],
     privateTables: [any SynchronizableTable] = [],
     startImmediately: Bool = true
@@ -210,6 +214,7 @@ extension SyncEngine {
       },
       userDatabase: userDatabase,
       logger: Logger(.disabled),
+      delegate: delegate,
       tables: tables,
       privateTables: privateTables
     )

--- a/Tests/SQLiteDataTests/Internal/TestScopes.swift
+++ b/Tests/SQLiteDataTests/Internal/TestScopes.swift
@@ -101,4 +101,29 @@
       Self(accountStatus)
     }
   }
+
+  struct _SyncEngineDelegateTrait: SuiteTrait, TestScoping, TestTrait {
+    @TaskLocal static var syncEngineDelegate: (any SyncEngineDelegate)?
+    let syncEngineDelegate: (any SyncEngineDelegate)?
+    init(syncEngineDelegate: (any SyncEngineDelegate)?) {
+      self.syncEngineDelegate = syncEngineDelegate
+    }
+    func provideScope(
+      for test: Test,
+      testCase: Test.Case?,
+      performing function: () async throws -> Void
+    ) async throws {
+      try await Self.$syncEngineDelegate.withValue(syncEngineDelegate) {
+        try await function()
+      }
+    }
+  }
+
+  extension Trait where Self == _SyncEngineDelegateTrait {
+    static func syncEngineDelegate(
+      _ syncEngineDelegate: (any SyncEngineDelegate)?
+    ) -> Self {
+      Self(syncEngineDelegate: syncEngineDelegate)
+    }
+  }
 #endif


### PR DESCRIPTION
Right now when the `SyncEngine` detects an iCloud account has signed out, it deletes all local data. The assumption is that the data belongs to the iCloud account, and since it is no longer logged in the app shouldn't have that data anymore.

However, as brought up in [this discussion](https://github.com/pointfreeco/sqlite-data/discussions/218#discussioncomment-14502829), this isn't always appropriate. Many of Apple's first party apps specifically ask the user whether or not they want the local data to be cleared out when it detects the iCloud account has signed out. So, we are opening up this possibility with a new `SyncEngineDelegate` that can be used to be notified when the iCloud account has signed out, and you can choose what should be done with the local data. You can clear the local data (the default behavior), or not clear the local data, or you can ask the user what they want to do.