### PR TITLE
Avoid overwriting local db column values in cases were `CKRecord` has no value.

### DIFF
--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -2046,7 +2046,7 @@
       if columnNamesForUpdate.isEmpty {
           query.append(") ON CONFLICT(\(quote: T.primaryKey.name)) DO NOTHING ")
       } else {
-          query.append(") ON CONFLICT(\(quote: T.primaryKey.name)) DO UPDATE SET ")
+          query.append(") ON CONFLICT(\(quote: T.primaryKey.name)) DO UPDATE SET")
           query.append(" ")
           query.append(
             columnNamesForUpdate
@@ -2056,15 +2056,15 @@
                   if data == nil {
                     reportIssue("Asset data not found on disk")
                   }
-                  return "\(quote: columnName) = \(data?.queryFragment ?? #""excluded".\#(quote: columnName)"#))"
+                  return "\(quote: columnName) = \(data?.queryFragment ?? #""excluded".\#(quote: columnName)"#)"
                 } else {
                   return """
                     \(quote: columnName) = \
-                    \(record.encryptedValues[columnName]?.queryFragment ?? #""excluded".\#(quote: columnName)"#))
+                    \(record.encryptedValues[columnName]?.queryFragment ?? #""excluded".\#(quote: columnName)"#)
                     """
                 }
               }
-              .joined(separator: ",")
+              .joined(separator: ", ")
           )
       }
       

