### PR TITLE
Fix 'limitExceeded' errors related to FK constraint failures.

### DIFF
--- a/Examples/CloudKitDemo/CountersListFeature.swift
+++ b/Examples/CloudKitDemo/CountersListFeature.swift
@@ -33,20 +33,6 @@ struct CountersListView: View {
           }
         }
       }
-      ToolbarItem {
-        Button("💥") {
-          withErrorReporting {
-            try database.write { db in
-              for index in 1...1000 {
-                try Counter.insert {
-                  Counter.Draft(count: index)
-                }
-                .execute(db)
-              }
-            }
-          }
-        }
-      }
     }
   }
 

--- a/Examples/CloudKitDemo/CountersListFeature.swift
+++ b/Examples/CloudKitDemo/CountersListFeature.swift
@@ -33,6 +33,20 @@ struct CountersListView: View {
           }
         }
       }
+      ToolbarItem {
+        Button("💥") {
+          withErrorReporting {
+            try database.write { db in
+              for index in 1...1000 {
+                try Counter.insert {
+                  Counter.Draft(count: index)
+                }
+                .execute(db)
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/Sources/SQLiteData/CloudKit/Internal/MockCloudDatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockCloudDatabase.swift
@@ -65,9 +65,7 @@
       else { throw ckError(forAccountStatus: accountStatus) }
 
       guard ids.count < 200
-      else {
-        throw CKError(.limitExceeded)
-      }
+      else { throw CKError(.limitExceeded) }
 
       var results: [CKRecord.ID: Result<CKRecord, any Error>] = [:]
       for id in ids {
@@ -88,6 +86,11 @@
       let accountStatus = container.accountStatus()
       guard accountStatus == .available
       else { throw ckError(forAccountStatus: accountStatus) }
+
+      guard (recordsToSave.count + recordIDsToDelete.count) < 200
+      else {
+        throw CKError(.limitExceeded)
+      }
 
       return storage.withValue { storage in
         let previousStorage = storage

--- a/Sources/SQLiteData/CloudKit/Internal/MockCloudDatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockCloudDatabase.swift
@@ -64,6 +64,11 @@
       guard accountStatus == .available
       else { throw ckError(forAccountStatus: accountStatus) }
 
+      guard ids.count < 200
+      else {
+        throw CKError(.limitExceeded)
+      }
+
       var results: [CKRecord.ID: Result<CKRecord, any Error>] = [:]
       for id in ids {
         results[id] = Result { try record(for: id) }

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -1523,8 +1523,8 @@
 
       let modifications = (modifications + unsyncedRecords).sorted { lhs, rhs in
         topologicallyAscending(
-          lhsTableName: lhs.recordID.tableName,
-          rhsTableName: rhs.recordID.tableName,
+          lhsTableName: lhs.recordType,
+          rhsTableName: rhs.recordType,
           rootFirst: true
         )
       }

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -1501,10 +1501,10 @@
           }
           var unsyncedRecords: [CKRecord] = []
           for batch in 0...batchCount {
-            let recordIDs = orderedUnsyncedRecordIDs
+            let recordIDsBatch = orderedUnsyncedRecordIDs
               .dropFirst(batch * batchSize)
               .prefix(batchSize)
-            let results = try await syncEngine.database.records(for: Array(recordIDs))
+            let results = try await syncEngine.database.records(for: Array(recordIDsBatch))
             for (recordID, result) in results {
               switch result {
               case .success(let record):

--- a/Tests/SQLiteDataTests/CloudKitTests/FetchRecordZoneChangesTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/FetchRecordZoneChangesTests.swift
@@ -739,6 +739,12 @@
         }
         #expect(error?.message == SyncEngine.invalidRecordNameError)
       }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func syncInvalidRecordID() async throws {
+        let record = CKRecord(recordType: "foo", recordID: CKRecord.ID(recordName: "bar"))
+        try await syncEngine.modifyRecords(scope: .private, saving: [record]).notify()
+      }
     }
   }
 #endif

--- a/Tests/SQLiteDataTests/CloudKitTests/ForeignKeyConstraintTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ForeignKeyConstraintTests.swift
@@ -891,8 +891,7 @@
           saving: [remindersListRecord]
         )
 
-        let reminderCount = 500
-        let reminderRecords = (1...reminderCount).map { index in
+        let reminderRecords = (1...500).map { index in
           let reminderRecord = CKRecord(
             recordType: Reminder.tableName,
             recordID: Reminder.recordID(for: index)
@@ -909,14 +908,29 @@
 
         try await syncEngine.modifyRecords(
           scope: .private,
-          saving: reminderRecords
-        )
-        .notify()
+          saving: Array(reminderRecords[0...100])
+        ).notify()
+        try await syncEngine.modifyRecords(
+          scope: .private,
+          saving: Array(reminderRecords[101...200])
+        ).notify()
+        try await syncEngine.modifyRecords(
+          scope: .private,
+          saving: Array(reminderRecords[201...300])
+        ).notify()
+        try await syncEngine.modifyRecords(
+          scope: .private,
+          saving: Array(reminderRecords[301...400])
+        ).notify()
+        try await syncEngine.modifyRecords(
+          scope: .private,
+          saving: Array(reminderRecords[401...499])
+        ).notify()
         await remindersListModification.notify()
 
         try await userDatabase.read { db in
           try #expect(RemindersList.fetchCount(db) == 1)
-          try #expect(Reminder.fetchCount(db) == reminderCount)
+          try #expect(Reminder.fetchCount(db) == 500)
         }
       }
     }

--- a/Tests/SQLiteDataTests/CloudKitTests/ForeignKeyConstraintTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ForeignKeyConstraintTests.swift
@@ -870,7 +870,13 @@
         }
       }
 
-      // When downloading
+      /*
+       * Create a parent record in CloudKit database but do not sync to client.
+       * Create many child records in CloudKit database and **do** sync to client.
+       * Sync parent record to client.
+       * => Cached unsaved child records should be batched so as to not run into 'limitExceeded'
+            errors
+       */
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func batchAssociations() async throws {
 

--- a/Tests/SQLiteDataTests/CloudKitTests/TopologicalTableSortingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/TopologicalTableSortingTests.swift
@@ -9,7 +9,20 @@
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func tablesByOrder() async throws {
         #expect(
-          syncEngine.tablesByOrder == ["remindersListPrivates": 11, "childWithOnDeleteSetNulls": 6, "reminders": 1, "modelAs": 8, "remindersLists": 0, "reminderTags": 4, "modelBs": 9, "parents": 5, "childWithOnDeleteSetDefaults": 7, "modelCs": 10, "remindersListAssets": 2, "tags": 3]
+          syncEngine.tablesByOrder == [
+            "remindersLists": 0,
+            "reminders": 1,
+            "remindersListAssets": 2,
+            "tags": 3,
+            "reminderTags": 4,
+            "parents": 5,
+            "childWithOnDeleteSetNulls": 6,
+            "childWithOnDeleteSetDefaults": 7,
+            "modelAs": 8,
+            "modelBs": 9,
+            "modelCs": 10,
+            "remindersListPrivates": 11,
+          ]
         )
       }
     }

--- a/Tests/SQLiteDataTests/CloudKitTests/TopologicalTableSortingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/TopologicalTableSortingTests.swift
@@ -1,0 +1,17 @@
+#if canImport(CloudKit)
+  import CloudKit
+  import SQLiteData
+  import Testing
+
+  extension BaseCloudKitTests {
+    @MainActor
+    final class TopologicalTableSortingTests: BaseCloudKitTests, @unchecked Sendable {
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func tablesByOrder() async throws {
+        #expect(
+          syncEngine.tablesByOrder == ["remindersListPrivates": 11, "childWithOnDeleteSetNulls": 6, "reminders": 1, "modelAs": 8, "remindersLists": 0, "reminderTags": 4, "modelBs": 9, "parents": 5, "childWithOnDeleteSetDefaults": 7, "modelCs": 10, "remindersListAssets": 2, "tags": 3]
+        )
+      }
+    }
+  }
+#endif


### PR DESCRIPTION
Right now it is possible to run into a `limitExceeded` error when downloading lots of data (such as fresh install) when there are associations that have lots of data. Those associations can only sync when their parent record is available, and if the parent is not available the record ID is cached to be tried later. The problem is that when the record is tried later we load the freshest data from the server via [records(for:)](https://github.com/pointfreeco/sqlite-data/blob/df360b234eec719360b1fa7912efeff54d6eee8e/Sources/SQLiteData/CloudKit/SyncEngine.swift#L1493), and _that_ API must be batched if fetching lots of records.

This PR implements that batching logic and updates the mock cloud database to reject fetching/sending data if there is too much data.

Fixes #333 / #334 