### PR TITLE
Fetch current record before sharing.

### DIFF
--- a/Sources/SQLiteData/CloudKit/Internal/MockCloudDatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockCloudDatabase.swift
@@ -189,6 +189,18 @@
               // TODO: This should merge copy's values to more accurately reflect reality
               storage[recordToSave.recordID.zoneID]?.records[recordToSave.recordID] = copy
               saveResults[recordToSave.recordID] = .success(copy)
+
+              // NB: "Touch" parent records when saving a child:
+              if let parent = recordToSave.parent,
+                // If the parent isn't also being saved in this batch.
+                !recordsToSave.contains(where: { $0.recordID == parent.recordID }),
+                // And if the parent is in the database.
+                let parentRecord = storage[parent.recordID.zoneID]?.records[parent.recordID]?.copy()
+                  as? CKRecord
+              {
+                parentRecord._recordChangeTag = UUID().uuidString
+                storage[parent.recordID.zoneID]?.records[parent.recordID] = parentRecord
+              }
             }
 
             switch (existingRecord, recordToSave._recordChangeTag) {

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -847,6 +847,86 @@
         }
       }
 
+      /*
+       * Create parent record and synchronize.
+       * Create child record and synchronize.
+       * Share parent record.
+       */
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func createParentThenChildThenShare() async throws {
+        let remindersList = RemindersList(id: 1, title: "Personal")
+        try await userDatabase.userWrite { db in
+          try db.seed { remindersList }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        let reminder = Reminder(id: 1, title: "Groceries", remindersListID: 1)
+        try await userDatabase.userWrite { db in
+          try db.seed { reminder }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        let _ = try await syncEngine.share(record: remindersList, configure: { _ in })
+
+        assertQuery(
+          SyncMetadata.select { ($0.share, $0.userModificationTime) },
+          database: syncEngine.metadatabase
+        ) {
+          """
+          ┌────────────────────────────────────────────────────────────────────────┬───┐
+          │ CKRecord(                                                              │ 0 │
+          │   recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__), │   │
+          │   recordType: "cloudkit.share",                                        │   │
+          │   parent: nil,                                                         │   │
+          │   share: nil                                                           │   │
+          │ )                                                                      │   │
+          ├────────────────────────────────────────────────────────────────────────┼───┤
+          │ nil                                                                    │ 0 │
+          └────────────────────────────────────────────────────────────────────────┴───┘
+          """
+        }
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__),
+                  recordType: "cloudkit.share",
+                  parent: nil,
+                  share: nil
+                ),
+                [1]: CKRecord(
+                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                  recordType: "reminders",
+                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                  share: nil,
+                  id: 1,
+                  isCompleted: 0,
+                  remindersListID: 1,
+                  title: "Groceries"
+                ),
+                [2]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__)),
+                  id: 1,
+                  title: "Personal"
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func shareTwice() async throws {
         let remindersList = RemindersList(id: 1, title: "Personal")

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -851,6 +851,7 @@
        * Create parent record and synchronize.
        * Create child record and synchronize.
        * Share parent record.
+       * See: https://github.com/pointfreeco/sqlite-data/pull/363
        */
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func createParentThenChildThenShare() async throws {

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -851,10 +851,10 @@
        * Create parent record and synchronize.
        * Create child record and synchronize.
        * Share parent record.
-       * See: https://github.com/pointfreeco/sqlite-data/pull/363
        */
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-      @Test func createParentThenChildThenShare() async throws {
+      @Test(.bug("https://github.com/pointfreeco/sqlite-data/pull/363"))
+      func createParentThenChildThenShare() async throws {
         let remindersList = RemindersList(id: 1, title: "Personal")
         try await userDatabase.userWrite { db in
           try db.seed { remindersList }


### PR DESCRIPTION
There's a "quirk" (maybe bug?) in CloudKit where saving a child record will cause iCloud to update the parent's `recordChangeTag` (this part is documented), but that update does not get sent to the `CKSyncEngine` (not documented, possible bug). This can cause us to have a stale `lastKnownServerRecord`, which can cause updates to the parent record to fail. Most of the time that is handled just fine by the conflict resolution mechanism in the library, but when sharing in particular we have to handle the situation more delicately. So now we make sure to fetch the freshest record from iCloud before sharing.