### PR TITLE
Do not delete records when sharee deletes share.

### DIFF
--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -1227,7 +1227,7 @@
                               recordName: metadata.recordName,
                               lastKnownServerRecord: metadata.lastKnownServerRecord,
                               rootRecordName: tree.rootRecordName,
-                              rootLastKnownServerRecord: tree.lastKnownServerRecord
+                              rootLastKnownServerRecord: tree.rootLastKnownServerRecord
                             )
                           }
                       )


### PR DESCRIPTION
We have special logic to make sure to not delete records when a _sharee_ deletes a root shared record. However, the query for that logic had a typo that caused associations of associations to be deleted, and this PR fixes that query.