### PR TITLE
Methods to explicitly fetch and send changes.

### DIFF
--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c133bf7d10c8ce1e5d6506c3d2f080eac8b4c8c2827044d53a9b925e903564fd",
+  "originHash" : "41e7781e6c506773b6af84af513bcd6d3b1be59d635e6c4c4bd89638368e4629",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -71,6 +71,24 @@
       "state" : {
         "revision" : "a501eebe552fd23691c560adf474fca2169ad8aa",
         "version" : "1.9.4"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
+        "version" : "1.4.5"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Examples/Reminders/RemindersLists.swift
+++ b/Examples/Reminders/RemindersLists.swift
@@ -306,7 +306,7 @@ struct RemindersListsView: View {
     }
     .refreshable {
       await withErrorReporting {
-        try await syncEngine.processChanges()
+        try await syncEngine.syncChanges()
       }
     }
     .onAppear {

--- a/Examples/Reminders/RemindersLists.swift
+++ b/Examples/Reminders/RemindersLists.swift
@@ -304,6 +304,11 @@ struct RemindersListsView: View {
         .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
       }
     }
+    .refreshable {
+      await withErrorReporting {
+        try await syncEngine.processChanges()
+      }
+    }
     .onAppear {
       model.onAppear()
     }

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -506,7 +506,7 @@
     /// Fetches pending remote changes from the server.
     ///
     /// Use this method to ensure the sync engine immediately fetches all pending remote changes
-    /// before your app continues. This isn’t necessary in normal use, as the engine automatically
+    /// before your app continues. This isn't necessary in normal use, as the engine automatically
     /// syncs your app’s records. It is useful, however, in scenarios where you require more control
     /// over sync, such as pull-to-refresh.
     ///
@@ -527,9 +527,9 @@
     /// Sends pending local changes to the server.
     ///
     /// Use this method to ensure the sync engine sends all pending local changes to the server
-    /// before your app continues. This isn’t necessary in normal use, as the engine automatically
+    /// before your app continues. This isn't necessary in normal use, as the engine automatically
     /// syncs your app’s records. It is useful, however, in scenarios where you require greater
-    /// control over sync, such as a “Backup now” button.
+    /// control over sync, such as a "Backup now" button.
     ///
     /// - Parameter options: The options to use when sending changes.
     public func sendChanges(
@@ -549,7 +549,7 @@
     ///
     /// Use this method to ensure the sync engine immediately fetches all pending remote changes
     /// _and_ sends all pending local changes to the server. This isn't necessary in normal use,
-    /// as the engine autmoatically syncs your app's records. It is useful, however, in scenarios
+    /// as the engine automatically syncs your app's records. It is useful, however, in scenarios
     /// where you require greater control over sync.
     ///
     /// - Parameters:

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -503,6 +503,40 @@
       }
     }
 
+    public func fetchChanges(
+      _ options: CKSyncEngine.FetchChangesOptions = CKSyncEngine.FetchChangesOptions()
+    ) async throws {
+      let (privateSyncEngine, sharedSyncEngine) = syncEngines.withValue {
+        ($0.private, $0.shared)
+      }
+      guard let privateSyncEngine, let sharedSyncEngine
+      else { return }
+      async let `private`: Void = privateSyncEngine.fetchChanges(options)
+      async let shared: Void = sharedSyncEngine.fetchChanges(options)
+      _ = try await (`private`, shared)
+    }
+
+    public func sendChanges(
+      _ options: CKSyncEngine.SendChangesOptions = CKSyncEngine.SendChangesOptions()
+    ) async throws {
+      let (privateSyncEngine, sharedSyncEngine) = syncEngines.withValue {
+        ($0.private, $0.shared)
+      }
+      guard let privateSyncEngine, let sharedSyncEngine
+      else { return }
+      async let `private`: Void = privateSyncEngine.sendChanges(options)
+      async let shared: Void = sharedSyncEngine.sendChanges(options)
+      _ = try await (`private`, shared)
+    }
+
+    public func processChanges(
+      fetchOptions: CKSyncEngine.FetchChangesOptions = CKSyncEngine.FetchChangesOptions(),
+      sendOptions: CKSyncEngine.SendChangesOptions = CKSyncEngine.SendChangesOptions()
+    ) async throws {
+      try await fetchChanges(fetchOptions)
+      try await sendChanges(sendOptions)
+    }
+
     private func cacheUserTables(recordTypes: [RecordType]) async throws {
       try await userDatabase.write { db in
         try RecordType

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -502,7 +502,15 @@
         }
       }
     }
-
+    
+    /// Fetches pending remote changes from the server.
+    ///
+    /// Use this method to ensure the sync engine immediately fetches all pending remote changes
+    /// before your app continues. This isn’t necessary in normal use, as the engine automatically
+    /// syncs your app’s records. It is useful, however, in scenarios where you require more control
+    /// over sync, such as pull-to-refresh.
+    ///
+    /// - Parameter options: The options to use when fetching changes.
     public func fetchChanges(
       _ options: CKSyncEngine.FetchChangesOptions = CKSyncEngine.FetchChangesOptions()
     ) async throws {
@@ -515,7 +523,15 @@
       async let shared: Void = sharedSyncEngine.fetchChanges(options)
       _ = try await (`private`, shared)
     }
