### PR TITLE
Improve MergeConflictTests coverage and naming

### DIFF
--- a/Tests/SQLiteDataTests/CloudKitTests/MergeConflictTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MergeConflictTests.swift
@@ -14,7 +14,7 @@
     @Suite(.printTimestamps) final class MergeConflictTests: BaseCloudKitTests, @unchecked Sendable
     {
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-      @Test func merge_clientRecordUpdatedBeforeServerRecord() async throws {
+      @Test func clientRecordUpdatedBeforeServerRecord() async throws {
         try await userDatabase.userWrite { db in
           try db.seed {
             RemindersList(id: 1, title: "")
@@ -22,44 +22,38 @@
           }
         }
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-        assertInlineSnapshot(of: container, as: .customDump) {
+        assertInlineSnapshot(of: container.privateCloudDatabase, as: .customDump) {
           """
-          MockCloudContainer(
-            privateCloudDatabase: MockCloudDatabase(
-              databaseScope: .private,
-              storage: [
-                [0]: CKRecord(
-                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
-                  recordType: "reminders",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  isCompleted: 0,
-                  isCompleted🗓️: 0,
-                  remindersListID: 1,
-                  remindersListID🗓️: 0,
-                  title: "",
-                  title🗓️: 0,
-                  🗓️: 0
-                ),
-                [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
-                  recordType: "remindersLists",
-                  parent: nil,
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  title: "",
-                  title🗓️: 0,
-                  🗓️: 0
-                )
-              ]
-            ),
-            sharedCloudDatabase: MockCloudDatabase(
-              databaseScope: .shared,
-              storage: []
-            )
+          MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                recordType: "reminders",
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                isCompleted: 0,
+                isCompleted🗓️: 0,
+                remindersListID: 1,
+                remindersListID🗓️: 0,
+                title: "",
+                title🗓️: 0,
+                🗓️: 0
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                title: "",
+                title🗓️: 0,
+                🗓️: 0
+              )
+            ]
           )
           """
         }
@@ -71,7 +65,7 @@
         }()
 
         try await withDependencies {
-          $0.currentTime.now += 30
+          $0.currentTime.now = 30
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.isCompleted = true }.execute(db)
@@ -79,44 +73,38 @@
         }
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-        assertInlineSnapshot(of: container, as: .customDump) {
+        assertInlineSnapshot(of: container.privateCloudDatabase, as: .customDump) {
           """
-          MockCloudContainer(
-            privateCloudDatabase: MockCloudDatabase(
-              databaseScope: .private,
-              storage: [
-                [0]: CKRecord(
-                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
-                  recordType: "reminders",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  isCompleted: 0,
-                  isCompleted🗓️: 0,
-                  remindersListID: 1,
-                  remindersListID🗓️: 0,
-                  title: "Buy milk",
-                  title🗓️: 60,
-                  🗓️: 60
-                ),
-                [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
-                  recordType: "remindersLists",
-                  parent: nil,
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  title: "",
-                  title🗓️: 0,
-                  🗓️: 0
-                )
-              ]
-            ),
-            sharedCloudDatabase: MockCloudDatabase(
-              databaseScope: .shared,
-              storage: []
-            )
+          MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                recordType: "reminders",
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                isCompleted: 0,
+                isCompleted🗓️: 0,
+                remindersListID: 1,
+                remindersListID🗓️: 0,
+                title: "Buy milk",
+                title🗓️: 60,
+                🗓️: 60
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                title: "",
+                title🗓️: 0,
+                🗓️: 0
+              )
+            ]
           )
           """
         }
@@ -124,44 +112,38 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
         await modificationCallback.notify()
 
-        assertInlineSnapshot(of: container, as: .customDump) {
+        assertInlineSnapshot(of: container.privateCloudDatabase, as: .customDump) {
           """
-          MockCloudContainer(
-            privateCloudDatabase: MockCloudDatabase(
-              databaseScope: .private,
-              storage: [
-                [0]: CKRecord(
-                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
-                  recordType: "reminders",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  isCompleted: 1,
-                  isCompleted🗓️: 30,
-                  remindersListID: 1,
-                  remindersListID🗓️: 0,
-                  title: "Buy milk",
-                  title🗓️: 60,
-                  🗓️: 60
-                ),
-                [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
-                  recordType: "remindersLists",
-                  parent: nil,
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  title: "",
-                  title🗓️: 0,
-                  🗓️: 0
-                )
-              ]
-            ),
-            sharedCloudDatabase: MockCloudDatabase(
-              databaseScope: .shared,
-              storage: []
-            )
+          MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                recordType: "reminders",
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                isCompleted: 1,
+                isCompleted🗓️: 30,
+                remindersListID: 1,
+                remindersListID🗓️: 0,
+                title: "Buy milk",
+                title🗓️: 60,
+                🗓️: 60
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                title: "",
+                title🗓️: 0,
+                🗓️: 0
+              )
+            ]
           )
           """
         }
@@ -176,44 +158,38 @@
           }
         }
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-        assertInlineSnapshot(of: container, as: .customDump) {
+        assertInlineSnapshot(of: container.privateCloudDatabase, as: .customDump) {
           """
-          MockCloudContainer(
-            privateCloudDatabase: MockCloudDatabase(
-              databaseScope: .private,
-              storage: [
-                [0]: CKRecord(
-                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
-                  recordType: "reminders",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  isCompleted: 0,
-                  isCompleted🗓️: 0,
-                  remindersListID: 1,
-                  remindersListID🗓️: 0,
-                  title: "",
-                  title🗓️: 0,
-                  🗓️: 0
-                ),
-                [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
-                  recordType: "remindersLists",
-                  parent: nil,
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  title: "",
-                  title🗓️: 0,
-                  🗓️: 0
-                )
-              ]
-            ),
-            sharedCloudDatabase: MockCloudDatabase(
-              databaseScope: .shared,
-              storage: []
-            )
+          MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                recordType: "reminders",
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                isCompleted: 0,
+                isCompleted🗓️: 0,
+                remindersListID: 1,
+                remindersListID🗓️: 0,
+                title: "",
+                title🗓️: 0,
+                🗓️: 0
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                title: "",
+                title🗓️: 0,
+                🗓️: 0
+              )
+            ]
           )
           """
         }
@@ -225,7 +201,7 @@
         }()
 
         try await withDependencies {
-          $0.currentTime.now += 60
+          $0.currentTime.now = 60
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.isCompleted = true }.execute(db)
@@ -233,44 +209,38 @@
         }
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-        assertInlineSnapshot(of: container, as: .customDump) {
+        assertInlineSnapshot(of: container.privateCloudDatabase, as: .customDump) {
           """
-          MockCloudContainer(
-            privateCloudDatabase: MockCloudDatabase(
-              databaseScope: .private,
-              storage: [
-                [0]: CKRecord(
-                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
-                  recordType: "reminders",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  isCompleted: 0,
-                  isCompleted🗓️: 0,
-                  remindersListID: 1,
-                  remindersListID🗓️: 0,
-                  title: "Buy milk",
-                  title🗓️: 30,
-                  🗓️: 30
-                ),
-                [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
-                  recordType: "remindersLists",
-                  parent: nil,
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  title: "",
-                  title🗓️: 0,
-                  🗓️: 0
-                )
-              ]
-            ),
-            sharedCloudDatabase: MockCloudDatabase(
-              databaseScope: .shared,
-              storage: []
-            )
+          MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                recordType: "reminders",
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                isCompleted: 0,
+                isCompleted🗓️: 0,
+                remindersListID: 1,
+                remindersListID🗓️: 0,
+                title: "Buy milk",
+                title🗓️: 30,
+                🗓️: 30
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                title: "",
+                title🗓️: 0,
+                🗓️: 0
+              )
+            ]
           )
           """
         }
@@ -278,44 +248,38 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
         await modificationCallback.notify()
 
-        assertInlineSnapshot(of: container, as: .customDump) {
+        assertInlineSnapshot(of: container.privateCloudDatabase, as: .customDump) {
           """
-          MockCloudContainer(
-            privateCloudDatabase: MockCloudDatabase(
-              databaseScope: .private,
-              storage: [
-                [0]: CKRecord(
-                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
-                  recordType: "reminders",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  isCompleted: 1,
-                  isCompleted🗓️: 60,
-                  remindersListID: 1,
-                  remindersListID🗓️: 0,
-                  title: "Buy milk",
-                  title🗓️: 30,
-                  🗓️: 60
-                ),
-                [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
-                  recordType: "remindersLists",
-                  parent: nil,
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  title: "",
-                  title🗓️: 0,
-                  🗓️: 0
-                )
-              ]
-            ),
-            sharedCloudDatabase: MockCloudDatabase(
-              databaseScope: .shared,
-              storage: []
-            )
+          MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                recordType: "reminders",
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                isCompleted: 1,
+                isCompleted🗓️: 60,
+                remindersListID: 1,
+                remindersListID🗓️: 0,
+                title: "Buy milk",
+                title🗓️: 30,
+                🗓️: 60
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                title: "",
+                title🗓️: 0,
+                🗓️: 0
+              )
+            ]
           )
           """
         }
@@ -338,7 +302,7 @@
         }()
 
         try await withDependencies {
-          $0.currentTime.now += 60
+          $0.currentTime.now = 60
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.isCompleted = true }.execute(db)
@@ -347,44 +311,38 @@
         await modificationCallback.notify()
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-        assertInlineSnapshot(of: container, as: .customDump) {
+        assertInlineSnapshot(of: container.privateCloudDatabase, as: .customDump) {
           """
-          MockCloudContainer(
-            privateCloudDatabase: MockCloudDatabase(
-              databaseScope: .private,
-              storage: [
-                [0]: CKRecord(
-                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
-                  recordType: "reminders",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  isCompleted: 1,
-                  isCompleted🗓️: 60,
-                  remindersListID: 1,
-                  remindersListID🗓️: 0,
-                  title: "Buy milk",
-                  title🗓️: 30,
-                  🗓️: 60
-                ),
-                [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
-                  recordType: "remindersLists",
-                  parent: nil,
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  title: "",
-                  title🗓️: 0,
-                  🗓️: 0
-                )
-              ]
-            ),
-            sharedCloudDatabase: MockCloudDatabase(
-              databaseScope: .shared,
-              storage: []
-            )
+          MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                recordType: "reminders",
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                isCompleted: 1,
+                isCompleted🗓️: 60,
+                remindersListID: 1,
+                remindersListID🗓️: 0,
+                title: "Buy milk",
+                title🗓️: 30,
+                🗓️: 60
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                title: "",
+                title🗓️: 0,
+                🗓️: 0
+              )
+            ]
           )
           """
         }
@@ -401,24 +359,21 @@
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         try await withDependencies {
-          $0.currentTime.now += 30
+          $0.currentTime.now = 30
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.title = "Get milk" }.execute(db)
           }
-          try await withDependencies {
-            $0.currentTime.now += 30
-          } operation: {
-            let record = try syncEngine.private.database.record(for: Reminder.recordID(for: 1))
-            record.setValue("Buy milk", forKey: "title", at: now)
-            let modificationCallback = try {
-              try syncEngine.modifyRecords(scope: .private, saving: [record])
-            }()
-
-            await modificationCallback.notify()
-            try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-          }
         }
+        
+        let record = try syncEngine.private.database.record(for: Reminder.recordID(for: 1))
+        record.setValue("Buy milk", forKey: "title", at: 60)
+        let modificationCallback = try {
+          try syncEngine.modifyRecords(scope: .private, saving: [record])
+        }()
+        
+        await modificationCallback.notify()
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         assertQuery(Reminder.all, database: userDatabase.database) {
           """
@@ -434,44 +389,38 @@
           └───────────────────────┘
           """
         }
-        assertInlineSnapshot(of: container, as: .customDump) {
+        assertInlineSnapshot(of: container.privateCloudDatabase, as: .customDump) {
           """
-          MockCloudContainer(
-            privateCloudDatabase: MockCloudDatabase(
-              databaseScope: .private,
-              storage: [
-                [0]: CKRecord(
-                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
-                  recordType: "reminders",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  isCompleted: 0,
-                  isCompleted🗓️: 0,
-                  remindersListID: 1,
-                  remindersListID🗓️: 0,
-                  title: "Get milk",
-                  title🗓️: 60,
-                  🗓️: 60
-                ),
-                [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
-                  recordType: "remindersLists",
-                  parent: nil,
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  title: "",
-                  title🗓️: 0,
-                  🗓️: 0
-                )
-              ]
-            ),
-            sharedCloudDatabase: MockCloudDatabase(
-              databaseScope: .shared,
-              storage: []
-            )
+          MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                recordType: "reminders",
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                isCompleted: 0,
+                isCompleted🗓️: 0,
+                remindersListID: 1,
+                remindersListID🗓️: 0,
+                title: "Get milk",
+                title🗓️: 60,
+                🗓️: 60
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                title: "",
+                title🗓️: 0,
+                🗓️: 0
+              )
+            ]
           )
           """
         }
@@ -494,7 +443,7 @@
         }()
 
         try await withDependencies {
-          $0.currentTime.now += 60
+          $0.currentTime.now = 60
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.title = "Get milk" }.execute(db)
@@ -503,44 +452,38 @@
         await modificationCallback.notify()
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-        assertInlineSnapshot(of: container, as: .customDump) {
+        assertInlineSnapshot(of: container.privateCloudDatabase, as: .customDump) {
           """
-          MockCloudContainer(
-            privateCloudDatabase: MockCloudDatabase(
-              databaseScope: .private,
-              storage: [
-                [0]: CKRecord(
-                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
-                  recordType: "reminders",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  isCompleted: 0,
-                  isCompleted🗓️: 0,
-                  remindersListID: 1,
-                  remindersListID🗓️: 0,
-                  title: "Get milk",
-                  title🗓️: 60,
-                  🗓️: 60
-                ),
-                [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
-                  recordType: "remindersLists",
-                  parent: nil,
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  title: "",
-                  title🗓️: 0,
-                  🗓️: 0
-                )
-              ]
-            ),
-            sharedCloudDatabase: MockCloudDatabase(
-              databaseScope: .shared,
-              storage: []
-            )
+          MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                recordType: "reminders",
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                isCompleted: 0,
+                isCompleted🗓️: 0,
+                remindersListID: 1,
+                remindersListID🗓️: 0,
+                title: "Get milk",
+                title🗓️: 60,
+                🗓️: 60
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                title: "",
+                title🗓️: 0,
+                🗓️: 0
+              )
+            ]
           )
           """
         }
@@ -563,7 +506,7 @@
         }()
 
         try await withDependencies {
-          $0.currentTime.now += 60
+          $0.currentTime.now = 60
         } operation: {
           try await userDatabase.userWrite { db in
             try Reminder.find(1).update { $0.title = "Get milk" }.execute(db)
@@ -573,44 +516,38 @@
         await modificationCallback.notify()
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-        assertInlineSnapshot(of: container, as: .customDump) {
+        assertInlineSnapshot(of: container.privateCloudDatabase, as: .customDump) {
           """
-          MockCloudContainer(
-            privateCloudDatabase: MockCloudDatabase(
-              databaseScope: .private,
-              storage: [
-                [0]: CKRecord(
-                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
-                  recordType: "reminders",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  isCompleted: 0,
-                  isCompleted🗓️: 0,
-                  remindersListID: 1,
-                  remindersListID🗓️: 0,
-                  title: "Get milk",
-                  title🗓️: 60,
-                  🗓️: 60
-                ),
-                [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
-                  recordType: "remindersLists",
-                  parent: nil,
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  title: "",
-                  title🗓️: 0,
-                  🗓️: 0
-                )
-              ]
-            ),
-            sharedCloudDatabase: MockCloudDatabase(
-              databaseScope: .shared,
-              storage: []
-            )
+          MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                recordType: "reminders",
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                isCompleted: 0,
+                isCompleted🗓️: 0,
+                remindersListID: 1,
+                remindersListID🗓️: 0,
+                title: "Get milk",
+                title🗓️: 60,
+                🗓️: 60
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                title: "",
+                title🗓️: 0,
+                🗓️: 0
+              )
+            ]
           )
           """
         }
@@ -649,48 +586,42 @@
           try await syncEngine.processPendingRecordZoneChanges(scope: .private)
         }
 
-        assertInlineSnapshot(of: container, as: .customDump) {
+        assertInlineSnapshot(of: container.privateCloudDatabase, as: .customDump) {
           """
-          MockCloudContainer(
-            privateCloudDatabase: MockCloudDatabase(
-              databaseScope: .private,
-              storage: [
-                [0]: CKRecord(
-                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
-                  recordType: "reminders",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
-                  share: nil,
-                  dueDate: Date(1970-01-01T00:00:30.000Z),
-                  dueDate🗓️: 0,
-                  id: 1,
-                  id🗓️: 0,
-                  isCompleted: 0,
-                  isCompleted🗓️: 0,
-                  priority: 3,
-                  priority🗓️: 1,
-                  remindersListID: 1,
-                  remindersListID🗓️: 0,
-                  title: "",
-                  title🗓️: 0,
-                  🗓️: 1
-                ),
-                [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
-                  recordType: "remindersLists",
-                  parent: nil,
-                  share: nil,
-                  id: 1,
-                  id🗓️: 0,
-                  title: "Personal",
-                  title🗓️: 0,
-                  🗓️: 0
-                )
-              ]
-            ),
-            sharedCloudDatabase: MockCloudDatabase(
-              databaseScope: .shared,
-              storage: []
-            )
+          MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                recordType: "reminders",
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                share: nil,
+                dueDate: Date(1970-01-01T00:00:30.000Z),
+                dueDate🗓️: 0,
+                id: 1,
+                id🗓️: 0,
+                isCompleted: 0,
+                isCompleted🗓️: 0,
+                priority: 3,
+                priority🗓️: 1,
+                remindersListID: 1,
+                remindersListID🗓️: 0,
+                title: "",
+                title🗓️: 0,
+                🗓️: 1
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: nil,
+                id: 1,
+                id🗓️: 0,
+                title: "Personal",
+                title🗓️: 0,
+                🗓️: 0
+              )
+            ]
           )
           """
         }


### PR DESCRIPTION
This PR completes the test matrix for conflict scenarios between server and client versions by adding the last missing test case:

- `serverRecordEditedAfterClientAndProcessedBeforeClient()`
- `serverRecordEditedAfterClientAndProcessedAfterClient()` 🆕
- `serverRecordEditedBeforeClientAndProcessedBeforeClient()`
- `serverRecordEditedBeforeClientAndProcessedAfterClient()`

It also includes a few cosmetic changes to improve readability and naming consistency.

The main motivation for this PR is to provide a concrete reference for a follow-up issue about a flaw in the current “last edit wins” conflict resolution strategy. See #354.