### PR TITLE
Fix bug that reset timestamp of record when sharing.

### DIFF
--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -125,7 +125,7 @@
             .select { ($0.recordType, $0.recordName, $0.lastKnownServerRecord) }
             .fetchOne(db)
         } ?? nil
-      guard let (recordType, recordName, lastKnownServerRecord) = metadata
+      guard let (_, recordName, lastKnownServerRecord) = metadata
       else {
         throw SharingError(
           recordTableName: T.tableName,

--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -118,16 +118,14 @@
         )
       }
       let recordName = record.recordName
-      let metadata =
+      let lastKnownServerRecord =
         try await metadatabase.read { db in
           try SyncMetadata
             .where { $0.recordName.eq(recordName) }
-            .select { ($0.recordName, $0._lastKnownServerRecordAllFields) }
+            .select(\._lastKnownServerRecordAllFields)
             .fetchOne(db)
         } ?? nil
-      guard
-        let (recordName, lastKnownServerRecord) = metadata,
-        let lastKnownServerRecord
+      guard let lastKnownServerRecord
       else {
         throw SharingError(
           recordTableName: T.tableName,

--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -137,12 +137,11 @@
         )
       }
 
-      let rootRecord =
-        lastKnownServerRecord
-        ?? CKRecord(
-          recordType: recordType,
-          recordID: CKRecord.ID(recordName: recordName, zoneID: defaultZone.zoneID)
-        )
+      let rootRecordID =
+      lastKnownServerRecord?.recordID
+      ?? CKRecord.ID(recordName: recordName, zoneID: defaultZone.zoneID)
+      let cloudKitDatabase = container.database(for: rootRecordID)
+      let rootRecord = try await cloudKitDatabase.record(for: rootRecordID)
 
       var existingShare: CKShare? {
         get async throws {
@@ -157,8 +156,7 @@
             return nil
           }
           do {
-            return try await container.database(for: rootRecord.recordID)
-              .record(for: shareRecordID) as? CKShare
+            return try await cloudKitDatabase.record(for: shareRecordID) as? CKShare
           } catch let error as CKError where error.code == .unknownItem {
             return nil
           }

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -321,12 +321,6 @@
           : URL(filePath: metadatabase.path).lastPathComponent
         let attachedMetadatabaseName =
           URL(string: attachedMetadatabasePath)?.lastPathComponent ?? ""
-
-        try URL.metadatabase(
-          databasePath: attachedMetadatabasePath,
-          containerIdentifier: self.container.containerIdentifier
-        )
-        .lastPathComponent
         if metadatabaseName != attachedMetadatabaseName {
           throw SchemaError(
             reason: .metadatabaseMismatch(

--- a/Tests/SQLiteDataTests/CloudKitTests/MetadataTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MetadataTests.swift
@@ -551,7 +551,7 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         assertQuery(
-          RemindersList.join(SyncMetadata.all) { $0.hasMetadata(in: $1) },
+          RemindersList.join(SyncMetadata.all) { $0.syncMetadataID.eq($1.id) },
           database: userDatabase.database
         ) {
           """

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -612,16 +612,19 @@
 
         let _ = try await syncEngine.share(record: remindersList, configure: { _ in })
 
-        assertQuery(SyncMetadata.select(\.share), database: syncEngine.metadatabase) {
+        assertQuery(
+          SyncMetadata.select { ($0.share, $0.userModificationTime) },
+          database: syncEngine.metadatabase
+        ) {
           """
-          ┌────────────────────────────────────────────────────────────────────────┐
-          │ CKRecord(                                                              │
-          │   recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__), │
-          │   recordType: "cloudkit.share",                                        │
-          │   parent: nil,                                                         │
-          │   share: nil                                                           │
-          │ )                                                                      │
-          └────────────────────────────────────────────────────────────────────────┘
+          ┌────────────────────────────────────────────────────────────────────────┬───┐
+          │ CKRecord(                                                              │ 0 │
+          │   recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__), │   │
+          │   recordType: "cloudkit.share",                                        │   │
+          │   parent: nil,                                                         │   │
+          │   share: nil                                                           │   │
+          │ )                                                                      │   │
+          └────────────────────────────────────────────────────────────────────────┴───┘
           """
         }
 

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -641,7 +641,9 @@
                   recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                   recordType: "remindersLists",
                   parent: nil,
-                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__))
+                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__)),
+                  id: 1,
+                  title: "Personal"
                 )
               ]
             ),
@@ -700,7 +702,9 @@
                   recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                   recordType: "remindersLists",
                   parent: nil,
-                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__))
+                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__)),
+                  id: 1,
+                  title: "Personal"
                 )
               ]
             ),
@@ -763,7 +767,9 @@
                   recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                   recordType: "remindersLists",
                   parent: nil,
-                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__))
+                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__)),
+                  id: 1,
+                  title: "Personal"
                 )
               ]
             ),
@@ -793,7 +799,9 @@
                   recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                   recordType: "remindersLists",
                   parent: nil,
-                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__))
+                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__)),
+                  id: 1,
+                  title: "Personal"
                 )
               ]
             ),
@@ -2787,7 +2795,9 @@
                   recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                   recordType: "remindersLists",
                   parent: nil,
-                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__))
+                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__)),
+                  id: 1,
+                  title: "Personal"
                 )
               ]
             ),

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineLifecycleTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineLifecycleTests.swift
@@ -452,7 +452,9 @@
                     recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                     recordType: "remindersLists",
                     parent: nil,
-                    share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__))
+                    share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__)),
+                    id: 1,
+                    title: "Personal"
                   )
                 ]
               ),


### PR DESCRIPTION
Right now we accidentally reset the `userModificationTime` on a record's metadata when it is shared because the `share(record:)` method is only dealing with a system fields `CKRecord`. So let's go ahead and fetch the full record when sharing so that we have the most recent timestamps.