### PR TITLE
Fix for schema migration involving 'NOT NULL' columns.

### DIFF
--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -2005,11 +2005,11 @@
               if data == nil {
                 reportIssue("Asset data not found on disk")
               }
-              return "\(quote: columnName) = \(data?.queryFragment ?? "NULL")"
+              return "\(quote: columnName) = \(data?.queryFragment ?? #""excluded".\#(quote: columnName)"#)"
             } else {
               return """
                 \(quote: columnName) = \
-                \(record.encryptedValues[columnName]?.queryFragment ?? "NULL")
+                \(record.encryptedValues[columnName]?.queryFragment ?? #""excluded".\#(quote: columnName)"#)
                 """
             }
           }

--- a/Tests/SQLiteDataTests/CloudKitTests/SchemaChangeTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SchemaChangeTests.swift
@@ -106,6 +106,12 @@
         }
       }
 
+      /*
+       * Old schema creates record and synchronizes to iCloud.
+       * Schema is migrated to add a "NOT NULL" column.
+       * New sync engine is launched.
+       => Sync starts without emitting an error.
+       */
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func addColumn_OldRecordsSyncToNewSchema() async throws {
         let remindersList = RemindersList(id: 1, title: "Personal")
@@ -128,7 +134,8 @@
           .execute(db)
         }
 
-        let relaunchedSyncEngine = try await SyncEngine(
+        // NB: Sync engine should start without emitting issue.
+        _ = try await SyncEngine(
           container: syncEngine.container,
           userDatabase: syncEngine.userDatabase,
           tables: syncEngine.tables
@@ -139,7 +146,6 @@
             ],
           privateTables: syncEngine.privateTables
         )
-        defer { _ = relaunchedSyncEngine }
       }
 
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)


### PR DESCRIPTION
We got a report of a "NOT NULL" constraint failure that can happen after migrating a schema to add a "NOT NULL" column. We intend for that to be totally support, we just had a bug in our upsert query.