### PR TITLE
Use metadatabase to query sync metadata.

### DIFF
--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -1670,7 +1670,7 @@
     }
 
     func deleteShare(shareRecordID: CKRecord.ID) async throws {
-      let shareAndRecordNameAndZone = try await userDatabase.read { db in
+      let shareAndRecordNameAndZone = try await metadatabase.read { db in
         try SyncMetadata
           .where(\.isShared)
           .select { ($0.share, $0.recordName, $0.zoneName, $0.ownerName) }

--- a/Tests/SQLiteDataTests/CloudKitTests/AttachedMetadatabaseTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/AttachedMetadatabaseTests.swift
@@ -1,0 +1,69 @@
+#if canImport(CloudKit)
+  import CloudKit
+  import ConcurrencyExtras
+  import CustomDump
+  import InlineSnapshotTesting
+  import OrderedCollections
+  import SQLiteData
+  import SQLiteDataTestSupport
+  import SnapshotTestingCustomDump
+  import Testing
+
+  extension BaseCloudKitTests {
+    @MainActor
+    @Suite(.attachMetadatabase(true))
+    final class AttachedMetadatabaseTests: BaseCloudKitTests, @unchecked Sendable {
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func basics() async throws {
+        let remindersList = RemindersList(id: 1, title: "Personal")
+        try await userDatabase.userWrite { db in
+          try db.seed {
+            remindersList
+          }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        assertQuery(
+          RemindersList
+            .leftJoin(SyncMetadata.all) { $0.syncMetadataID.eq($1.id) },
+          database: userDatabase.database
+        ) {
+          """
+          ┌─────────────────────┬────────────────────────────────────────────────────────────────────┐
+          │ RemindersList(      │ SyncMetadata(                                                      │
+          │   id: 1,            │   id: SyncMetadata.ID(                                             │
+          │   title: "Personal" │     recordPrimaryKey: "1",                                         │
+          │ )                   │     recordType: "remindersLists"                                   │
+          │                     │   ),                                                               │
+          │                     │   zoneName: "zone",                                                │
+          │                     │   ownerName: "__defaultOwner__",                                   │
+          │                     │   recordName: "1:remindersLists",                                  │
+          │                     │   parentRecordID: nil,                                             │
+          │                     │   parentRecordName: nil,                                           │
+          │                     │   lastKnownServerRecord: CKRecord(                                 │
+          │                     │     recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__), │
+          │                     │     recordType: "remindersLists",                                  │
+          │                     │     parent: nil,                                                   │
+          │                     │     share: nil                                                     │
+          │                     │   ),                                                               │
+          │                     │   _lastKnownServerRecordAllFields: CKRecord(                       │
+          │                     │     recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__), │
+          │                     │     recordType: "remindersLists",                                  │
+          │                     │     parent: nil,                                                   │
+          │                     │     share: nil,                                                    │
+          │                     │     id: 1,                                                         │
+          │                     │     title: "Personal"                                              │
+          │                     │   ),                                                               │
+          │                     │   share: nil,                                                      │
+          │                     │   _isDeleted: false,                                               │
+          │                     │   hasLastKnownServerRecord: true,                                  │
+          │                     │   isShared: false,                                                 │
+          │                     │   userModificationTime: 0                                          │
+          │                     │ )                                                                  │
+          └─────────────────────┴────────────────────────────────────────────────────────────────────┘
+          """
+        }
+      }
+    }
+  }
+#endif

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -11,6 +11,7 @@
 
   extension BaseCloudKitTests {
     @MainActor
+    @Suite(.attachMetadatabase(false))
     final class SharingTests: BaseCloudKitTests, @unchecked Sendable {
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func shareNonRootRecord() async throws {
@@ -2687,6 +2688,52 @@
                   title: "Blob"
                 )
               ]
+            )
+          )
+          """
+        }
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func deleteShare() async throws {
+        let remindersList = RemindersList(id: 1, title: "Personal")
+        try await userDatabase.userWrite { db in
+          try db.seed {
+            remindersList
+          }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        let sharedRecord = try await syncEngine.share(record: remindersList, configure: { _ in })
+
+        try await syncEngine
+          .modifyRecords(scope: .private, deleting: [sharedRecord.share.recordID])
+          .notify()
+
+        assertQuery(SyncMetadata.select(\.share), database: syncEngine.metadatabase) {
+          """
+          ┌─────┐
+          │ nil │
+          └─────┘
+          """
+        }
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__))
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
             )
           )
           """

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -11,7 +11,6 @@
 
   extension BaseCloudKitTests {
     @MainActor
-    @Suite(.attachMetadatabase(false))
     final class SharingTests: BaseCloudKitTests, @unchecked Sendable {
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func shareNonRootRecord() async throws {

--- a/Tests/SQLiteDataTests/Internal/BaseCloudKitTests.swift
+++ b/Tests/SQLiteDataTests/Internal/BaseCloudKitTests.swift
@@ -11,7 +11,8 @@ import os
   .dependencies {
     $0.currentTime.now = 0
     $0.dataManager = InMemoryDataManager()
-  }
+  },
+  .attachMetadatabase(false)
 )
 class BaseCloudKitTests: @unchecked Sendable {
   let userDatabase: UserDatabase


### PR DESCRIPTION
All reads/writes to the metadatabase should happen through the dedicated metadatabase connection because the user's connection may not have the metadatabase attached. This can be tricky to get right, and we seem to have a spot where we forgot to use the metadatabase directly.

- [ ] Add a test that deletes shares when the metadatabase is not attached.