### PR TITLE
Fix id column type in documentation example schema to prevent error

### DIFF
--- a/Sources/SQLiteData/Documentation.docc/Articles/PreparingDatabase.md
+++ b/Sources/SQLiteData/Documentation.docc/Articles/PreparingDatabase.md
@@ -170,7 +170,7 @@ code, but we personally feel that it is simpler, more flexible and more powerful
 migrator.registerMigration("Create tables") { db in
   try #sql("""
     CREATE TABLE "remindersLists"(
-      "id" INT NOT NULL PRIMARY KEY AUTOINCREMENT,
+      "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
       "title" TEXT NOT NULL
     ) STRICT
     """)
@@ -178,10 +178,10 @@ migrator.registerMigration("Create tables") { db in
 
   try #sql("""
     CREATE TABLE "reminders"(
-      "id" INT NOT NULL PRIMARY KEY AUTOINCREMENT,
-      "isCompleted" INT NOT NULL DEFAULT 0,
+      "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+      "isCompleted" INTEGER NOT NULL DEFAULT 0,
       "title" TEXT NOT NULL,
-      "remindersListID" INT NOT NULL REFERENCES "remindersLists"("id") ON DELETE CASCADE
+      "remindersListID" INTEGER NOT NULL REFERENCES "remindersLists"("id") ON DELETE CASCADE
     ) STRICT
     """)
     .execute(db)


### PR DESCRIPTION
When the `id` column is defined as `INT NOT NULL PRIMARY KEY AUTOINCREMENT` sqlite will throw an error:

> AUTOINCREMENT is only allowed on an INTEGER PRIMARY KEY

This is fixed by changing `INT` to `INTEGER`. I also changed the other columns for consistency.

The error was being thrown for sqlite-data 1.4.0, iOS 26.1.