### PR TITLE
Fix logic that determines sharing private tables.

### DIFF
--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c133bf7d10c8ce1e5d6506c3d2f080eac8b4c8c2827044d53a9b925e903564fd",
+  "originHash" : "41e7781e6c506773b6af84af513bcd6d3b1be59d635e6c4c4bd89638368e4629",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -71,6 +71,24 @@
       "state" : {
         "revision" : "a501eebe552fd23691c560adf474fca2169ad8aa",
         "version" : "1.9.4"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
+        "version" : "1.4.5"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -1127,8 +1127,7 @@
               recordID: recordID
             )
           if let parentRecordName = metadata.parentRecordName,
-            let parentRecordType = metadata.parentRecordType,
-            !privateTables.contains(where: { $0.base.tableName == parentRecordType })
+            !privateTables.contains(where: { $0.base.tableName == metadata.recordType })
           {
             record.parent = CKRecord.Reference(
               recordID: CKRecord.ID(

--- a/Tests/SQLiteDataTests/CloudKitTests/AccountLifecycleTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/AccountLifecycleTests.swift
@@ -17,7 +17,7 @@
           try db.seed {
             RemindersList(id: 1, title: "Personal")
             Reminder(id: 1, title: "Get milk", remindersListID: 1)
-            RemindersListPrivate(id: 1, remindersListID: 1)
+            RemindersListPrivate(remindersListID: 1)
             UnsyncedModel(id: 1)
           }
         }
@@ -43,7 +43,7 @@
           try db.seed {
             RemindersList(id: 1, title: "Personal")
             Reminder(id: 1, title: "Get milk", remindersListID: 1)
-            RemindersListPrivate(id: 1, remindersListID: 1)
+            RemindersListPrivate(remindersListID: 1)
             UnsyncedModel(id: 1)
           }
         }
@@ -95,9 +95,8 @@
                 [1]: CKRecord(
                   recordID: CKRecord.ID(1:remindersListPrivates/zone/__defaultOwner__),
                   recordType: "remindersListPrivates",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                  parent: nil,
                   share: nil,
-                  id: 1,
                   position: 0,
                   remindersListID: 1
                 ),
@@ -611,7 +610,7 @@
           try db.seed {
             RemindersList(id: 1, title: "Personal")
             Reminder(id: 1, title: "Get milk", remindersListID: 1)
-            RemindersListPrivate(id: 1, remindersListID: 1)
+            RemindersListPrivate(remindersListID: 1)
             UnsyncedModel(id: 1)
           }
         }

--- a/Tests/SQLiteDataTests/CloudKitTests/CloudKitTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/CloudKitTests.swift
@@ -75,29 +75,22 @@
               tableName: "remindersListPrivates",
               schema: """
                 CREATE TABLE "remindersListPrivates" (
-                  "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-                  "position" INTEGER NOT NULL ON CONFLICT REPLACE DEFAULT 0,
-                  "remindersListID" INTEGER NOT NULL REFERENCES "remindersLists"("id") ON DELETE CASCADE
+                  "remindersListID" INTEGER PRIMARY KEY NOT NULL REFERENCES "remindersLists"("id") 
+                    ON DELETE CASCADE,
+                  "position" INTEGER NOT NULL ON CONFLICT REPLACE DEFAULT 0
                 ) STRICT
                 """,
               tableInfo: [
                 [0]: TableInfo(
-                  defaultValue: nil,
-                  isPrimaryKey: true,
-                  name: "id",
-                  isNotNull: true,
-                  type: "INTEGER"
-                ),
-                [1]: TableInfo(
                   defaultValue: "0",
                   isPrimaryKey: false,
                   name: "position",
                   isNotNull: true,
                   type: "INTEGER"
                 ),
-                [2]: TableInfo(
+                [1]: TableInfo(
                   defaultValue: nil,
-                  isPrimaryKey: false,
+                  isPrimaryKey: true,
                   name: "remindersListID",
                   isNotNull: true,
                   type: "INTEGER"
@@ -769,7 +762,7 @@
           try await userDatabase.userWrite { db in
             try db.seed {
               RemindersList(id: 1, title: "Personal")
-              RemindersListPrivate(id: 1, position: 1, remindersListID: 1)
+              RemindersListPrivate(remindersListID: 1, position: 1)
               Reminder(id: 1, title: "", remindersListID: 1)
               Reminder(id: 2, title: "", remindersListID: 1)
               Reminder(id: 3, title: "", remindersListID: 1)
@@ -901,6 +894,5 @@
         }
       }
     }
-
   }
 #endif

--- a/Tests/SQLiteDataTests/CloudKitTests/FetchedDatabaseChangesTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/FetchedDatabaseChangesTests.swift
@@ -20,8 +20,8 @@
             RemindersList(id: 2, title: "Business")
             Reminder(id: 1, title: "Get milk", remindersListID: 1)
             Reminder(id: 2, title: "Call accountant", remindersListID: 2)
-            RemindersListPrivate(id: 1, remindersListID: 1)
-            RemindersListPrivate(id: 2, remindersListID: 2)
+            RemindersListPrivate(remindersListID: 1)
+            RemindersListPrivate(remindersListID: 2)
             UnsyncedModel(id: 1)
             UnsyncedModel(id: 2)
           }