-
+    
+    /// Sends pending local changes to the server.
+    ///
+    /// Use this method to ensure the sync engine sends all pending local changes to the server
+    /// before your app continues. This isn’t necessary in normal use, as the engine automatically
+    /// syncs your app’s records. It is useful, however, in scenarios where you require greater
+    /// control over sync, such as a “Backup now” button.
+    ///
+    /// - Parameter options: The options to use when sending changes.
     public func sendChanges(
       _ options: CKSyncEngine.SendChangesOptions = CKSyncEngine.SendChangesOptions()
     ) async throws {
@@ -528,8 +544,18 @@
       async let shared: Void = sharedSyncEngine.sendChanges(options)
       _ = try await (`private`, shared)
     }
-
-    public func processChanges(
+    
+    /// Synchronizes local and remote pending changes.
+    ///
+    /// Use this method to ensure the sync engine immediately fetches all pending remote changes
+    /// _and_ sends all pending local changes to the server. This isn't necessary in normal use,
+    /// as the engine autmoatically syncs your app's records. It is useful, however, in scenarios
+    /// where you require greater control over sync.
+    ///
+    /// - Parameters:
+    ///   - fetchOptions: The options to use when fetching changes.
+    ///   - sendOptions: The options to use when sending changes.
+    public func syncChanges(
       fetchOptions: CKSyncEngine.FetchChangesOptions = CKSyncEngine.FetchChangesOptions(),
       sendOptions: CKSyncEngine.SendChangesOptions = CKSyncEngine.SendChangesOptions()
     ) async throws {

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -507,7 +507,7 @@
     ///
     /// Use this method to ensure the sync engine immediately fetches all pending remote changes
     /// before your app continues. This isn't necessary in normal use, as the engine automatically
-    /// syncs your app’s records. It is useful, however, in scenarios where you require more control
+    /// syncs your app's records. It is useful, however, in scenarios where you require more control
     /// over sync, such as pull-to-refresh.
     ///
     /// - Parameter options: The options to use when fetching changes.
@@ -528,7 +528,7 @@
     ///
     /// Use this method to ensure the sync engine sends all pending local changes to the server
     /// before your app continues. This isn't necessary in normal use, as the engine automatically
-    /// syncs your app’s records. It is useful, however, in scenarios where you require greater
+    /// syncs your app's records. It is useful, however, in scenarios where you require greater
     /// control over sync, such as a "Backup now" button.
     ///
     /// - Parameter options: The options to use when sending changes.

--- a/Tests/SQLiteDataTests/CloudKitTests/CloudKitTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/CloudKitTests.swift
@@ -823,73 +823,84 @@
           }
         }
       }
-    }
 
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    @Test func generatedColumns() async throws {
-      try await userDatabase.userWrite { db in
-        try db.seed {
-          ModelA(id: 1, count: 42, isEven: true)
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func sendChanges() async throws {
+        try await userDatabase.userWrite { db in
+          try db.seed {
+            RemindersList(id: 1, title: "Personal")
+          }
+        }
+        try await syncEngine.sendChanges(CKSyncEngine.SendChangesOptions())
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func generatedColumns() async throws {
+        try await userDatabase.userWrite { db in
+          try db.seed {
+            ModelA(id: 1, count: 42, isEven: true)
+          }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:modelAs/zone/__defaultOwner__),
+                  recordType: "modelAs",
+                  parent: nil,
+                  share: nil,
+                  count: 42,
+                  id: 1
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+
+        let record = try syncEngine.private.database.record(for: ModelA.recordID(for: 1))
+        record.encryptedValues["isEven"] = false
+        try await syncEngine.modifyRecords(scope: .private, saving: [record]).notify()
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:modelAs/zone/__defaultOwner__),
+                  recordType: "modelAs",
+                  parent: nil,
+                  share: nil,
+                  count: 42,
+                  id: 1,
+                  isEven: 0
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+
+        try await userDatabase.read { db in
+          let modelA = try #require(try ModelA.find(1).fetchOne(db))
+          #expect(modelA.isEven == true)
         }
       }
-      try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: container, as: .customDump) {
-        """
-        MockCloudContainer(
-          privateCloudDatabase: MockCloudDatabase(
-            databaseScope: .private,
-            storage: [
-              [0]: CKRecord(
-                recordID: CKRecord.ID(1:modelAs/zone/__defaultOwner__),
-                recordType: "modelAs",
-                parent: nil,
-                share: nil,
-                count: 42,
-                id: 1
-              )
-            ]
-          ),
-          sharedCloudDatabase: MockCloudDatabase(
-            databaseScope: .shared,
-            storage: []
-          )
-        )
-        """
-      }
-
-      let record = try syncEngine.private.database.record(for: ModelA.recordID(for: 1))
-      record.encryptedValues["isEven"] = false
-      try await syncEngine.modifyRecords(scope: .private, saving: [record]).notify()
-
-      assertInlineSnapshot(of: container, as: .customDump) {
-        """
-        MockCloudContainer(
-          privateCloudDatabase: MockCloudDatabase(
-            databaseScope: .private,
-            storage: [
-              [0]: CKRecord(
-                recordID: CKRecord.ID(1:modelAs/zone/__defaultOwner__),
-                recordType: "modelAs",
-                parent: nil,
-                share: nil,
-                count: 42,
-                id: 1,
-                isEven: 0
-              )
-            ]
-          ),
-          sharedCloudDatabase: MockCloudDatabase(
-            databaseScope: .shared,
-            storage: []
-          )
-        )
-        """
-      }
-
-      try await userDatabase.read { db in
-        let modelA = try #require(try ModelA.find(1).fetchOne(db))
-        #expect(modelA.isEven == true)
-      }
     }
+
   }
 #endif


### PR DESCRIPTION
It can sometimes be handy to tell the sync engine to fetch remote changes and send pending changes explicitly (such as pull-to-refresh), and so we expose those methods on our `SyncEngine`.