--- a/Tests/SQLiteDataTests/Internal/Schema.swift
+++ b/Tests/SQLiteDataTests/Internal/Schema.swift
@@ -77,7 +77,8 @@ import SQLiteData
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
 func database(
   containerIdentifier: String,
-  attachMetadatabase: Bool
+  attachMetadatabase: Bool,
+  url databaseURL: URL? = nil
 ) throws -> DatabasePool {
   var configuration = Configuration()
   configuration.prepareDatabase { db in
@@ -88,8 +89,11 @@ func database(
     //   print($0.expandedDescription)
     // }
   }
-  let url = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).sqlite")
+  let url = databaseURL ?? URL.temporaryDirectory.appending(path: "\(UUID().uuidString).sqlite")
   let database = try DatabasePool(path: url.path(), configuration: configuration)
+  guard databaseURL == nil else {
+    return database
+  }
   try database.write { db in
     try #sql(
       """

--- a/Tests/SQLiteDataTests/MigrationTests.swift
+++ b/Tests/SQLiteDataTests/MigrationTests.swift
@@ -33,7 +33,176 @@ import Testing
   }
 }
 
+
 @available(iOS 15, *)
 @Table private struct Model {
   var date: Date
 }
+
+
+#if canImport(CloudKit)
+  @available(iOS 15, *)
+  @Table private struct User: Identifiable {
+    var id: UUID
+    var name: String
+  }
+
+  @Table("users") private struct UpdatedUser: Identifiable {
+    var id: UUID
+    var name: String
+    var honorific: String?
+  }
+
+  import CloudKit
+  import ConcurrencyExtras
+  import CustomDump
+  import InlineSnapshotTesting
+  import OrderedCollections
+  import SQLiteData
+  import SQLiteDataTestSupport
+  import SnapshotTestingCustomDump
+  import Testing
+
+  @MainActor
+  @Suite
+  final class MigrationSyncEngineTests {
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    
+    private let _container: any Sendable
+
+    var container: MockCloudContainer {
+      _container as! MockCloudContainer
+    }
+    
+    let testContainerIdentifier: String
+    let databaseURL: URL
+    
+    func userDatabase() throws -> UserDatabase {
+      UserDatabase(
+        database: try SQLiteDataTests.database(
+          containerIdentifier: testContainerIdentifier,
+          attachMetadatabase: false,
+          url: databaseURL
+        )
+      )
+    }
+
+    
+    init() async throws {
+      testContainerIdentifier = "iCloud.co.pointfree.Testing.\(UUID())"
+      databaseURL = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).sqlite")
+      
+      let privateDatabase = MockCloudDatabase(databaseScope: .private)
+      let sharedDatabase = MockCloudDatabase(databaseScope: .shared)
+      let container = MockCloudContainer(
+        accountStatus: _AccountStatusScope.accountStatus,
+        containerIdentifier: testContainerIdentifier,
+        privateCloudDatabase: privateDatabase,
+        sharedCloudDatabase: sharedDatabase
+      )
+      _container = container
+      privateDatabase.set(container: container)
+      sharedDatabase.set(container: container)
+    }
+    
+    @available(iOS 15, *)
+    @Test func handleDataMigration() async throws {
+      let userDatabase = try userDatabase()
+      // Do first migration
+      try await userDatabase.userWrite { db in
+        try #sql(
+          """
+          CREATE TABLE "users" (
+            "id" TEXT PRIMARY KEY NOT NULL ON CONFLICT REPLACE DEFAULT (uuid()),
+            "name" TEXT NOT NULL
+          )
+          """
+        )
+        .execute(db)
+      }
+      
+      var syncEngine: Optional<SyncEngine> = try await SyncEngine(
+        container: container,
+        userDatabase: userDatabase,
+        delegate: nil,
+        privateTables: User.self,
+        startImmediately: true
+      )
+      
+      let currentUserRecordID = CKRecord.ID(
+        recordName: "currentUser"
+      )
+      
+      await syncEngine!.handleEvent(
+        .accountChange(changeType: .signIn(currentUser: currentUserRecordID)),
+        syncEngine: syncEngine!.private
+      )
+      await syncEngine!.handleEvent(
+        .accountChange(changeType: .signIn(currentUser: currentUserRecordID)),
+        syncEngine: syncEngine!.shared
+      )
+      try await syncEngine!.processPendingDatabaseChanges(scope: .private)
+      
+      try await userDatabase.userWrite { db in
+        try User.insert {
+          User.Draft(name: "Bob")
+          User.Draft(name: "Alice")
+          User.Draft(name: "Alfred")
+        }.execute(db)
+      }
+      
+      // Do we need to await something here?
+      try await Task.sleep(for: .seconds(1))
+      try await syncEngine?.processPendingRecordZoneChanges(scope: .private)
+      syncEngine?.stop()
+      syncEngine = nil
+      
+      try userDatabase.database.close()
+      
+      let newDbConnection = try self.userDatabase()
+      
+      try await newDbConnection.userWrite { db in
+        try #sql(
+          """
+          ALTER TABLE "users"
+          ADD COLUMN "honorific" TEXT
+          """
+        )
+        .execute(db)
+        
+        let existingUsers = try UpdatedUser.all.fetchAll(db)
+        for user in existingUsers {
+          switch user.name.lowercased() {
+          case "bob":
+            try UpdatedUser.find(user.id).update {
+              $0.honorific = "Mr"
+            }.execute(db)
+          case "alice":
+            try UpdatedUser.find(user.id).update {
+              $0.honorific = "Ms"
+            }.execute(db)
+          default:
+            continue
+          }
+        }
+      }
+      
+      syncEngine = try await SyncEngine(
+        container: container,
+        userDatabase: newDbConnection,
+        delegate: nil,
+        privateTables: UpdatedUser.self,
+        startImmediately: true
+      )
+      
+      let bob = try await newDbConnection.read { db in
+        try UpdatedUser.all.where { $0.name.eq("Bob") }.fetchOne(db)
+      }
+      #expect(bob?.honorific == "Mr")
+    }
+    
+   
+    
+    // Do we need to wait here...
+  }
+#endif


### PR DESCRIPTION
it appears that if a db record is created (or modified) while the sync engine is not active (such as running a data migration at the same time as the db migration as is common) then when the sync engine starts the `SyncEngine.updateLocalFromSchemaChange` method is called and this in turn courses the `updateQuery` method and here any new columns you may have added are included, however since there is no entry in `CKRecord` for these columns the query is constructed to set this value to `NULL` on conflict.   

This change filters the fields used in the `ON CONFLICT` to only update fields were the `CKRecord` has some values.  I wander if an additional change that might be worth having here is a call that updates the local CKRecord to keep it in sync with the local db so that data migrations are then correctly tracked? 

I have also updated the method that is called when a cloud sync comes in over the wire to ensure that it also does not end up setting columns to NULL within the update block in cases were there is an existing value and the `CKRecord` has not indication of that column existing at all. 

This change assumes that `CKRecord` always persists null against a columnName rather than skipping the column.  I believe this is the correct assumption but maybe for columns with attachments it is not?  