### PR TITLE
Support `attachMetadatabase` in previews

### DIFF
--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "72bc7483118f950b5981c86ad1ea986d789ceef2694a317cea1b9dfff3119f82",
+  "originHash" : "41e7781e6c506773b6af84af513bcd6d3b1be59d635e6c4c4bd89638368e4629",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "edb84b339542b018477bab1d8e4cca851d5fa93c",
-        "version" : "0.23.0"
+        "revision" : "3a95b70a81b7027b8a5117e7dd08188837e5f54e",
+        "version" : "0.24.0"
       }
     },
     {

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -252,7 +252,6 @@
       self.userDatabase = userDatabase
       self.logger = logger
       self.metadatabase = try defaultMetadatabase(
-        database: userDatabase.database,
         logger: logger,
         url: try URL.metadatabase(
           databasePath: userDatabase.path,
@@ -1918,7 +1917,7 @@
       databasePath: String,
       containerIdentifier: String?
     ) throws -> URL {
-      guard let databaseURL = URL(string: databasePath.isEmpty ? ":memory:" : databasePath)
+      guard let databaseURL = URL(string: databasePath)
       else {
         struct InvalidDatabasePath: Error {}
         throw InvalidDatabasePath()
@@ -2001,8 +2000,6 @@
     /// - Parameter containerIdentifier: The identifier of the CloudKit container used to
     /// synchronize data. Defaults to the value set in the app's entitlements.
     public func attachMetadatabase(containerIdentifier: String? = nil) throws {
-      @Dependency(\.context) var context
-      guard context != .preview else { return }
       let containerIdentifier =
         containerIdentifier
         ?? ModelConfiguration(groupContainer: .automatic).cloudKitContainerIdentifier

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -311,17 +311,16 @@
         .select(\.file)
         .fetchOne(db)
       if let attachedMetadatabasePath {
-        let metadatabaseName = metadatabase.path.isEmpty ?
-        try URL.metadatabase(
-          databasePath: "",
-          containerIdentifier: self.container.containerIdentifier
-        )
-        .lastPathComponent
-        :
-        URL(
-          filePath: metadatabase.path
-        ).lastPathComponent
-        let attachedMetadatabaseName = URL(string: attachedMetadatabasePath)?.lastPathComponent ?? ""
+        let metadatabaseName =
+          metadatabase.path.isEmpty
+          ? try URL.metadatabase(
+            databasePath: "",
+            containerIdentifier: self.container.containerIdentifier
+          )
+          .lastPathComponent
+          : URL(filePath: metadatabase.path).lastPathComponent
+        let attachedMetadatabaseName =
+          URL(string: attachedMetadatabasePath)?.lastPathComponent ?? ""
 
         try URL.metadatabase(
           databasePath: attachedMetadatabasePath,
@@ -1943,7 +1942,9 @@
         return URL(string: "file:\(String.sqliteDataCloudKitSchemaName)?mode=memory&cache=shared")!
       }
       return
-        databaseURL.deletingLastPathComponent().appending(component: ".\(databaseURL.deletingPathExtension().lastPathComponent)")
+        databaseURL.deletingLastPathComponent().appending(
+          component: ".\(databaseURL.deletingPathExtension().lastPathComponent)"
+        )
         .appendingPathExtension("metadata\(containerIdentifier.map { "-\($0)" } ?? "").sqlite")
     }
 

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -311,8 +311,19 @@
         .select(\.file)
         .fetchOne(db)
       if let attachedMetadatabasePath {
-        let metadatabaseName = URL(string: metadatabase.path)?.lastPathComponent ?? ""
-        let attachedMetadatabaseName = try URL.metadatabase(
+        let metadatabaseName = metadatabase.path.isEmpty ?
+        try URL.metadatabase(
+          databasePath: "",
+          containerIdentifier: self.container.containerIdentifier
+        )
+        .lastPathComponent
+        :
+        URL(
+          filePath: metadatabase.path
+        ).lastPathComponent
+        let attachedMetadatabaseName = URL(string: attachedMetadatabasePath)?.lastPathComponent ?? ""
+
+        try URL.metadatabase(
           databasePath: attachedMetadatabasePath,
           containerIdentifier: self.container.containerIdentifier
         )
@@ -1932,9 +1943,7 @@
         return URL(string: "file:\(String.sqliteDataCloudKitSchemaName)?mode=memory&cache=shared")!
       }
       return
-        databaseURL
-        .deletingLastPathComponent()
-        .appending(component: ".\(databaseURL.deletingPathExtension().lastPathComponent)")
+        databaseURL.deletingLastPathComponent().appending(component: ".\(databaseURL.deletingPathExtension().lastPathComponent)")
         .appendingPathExtension("metadata\(containerIdentifier.map { "-\($0)" } ?? "").sqlite")
     }
 

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -252,6 +252,7 @@
       self.userDatabase = userDatabase
       self.logger = logger
       self.metadatabase = try defaultMetadatabase(
+        database: userDatabase.database,
         logger: logger,
         url: try URL.metadatabase(
           databasePath: userDatabase.path,
@@ -1917,7 +1918,7 @@
       databasePath: String,
       containerIdentifier: String?
     ) throws -> URL {
-      guard let databaseURL = URL(string: databasePath)
+      guard let databaseURL = URL(string: databasePath.isEmpty ? ":memory:" : databasePath)
       else {
         struct InvalidDatabasePath: Error {}
         throw InvalidDatabasePath()
@@ -2000,6 +2001,8 @@
     /// - Parameter containerIdentifier: The identifier of the CloudKit container used to
     /// synchronize data. Defaults to the value set in the app's entitlements.
     public func attachMetadatabase(containerIdentifier: String? = nil) throws {
+      @Dependency(\.context) var context
+      guard context != .preview else { return }
       let containerIdentifier =
         containerIdentifier
         ?? ModelConfiguration(groupContainer: .automatic).cloudKitContainerIdentifier

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -312,13 +312,11 @@
         .fetchOne(db)
       if let attachedMetadatabasePath {
         let metadatabaseName = URL(string: metadatabase.path)?.lastPathComponent ?? ""
-
-        let attachedMetadatabaseURL = try URL.metadatabase(
+        let attachedMetadatabaseName = try URL.metadatabase(
           databasePath: attachedMetadatabasePath,
           containerIdentifier: self.container.containerIdentifier
         )
-        let attachedMetadatabaseName = attachedMetadatabaseURL.lastPathComponent
-
+        .lastPathComponent
         if metadatabaseName != attachedMetadatabaseName {
           throw SchemaError(
             reason: .metadatabaseMismatch(


### PR DESCRIPTION
Previews can currently crash if an app database is provisioned that attaches a metadatabase due to the improper way we were handling database URLs.