### PR TITLE
Add SWCollaborationView wrapper

### DIFF
--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -273,11 +273,11 @@
 
   #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
 
-  @available(iOS 17, tvOS 17, *)
   /// A view that presents standard screens for the collaboration content and options.
   ///
   /// See <doc:CloudKitSharing#Creating-CKShare-records> for more info.
-  public struct CloudCollaborationView: UIViewRepresentable {
+  @available(iOS 17, tvOS 17, *)
+  public struct CloudCollaborationView: View {
     let sharedRecord: SharedRecord
     let allowedSharingOptions: CKAllowedSharingOptions
     let didFinish: (Result<Void, Error>) -> Void
@@ -300,7 +300,29 @@
       self.syncEngine = syncEngine
     }
 
-    public func makeCoordinator() -> _CloudCollaborationDelegate {
+    public var body: some View {
+      _CloudCollaborationView(
+        sharedRecord: sharedRecord,
+        allowedSharingOptions: allowedSharingOptions,
+        didFinish: didFinish,
+        didStopSharing: didStopSharing,
+        syncEngine: syncEngine
+      )
+      // setting frame is required to have it actually be clickable,
+      // otherwise the frame will be zero when placed on toolbar
+      .frame(width: 26, height: 26)
+    }
+  }
+
+  @available(iOS 17, tvOS 17, *)
+  private struct _CloudCollaborationView: UIViewRepresentable {
+    let sharedRecord: SharedRecord
+    let allowedSharingOptions: CKAllowedSharingOptions
+    let didFinish: (Result<Void, Error>) -> Void
+    let didStopSharing: () -> Void
+    let syncEngine: SyncEngine
+
+    func makeCoordinator() -> _CloudCollaborationDelegate {
       _CloudCollaborationDelegate(
         share: sharedRecord.share,
         didFinish: didFinish,
@@ -309,7 +331,7 @@
       )
     }
 
-    public func makeUIView(context: Context) -> SWCollaborationView {
+    func makeUIView(context: Context) -> SWCollaborationView {
       let itemProvider = NSItemProvider()
       itemProvider.registerCKShare(
         sharedRecord.share,
@@ -324,29 +346,29 @@
       return view
     }
 
-    public func updateUIView(
+    func updateUIView(
       _ uiViewController: SWCollaborationView,
       context: Context
     ) {
     }
   }
 
-  @available(iOS 17, tvOS 17, *)
-  public final class _CloudCollaborationDelegate: _CloudSharingDelegate, SWCollaborationViewDelegate {
-    override init(
-      share: CKShare,
-      didFinish: @escaping (Result<Void, Error>) -> Void,
-      didStopSharing: @escaping () -> Void,
-      syncEngine: SyncEngine
-    ) {
-      super.init(
-        share: share,
-        didFinish: didFinish,
-        didStopSharing: didStopSharing,
-        syncEngine: syncEngine
-      )
+    @available(iOS 17, tvOS 17, *)
+    public final class _CloudCollaborationDelegate: _CloudSharingDelegate, SWCollaborationViewDelegate {
+      override init(
+        share: CKShare,
+        didFinish: @escaping (Result<Void, Error>) -> Void,
+        didStopSharing: @escaping () -> Void,
+        syncEngine: SyncEngine
+      ) {
+        super.init(
+          share: share,
+          didFinish: didFinish,
+          didStopSharing: didStopSharing,
+          syncEngine: syncEngine
+        )
+      }
     }
-  }
 
     /// A view that presents standard screens for adding and removing people from a CloudKit share \
     /// record.

--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -273,85 +273,85 @@
 
   #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
 
-  /// A view that presents standard screens for the collaboration content and options.
-  ///
-  /// See <doc:CloudKitSharing#Creating-CKShare-records> for more info.
-  @available(iOS 17, tvOS 17, *)
-  public struct CloudCollaborationView: View {
-    let sharedRecord: SharedRecord
-    let allowedSharingOptions: CKAllowedSharingOptions
-    let didFinish: (Result<Void, Error>) -> Void
-    let didStopSharing: () -> Void
-    let syncEngine: SyncEngine
-    public init(
-      sharedRecord: SharedRecord,
-      allowedSharingOptions: CKAllowedSharingOptions = .standard,
-      didFinish: @escaping (Result<Void, Error>) -> Void = { _ in },
-      didStopSharing: @escaping () -> Void = {},
-      syncEngine: SyncEngine = {
-        @Dependency(\.defaultSyncEngine) var defaultSyncEngine
-        return defaultSyncEngine
-      }()
-    ) {
-      self.sharedRecord = sharedRecord
-      self.allowedSharingOptions = allowedSharingOptions
-      self.didFinish = didFinish
-      self.didStopSharing = didStopSharing
-      self.syncEngine = syncEngine
+    /// A view that presents standard screens for the collaboration content and options.
+    ///
+    /// See <doc:CloudKitSharing#Creating-CKShare-records> for more info.
+    @available(iOS 17, tvOS 17, *)
+    public struct CloudCollaborationView: View {
+      let sharedRecord: SharedRecord
+      let allowedSharingOptions: CKAllowedSharingOptions
+      let didFinish: (Result<Void, Error>) -> Void
+      let didStopSharing: () -> Void
+      let syncEngine: SyncEngine
+      public init(
+        sharedRecord: SharedRecord,
+        allowedSharingOptions: CKAllowedSharingOptions = .standard,
+        didFinish: @escaping (Result<Void, Error>) -> Void = { _ in },
+        didStopSharing: @escaping () -> Void = {},
+        syncEngine: SyncEngine = {
+          @Dependency(\.defaultSyncEngine) var defaultSyncEngine
+          return defaultSyncEngine
+        }()
+      ) {
+        self.sharedRecord = sharedRecord
+        self.allowedSharingOptions = allowedSharingOptions
+        self.didFinish = didFinish
+        self.didStopSharing = didStopSharing
+        self.syncEngine = syncEngine
+      }
+
+      public var body: some View {
+        _CloudCollaborationView(
+          sharedRecord: sharedRecord,
+          allowedSharingOptions: allowedSharingOptions,
+          didFinish: didFinish,
+          didStopSharing: didStopSharing,
+          syncEngine: syncEngine
+        )
+        // setting frame is required to have it actually be clickable,
+        // otherwise the frame will be zero when placed on toolbar
+        .frame(width: 26, height: 26)
+      }
     }
 
-    public var body: some View {
-      _CloudCollaborationView(
-        sharedRecord: sharedRecord,
-        allowedSharingOptions: allowedSharingOptions,
-        didFinish: didFinish,
-        didStopSharing: didStopSharing,
-        syncEngine: syncEngine
-      )
-      // setting frame is required to have it actually be clickable,
-      // otherwise the frame will be zero when placed on toolbar
-      .frame(width: 26, height: 26)
+    @available(iOS 17, tvOS 17, *)
+    private struct _CloudCollaborationView: UIViewRepresentable {
+      let sharedRecord: SharedRecord
+      let allowedSharingOptions: CKAllowedSharingOptions
+      let didFinish: (Result<Void, Error>) -> Void
+      let didStopSharing: () -> Void
+      let syncEngine: SyncEngine
+
+      func makeCoordinator() -> _CloudCollaborationDelegate {
+        _CloudCollaborationDelegate(
+          share: sharedRecord.share,
+          didFinish: didFinish,
+          didStopSharing: didStopSharing,
+          syncEngine: syncEngine
+        )
+      }
+
+      func makeUIView(context: Context) -> SWCollaborationView {
+        let itemProvider = NSItemProvider()
+        itemProvider.registerCKShare(
+          sharedRecord.share,
+          container: sharedRecord.container.rawValue,
+          allowedSharingOptions: allowedSharingOptions
+        )
+
+        let view = SWCollaborationView(itemProvider: itemProvider)
+        view.delegate = context.coordinator
+        view.cloudSharingControllerDelegate = context.coordinator
+
+        return view
+      }
+
+      func updateUIView(
+        _ uiViewController: SWCollaborationView,
+        context: Context
+      ) {
+      }
     }
-  }
-
-  @available(iOS 17, tvOS 17, *)
-  private struct _CloudCollaborationView: UIViewRepresentable {
-    let sharedRecord: SharedRecord
-    let allowedSharingOptions: CKAllowedSharingOptions
-    let didFinish: (Result<Void, Error>) -> Void
-    let didStopSharing: () -> Void
-    let syncEngine: SyncEngine
-
-    func makeCoordinator() -> _CloudCollaborationDelegate {
-      _CloudCollaborationDelegate(
-        share: sharedRecord.share,
-        didFinish: didFinish,
-        didStopSharing: didStopSharing,
-        syncEngine: syncEngine
-      )
-    }
-
-    func makeUIView(context: Context) -> SWCollaborationView {
-      let itemProvider = NSItemProvider()
-      itemProvider.registerCKShare(
-        sharedRecord.share,
-        container: sharedRecord.container.rawValue,
-        allowedSharingOptions: allowedSharingOptions
-      )
-
-      let view = SWCollaborationView(itemProvider: itemProvider)
-      view.delegate = context.coordinator
-      view.cloudSharingControllerDelegate = context.coordinator
-
-      return view
-    }
-
-    func updateUIView(
-      _ uiViewController: SWCollaborationView,
-      context: Context
-    ) {
-    }
-  }
 
     @available(iOS 17, tvOS 17, *)
     public final class _CloudCollaborationDelegate: _CloudSharingDelegate, SWCollaborationViewDelegate {


### PR DESCRIPTION
Proof of Concept of `SWCollaborationView` wrapper `CloudCollaborationView`. Designed to emulate the “Manage Share” button functionality of Reminders, is presented in the accompanying screen.

### TODOs
- [ ] `SWCollaborationView` toolbar button layout
- [ ] Fetch and observe existing `SharedRecord` query
- [ ] Documentation
- [ ] Update Reminders example
- [ ] macOS support? maybe not yet

PS. Nice [article](https://levelup.gitconnected.com/swiftui-a-simple-simultaneous-content-collaboration-app-with-icloud-b50802aa4007) as a reference. The article suggests another feature requests:
- support for `TransferRepresentation`
- support for `UIActivityViewController`

<img width="430" height="932" alt="image" src="https://github.com/user-attachments/assets/2ea1b259-7efc-4a23-addb-50f52a4a3d13" />
