### PR TITLE
Add indexes on foreign keys in Reminders and SyncUp examples

### DIFF
--- a/Examples/Reminders/Schema.swift
+++ b/Examples/Reminders/Schema.swift
@@ -174,6 +174,16 @@ func appDatabase() throws -> any DatabaseWriter {
     .execute(db)
     try #sql(
       """
+      CREATE TABLE "remindersListAssets" (
+        "remindersListID" TEXT PRIMARY KEY NOT NULL 
+          REFERENCES "remindersLists"("id") ON DELETE CASCADE,
+        "coverImage" BLOB
+      ) STRICT
+      """
+    )
+    .execute(db)
+    try #sql(
+      """
       CREATE TABLE "reminders" (
         "id" TEXT PRIMARY KEY NOT NULL ON CONFLICT REPLACE DEFAULT (uuid()),
         "dueDate" TEXT,
@@ -220,13 +230,6 @@ func appDatabase() throws -> any DatabaseWriter {
   }
 
   migrator.registerMigration("Create foreign key indexes") { db in
-    try #sql(
-      """
-      CREATE INDEX IF NOT EXISTS "idx_remindersListAssets_remindersListID"
-      ON "remindersListAssets"("remindersListID")
-      """
-    )
-    .execute(db)
     try #sql(
       """
       CREATE INDEX IF NOT EXISTS "idx_reminders_remindersListID"

--- a/Examples/Reminders/Schema.swift
+++ b/Examples/Reminders/Schema.swift
@@ -174,16 +174,6 @@ func appDatabase() throws -> any DatabaseWriter {
     .execute(db)
     try #sql(
       """
-      CREATE TABLE "remindersListAssets" (
-        "remindersListID" TEXT PRIMARY KEY NOT NULL 
-          REFERENCES "remindersLists"("id") ON DELETE CASCADE,
-        "coverImage" BLOB
-      ) STRICT
-      """
-    )
-    .execute(db)
-    try #sql(
-      """
       CREATE TABLE "reminders" (
         "id" TEXT PRIMARY KEY NOT NULL ON CONFLICT REPLACE DEFAULT (uuid()),
         "dueDate" TEXT,

--- a/Examples/Reminders/Schema.swift
+++ b/Examples/Reminders/Schema.swift
@@ -229,6 +229,37 @@ func appDatabase() throws -> any DatabaseWriter {
     .execute(db)
   }
 
+  migrator.registerMigration("Create foreign key indexes") { db in
+    try #sql(
+      """
+      CREATE INDEX IF NOT EXISTS "idx_remindersListAssets_remindersListID"
+      ON "remindersListAssets"("remindersListID")
+      """
+    )
+    .execute(db)
+    try #sql(
+      """
+      CREATE INDEX IF NOT EXISTS "idx_reminders_remindersListID"
+      ON "reminders"("remindersListID")
+      """
+    )
+    .execute(db)
+    try #sql(
+      """
+      CREATE INDEX IF NOT EXISTS "idx_remindersTags_reminderID"
+      ON "remindersTags"("reminderID")
+      """
+    )
+    .execute(db)
+    try #sql(
+      """
+      CREATE INDEX IF NOT EXISTS "idx_remindersTags_tagID"
+      ON "remindersTags"("tagID")
+      """
+    )
+    .execute(db)
+  }
+  
   try migrator.migrate(database)
 
   try database.write { db in
@@ -515,3 +546,4 @@ nonisolated private let logger = Logger(subsystem: "Reminders", category: "Datab
     }
   }
 #endif
+

--- a/Examples/SyncUps/Schema.swift
+++ b/Examples/SyncUps/Schema.swift
@@ -123,6 +123,22 @@ extension DependencyValues {
       )
       .execute(db)
     }
+    migrator.registerMigration("Create foreign key indexes") { db in
+      try #sql(
+        """
+        CREATE INDEX IF NOT EXISTS "idx_attendees_syncUpID"
+        ON "attendees"("syncUpID")
+        """
+      )
+      .execute(db)
+      try #sql(
+        """
+        CREATE INDEX IF NOT EXISTS "idx_meetings_syncUpID"
+        ON "meetings"("syncUpID")
+        """
+      )
+      .execute(db)
+    }
     try migrator.migrate(database)
     defaultDatabase = database
     defaultSyncEngine = try SyncEngine(


### PR DESCRIPTION
Adds index to foreign-key columns in the SQLiteData Reminders and SyncUp examples, as Brandon requested in Slack. Good practice to help query performance.