@@ -52,8 +52,8 @@
             RemindersList(id: 2, title: "Business")
             Reminder(id: 1, title: "Get milk", remindersListID: 1)
             Reminder(id: 2, title: "Call accountant", remindersListID: 2)
-            RemindersListPrivate(id: 1, remindersListID: 1)
-            RemindersListPrivate(id: 2, remindersListID: 2)
+            RemindersListPrivate(remindersListID: 1)
+            RemindersListPrivate(remindersListID: 2)
             UnsyncedModel(id: 1)
             UnsyncedModel(id: 2)
           }
@@ -106,18 +106,16 @@
                 [2]: CKRecord(
                   recordID: CKRecord.ID(1:remindersListPrivates/zone/__defaultOwner__),
                   recordType: "remindersListPrivates",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                  parent: nil,
                   share: nil,
-                  id: 1,
                   position: 0,
                   remindersListID: 1
                 ),
                 [3]: CKRecord(
                   recordID: CKRecord.ID(2:remindersListPrivates/zone/__defaultOwner__),
                   recordType: "remindersListPrivates",
-                  parent: CKReference(recordID: CKRecord.ID(2:remindersLists/zone/__defaultOwner__)),
+                  parent: nil,
                   share: nil,
-                  id: 2,
                   position: 0,
                   remindersListID: 2
                 ),

--- a/Tests/SQLiteDataTests/CloudKitTests/NextRecordZoneChangeBatchTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/NextRecordZoneChangeBatchTests.swift
@@ -225,7 +225,7 @@
         try await userDatabase.userWrite { db in
           try db.seed {
             RemindersList(id: 1, title: "Personal")
-            RemindersListPrivate(id: 1, position: 42, remindersListID: 1)
+            RemindersListPrivate(remindersListID: 1, position: 42)
           }
         }
 
@@ -239,9 +239,8 @@
                 [0]: CKRecord(
                   recordID: CKRecord.ID(1:remindersListPrivates/zone/__defaultOwner__),
                   recordType: "remindersListPrivates",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                  parent: nil,
                   share: nil,
-                  id: 1,
                   position: 42,
                   remindersListID: 1
                 ),

