### PR TITLE
Add existingShare

### DIFF
--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -208,6 +208,17 @@
       return SharedRecord(container: container, share: savedShare)
     }
 
+    public func existingShare<T: PrimaryKeyedTable>(record: T) async throws
+    where T.TableColumns.PrimaryKey.QueryOutput: IdentifierStringConvertible {
+      try await metadatabase.read { [recordName = record.recordName] db in
+        try SyncMetadata
+          .where { $0.recordName.eq(recordName) }
+          .select(\.share)
+          .fetchOne(db)
+          ?? nil
+      }
+    }
+
     public func unshare<T: PrimaryKeyedTable>(record: T) async throws
     where T.TableColumns.PrimaryKey.QueryOutput: IdentifierStringConvertible {
       let share = try await metadatabase.read { [recordName = record.recordName] db in


### PR DESCRIPTION
The method fetches existing `ShareRecord` without creating it.

Use case: `SWCollaborationView` should show only when `CKShare` exists, when `SyncEngine.share(record:configure:)` creates `CKShare` if it doesn’t exist.