--- a/Tests/SQLiteDataTests/CloudKitTests/RecordTypeTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/RecordTypeTests.swift
@@ -73,29 +73,22 @@
               tableName: "remindersListPrivates",
               schema: """
                 CREATE TABLE "remindersListPrivates" (
-                  "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-                  "position" INTEGER NOT NULL ON CONFLICT REPLACE DEFAULT 0,
-                  "remindersListID" INTEGER NOT NULL REFERENCES "remindersLists"("id") ON DELETE CASCADE
+                  "remindersListID" INTEGER PRIMARY KEY NOT NULL REFERENCES "remindersLists"("id") 
+                    ON DELETE CASCADE,
+                  "position" INTEGER NOT NULL ON CONFLICT REPLACE DEFAULT 0
                 ) STRICT
                 """,
               tableInfo: [
                 [0]: TableInfo(
-                  defaultValue: nil,
-                  isPrimaryKey: true,
-                  name: "id",
-                  isNotNull: true,
-                  type: "INTEGER"
-                ),
-                [1]: TableInfo(
                   defaultValue: "0",
                   isPrimaryKey: false,
                   name: "position",
                   isNotNull: true,
                   type: "INTEGER"
                 ),
-                [2]: TableInfo(
+                [1]: TableInfo(
                   defaultValue: nil,
-                  isPrimaryKey: false,
+                  isPrimaryKey: true,
                   name: "remindersListID",
                   isNotNull: true,
                   type: "INTEGER"

--- a/Tests/SQLiteDataTests/CloudKitTests/TriggerTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/TriggerTests.swift
@@ -255,7 +255,7 @@
               AFTER DELETE ON "remindersListPrivates"
               FOR EACH ROW WHEN "sqlitedata_icloud_syncEngineIsSynchronizingChanges"() BEGIN
                 DELETE FROM "sqlitedata_icloud_metadata"
-                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListPrivates'));
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListPrivates'));
               END
               """,
               [17]: """
@@ -276,7 +276,7 @@
                 WHERE ((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share")));
                 UPDATE "sqlitedata_icloud_metadata"
                 SET "_isDeleted" = 1
-                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListPrivates'));
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListPrivates'));
               END
               """,
               [18]: """
@@ -626,7 +626,7 @@
                 WHERE ((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share")));
                 INSERT INTO "sqlitedata_icloud_metadata"
                 ("recordPrimaryKey", "recordType", "zoneName", "ownerName", "parentRecordPrimaryKey", "parentRecordType")
-                SELECT "new"."id", 'remindersListPrivates', coalesce(coalesce("sqlitedata_icloud_currentZoneName"(), (SELECT "sqlitedata_icloud_metadata"."zoneName"
+                SELECT "new"."remindersListID", 'remindersListPrivates', coalesce(coalesce("sqlitedata_icloud_currentZoneName"(), (SELECT "sqlitedata_icloud_metadata"."zoneName"
                 FROM "sqlitedata_icloud_metadata"
                 WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersLists')))), 'zone'), coalesce(coalesce("sqlitedata_icloud_currentOwnerName"(), (SELECT "sqlitedata_icloud_metadata"."ownerName"
                 FROM "sqlitedata_icloud_metadata"
@@ -878,8 +878,8 @@
               """,
               [47]: """
               CREATE TRIGGER "sqlitedata_icloud_after_primary_key_change_on_remindersListPrivates"
-              AFTER UPDATE OF "id" ON "remindersListPrivates"
-              FOR EACH ROW WHEN ("old"."id") <> ("new"."id") BEGIN
+              AFTER UPDATE OF "remindersListID" ON "remindersListPrivates"
+              FOR EACH ROW WHEN ("old"."remindersListID") <> ("new"."remindersListID") BEGIN
                 WITH "rootShares" AS (
                   SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
                   FROM "sqlitedata_icloud_metadata"
@@ -894,7 +894,7 @@
                 WHERE ((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share")));
                 UPDATE "sqlitedata_icloud_metadata"
                 SET "_isDeleted" = 1
-                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListPrivates'));
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListPrivates'));
               END
               """,
               [48]: """
@@ -1230,7 +1230,7 @@
                 WHERE ((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share")));
                 INSERT INTO "sqlitedata_icloud_metadata"
                 ("recordPrimaryKey", "recordType", "zoneName", "ownerName", "parentRecordPrimaryKey", "parentRecordType")
-                SELECT "new"."id", 'remindersListPrivates', coalesce(coalesce("sqlitedata_icloud_currentZoneName"(), (SELECT "sqlitedata_icloud_metadata"."zoneName"
+                SELECT "new"."remindersListID", 'remindersListPrivates', coalesce(coalesce("sqlitedata_icloud_currentZoneName"(), (SELECT "sqlitedata_icloud_metadata"."zoneName"
                 FROM "sqlitedata_icloud_metadata"
                 WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersLists')))), 'zone'), coalesce(coalesce("sqlitedata_icloud_currentOwnerName"(), (SELECT "sqlitedata_icloud_metadata"."ownerName"
                 FROM "sqlitedata_icloud_metadata"
@@ -1242,7 +1242,7 @@
                 WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersLists')))), "sqlitedata_icloud_metadata"."zoneName"), "ownerName" = coalesce(coalesce("sqlitedata_icloud_currentOwnerName"(), (SELECT "sqlitedata_icloud_metadata"."ownerName"
                 FROM "sqlitedata_icloud_metadata"
                 WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersLists')))), "sqlitedata_icloud_metadata"."ownerName"), "parentRecordPrimaryKey" = "new"."remindersListID", "parentRecordType" = 'remindersLists', "userModificationTime" = "sqlitedata_icloud_currentTime"()
-                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListPrivates'));
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListPrivates'));
               END
               """,
               [60]: """

--- a/Tests/SQLiteDataTests/Internal/Schema.swift
+++ b/Tests/SQLiteDataTests/Internal/Schema.swift
@@ -23,9 +23,10 @@ import SQLiteData
   var id: RemindersList.ID { remindersListID }
 }
 @Table struct RemindersListPrivate: Equatable, Identifiable {
-  let id: Int
-  var position = 0
+  @Column(primaryKey: true)
   var remindersListID: RemindersList.ID
+  var position = 0
+  var id: RemindersList.ID { remindersListID }
 }
 @Table struct Tag: Equatable, Identifiable {
   @Column(primaryKey: true)
@@ -112,9 +113,9 @@ func database(
     try #sql(
       """
       CREATE TABLE "remindersListPrivates" (
-        "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-        "position" INTEGER NOT NULL ON CONFLICT REPLACE DEFAULT 0,
-        "remindersListID" INTEGER NOT NULL REFERENCES "remindersLists"("id") ON DELETE CASCADE
+        "remindersListID" INTEGER PRIMARY KEY NOT NULL REFERENCES "remindersLists"("id") 
+          ON DELETE CASCADE,
+        "position" INTEGER NOT NULL ON CONFLICT REPLACE DEFAULT 0
       ) STRICT
       """
     )


### PR DESCRIPTION
We have a bug right now that unfortunately sets a `parent` relationship for private tables when it should not. This PR fixes it.