### PR TITLE
Three-way merge model for built-in conflict resolution for CloudKit sync

### DIFF
--- a/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
@@ -130,7 +130,7 @@
 
   @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
   extension CKRecordKeyValueSetting {
-    fileprivate subscript(at key: String) -> Int64 {
+    package subscript(at key: String) -> Int64 {
       get {
         self["\(CKRecord.userModificationTimeKey)_\(key)"] as? Int64 ?? -1
       }

--- a/Tests/SQLiteDataTests/CloudKitTests/ConflictResolutionPlayground.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ConflictResolutionPlayground.swift
@@ -3,7 +3,9 @@
   import CryptoKit
   import DependenciesTestSupport
   import Foundation
+  import InlineSnapshotTesting
   @testable import SQLiteData
+  import StructuredQueriesTestSupport
   import Testing
 
   struct RowVersion<T: PrimaryKeyedTable> {
@@ -493,6 +495,19 @@
       // - `QueryOutput`: `Set<String>` (the Swift type)
       // - `QueryBinding`: `.text(…)` (the JSON serialized representation)
       #expect(conflict.mergedValue(for: \.tags, policy: .set) == ["hobby", "photography", "tech"])
+    }
+    
+    @Test
+    func makeUpdateQuery_latestPolicy() {
+      let conflict = makeTestMergeConflict()
+      
+      assertInlineSnapshot(of: #sql(conflict.makeUpdateQuery()), as: .sql) {
+        """
+        UPDATE "mergeModels"
+        SET "field1" = 'foo', "field2" = 'bar', "field3" = 'baz', "field4" = 'baz', "field5" = 'bar', "field6" = 'bar', "field7" = 'bar'
+        WHERE ("mergeModels"."id") = ('00000000-0000-0000-0000-000000000000')
+        """
+      }
     }
   }
 #endif

--- a/Tests/SQLiteDataTests/CloudKitTests/ConflictResolutionPlayground.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ConflictResolutionPlayground.swift
@@ -196,6 +196,8 @@
   }
 
   extension FieldMergePolicy {
+    /// Last-edit-wins merge policy that picks the edited value with the newer modification
+    /// timestamp (ties favor the client).
     static var latest: Self {
       Self { _, client, server in
         server.modificationTime > client.modificationTime ? server.value : client.value
@@ -204,6 +206,8 @@
   }
 
   extension FieldMergePolicy where Value: BinaryInteger {
+    /// Counter merge policy that combines the independent increments and decrements from
+    /// both edited values.
     static var counter: Self {
       Self { ancestor, client, server in
         ancestor.value
@@ -214,6 +218,8 @@
   }
 
   extension FieldMergePolicy where Value: SetAlgebra, Value.Element: Equatable {
+    /// Set merge policy that preserves elements not deleted on either side and adds new elements
+    /// from either side.
     static var set: Self {
       Self { ancestor, client, server in
         let notDeleted = ancestor.value

--- a/Tests/SQLiteDataTests/CloudKitTests/ConflictResolutionPlayground.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ConflictResolutionPlayground.swift
@@ -6,23 +6,66 @@
 
   struct RowVersion<T: PrimaryKeyedTable> {
     let row: T
-    
+    private let modificationTimes: [PartialKeyPath<T>: Int64]
+
+    package init(
+      row: T,
+      modificationTimes: [PartialKeyPath<T>: Int64]
+    ) {
+      self.row = row
+      self.modificationTimes = modificationTimes
+    }
+
     init(
       clientRow row: T,
       userModificationTime: Int64,
       ancestorVersion: RowVersion<T>
     ) {
-      self.row = row
-      fatalError("Not implemented")
+      var modificationTimes: [PartialKeyPath<T>: Int64] = [:]
+      for column in T.TableColumns.writableColumns {
+        func open<Root, Value>(_ column: some WritableTableColumnExpression<Root, Value>) {
+          let keyPath = column.keyPath as! KeyPath<T, Value>
+
+          let clientValue = row[keyPath: keyPath]
+          let ancestorValue = ancestorVersion.row[keyPath: keyPath]
+
+          if areEqual(clientValue, ancestorValue) {
+            modificationTimes[keyPath] = ancestorVersion.modificationTime(for: keyPath)
+          } else {
+            modificationTimes[keyPath] = userModificationTime
+          }
+        }
+        open(column)
+      }
+      
+      self.init(
+        row: row,
+        modificationTimes: modificationTimes
+      )
     }
 
     init(from record: CKRecord) throws {
       fatalError("Not implemented")
     }
 
-    func modificationDate(for column: PartialKeyPath<T.TableColumns>) -> Int64 {
-      fatalError("Not implemented")
+    func modificationTime(for column: PartialKeyPath<T>) -> Int64 {
+      return modificationTimes[column] ?? -1
     }
+  }
+
+  private func areEqual(_ lhs: Any, _ rhs: Any) -> Bool {
+    guard
+      let lhs = lhs as? any Equatable,
+      let rhs = rhs as? any Equatable
+    else {
+      return false
+    }
+    
+    func open<E: Equatable>(_ lhs: E, _ rhs: Any) -> Bool {
+      guard let rhs = rhs as? E else { return false }
+      return lhs == rhs
+    }
+    return open(lhs, rhs)
   }
 
   struct MergeConflict<T: PrimaryKeyedTable> {
@@ -41,7 +84,7 @@
 
   @Table
   private struct Counter {
-    let id: Int
+    let id: UUID
     var title: String
     var count: Int
   }
@@ -49,7 +92,37 @@
   @Suite
   struct ConflictResolutionPlaygroundTests {
     @Test
-    func placeholder() {
+    func init_rowAndModificationTimes() {
+      let version = RowVersion(
+        row: Counter(id: UUID(0), title: "MyCounter", count: 0),
+        modificationTimes: [
+          \.title: 100,
+          \.count: 0
+        ]
+      )
+      
+      #expect(version.modificationTime(for: \.title) == 100)
+      #expect(version.modificationTime(for: \.count) == 0)
+    }
+
+    @Test
+    func init_clientRow() {
+      let ancestor = RowVersion(
+        row: Counter(id: UUID(0), title: "", count: 0),
+        modificationTimes: [
+          \.title: 50,
+          \.count: 50
+        ]
+      )
+
+      let client = RowVersion(
+        clientRow: Counter(id: UUID(0), title: "My Counter", count: 0),
+        userModificationTime: 100,
+        ancestorVersion: ancestor
+      )
+
+      #expect(client.modificationTime(for: \.title) == 100)
+      #expect(client.modificationTime(for: \.count) == 50)
     }
   }
 #endif

--- a/Tests/SQLiteDataTests/CloudKitTests/ConflictResolutionPlayground.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ConflictResolutionPlayground.swift
@@ -62,7 +62,7 @@
           modificationTime: server.modificationTime(for: keyPath)
         )
         
-        return policy.resolve(ancestorVersion, clientVersion, serverVersion)
+        return policy.merge(ancestorVersion, clientVersion, serverVersion)
       }
     }
     
@@ -188,7 +188,7 @@
   }
 
   struct FieldMergePolicy<Value> {
-    let resolve: (
+    let merge: (
       _ ancestor: FieldVersion<Value>,
       _ client: FieldVersion<Value>,
       _ server: FieldVersion<Value>

--- a/Tests/SQLiteDataTests/CloudKitTests/ConflictResolutionPlayground.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ConflictResolutionPlayground.swift
@@ -1,0 +1,55 @@
+#if canImport(CloudKit)
+  import CloudKit
+  import Foundation
+  import SQLiteData
+  import Testing
+
+  struct RowVersion<T: PrimaryKeyedTable> {
+    let row: T
+    
+    init(
+      clientRow row: T,
+      userModificationTime: Int64,
+      ancestorVersion: RowVersion<T>
+    ) {
+      self.row = row
+      fatalError("Not implemented")
+    }
+
+    init(from record: CKRecord) throws {
+      fatalError("Not implemented")
+    }
+
+    func modificationDate(for column: PartialKeyPath<T.TableColumns>) -> Int64 {
+      fatalError("Not implemented")
+    }
+  }
+
+  struct MergeConflict<T: PrimaryKeyedTable> {
+    let ancestor: RowVersion<T>
+    let client: RowVersion<T>
+    let server: RowVersion<T>
+  }
+
+  extension MergeConflict {
+    func mergedValue<V: Equatable>(
+      for keyPath: some KeyPath<T.TableColumns, V>
+    ) -> V {
+      fatalError("Not implemented")
+    }
+  }
+
+  @Table
+  private struct Counter {
+    let id: Int
+    var title: String
+    var count: Int
+  }
+
+  @Suite
+  struct ConflictResolutionPlaygroundTests {
+    @Test
+    func placeholder() {
+    }
+  }
+#endif

--- a/Tests/SQLiteDataTests/CloudKitTests/ConflictResolutionPlayground.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ConflictResolutionPlayground.swift
@@ -139,10 +139,12 @@
   }
 
   @Table
-  private struct Counter {
+  private struct Todo {
     let id: UUID
     var title: String
-    var count: Int
+    var isCompleted: Bool
+    @Column(as: Set<String>.JSONRepresentation.self)
+    var tags: Set<String> = []
   }
 
   @Table
@@ -162,35 +164,37 @@
     @Test
     func versionInit_rowAndModificationTimes() {
       let version = RowVersion(
-        row: Counter(id: UUID(0), title: "My Counter", count: 0),
+        row: Todo(id: UUID(0), title: "Buy milk", isCompleted: false),
         modificationTimes: [
           \.title: 100,
-          \.count: 0
+          \.isCompleted: 0,
+          \.tags: 0
         ]
       )
-      
+
       #expect(version.modificationTime(for: \.title) == 100)
-      #expect(version.modificationTime(for: \.count) == 0)
+      #expect(version.modificationTime(for: \.isCompleted) == 0)
     }
 
     @Test
     func versionInit_clientRow() {
       let ancestor = RowVersion(
-        row: Counter(id: UUID(0), title: "", count: 0),
+        row: Todo(id: UUID(0), title: "", isCompleted: false),
         modificationTimes: [
           \.title: 50,
-          \.count: 50
+          \.isCompleted: 50,
+          \.tags: 0
         ]
       )
 
       let client = RowVersion(
-        clientRow: Counter(id: UUID(0), title: "My Counter", count: 0),
+        clientRow: Todo(id: UUID(0), title: "Buy milk", isCompleted: false),
         userModificationTime: 100,
         ancestorVersion: ancestor
       )
 
       #expect(client.modificationTime(for: \.title) == 100)
-      #expect(client.modificationTime(for: \.count) == 50)
+      #expect(client.modificationTime(for: \.isCompleted) == 50)
     }
 
     /// Tests the field-wise last edit wins strategy with all seven merge scenarios.

--- a/Tests/SQLiteDataTests/CloudKitTests/ConflictResolutionPlayground.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ConflictResolutionPlayground.swift
@@ -281,5 +281,49 @@
       #expect(conflict.mergedValue(for: \.field6) == "bar")
       #expect(conflict.mergedValue(for: \.field7) == "bar")
     }
+    
+    @Test
+    func mergeConflict_customRepresentation() {
+      let ancestor = RowVersion(
+        row: Todo(
+          id: UUID(0),
+          title: "Task",
+          isCompleted: false,
+          tags: ["work"]
+        ),
+        modificationTimes: [\.tags: 100]
+      )
+      
+      let client = RowVersion(
+        row: Todo(
+          id: UUID(0),
+          title: "Task",
+          isCompleted: false,
+          tags: ["work", "urgent"]
+        ),
+        modificationTimes: [\.tags: 200]
+      )
+      
+      let server = RowVersion(
+        row: Todo(
+          id: UUID(0),
+          title: "Task",
+          isCompleted: false,
+          tags: ["work", "personal"]
+        ),
+        modificationTimes: [\.tags: 150]
+      )
+      
+      let conflict = MergeConflict(
+        ancestor: ancestor,
+        client: client,
+        server: server
+      )
+      
+      // - `QueryValue`: `Set<String>.JSONRepresentation` (the storage type)
+      // - `QueryOutput`: `Set<String>` (the Swift type)
+      // - `QueryBinding`: `.text(…)` (the JSON serialized representation)
+      #expect(conflict.mergedValue(for: \.tags) == ["work", "urgent"])
+    }
   }
 #endif


### PR DESCRIPTION
This PR explores how the current conflict resolution based on the “field-wise last edit wins” strategy can be expressed as a proper three-way merge model, as described in [this document](https://github.com/structuredpath/sqlite-data-sync-notes/blob/main/BuiltInConflictResolutionModel.md). It is the first step towards a broader effort to support customizable conflict resolution, originally pitched in #272.

With minor exceptions, this PR focuses on **Stage 1** with the goal of refining the existing conflict resolution behavior into a clearer and more precise implementation and fixing a few correctness issues along the way. No public API changes are introduced and the current behavior remains effectively the same.

The prototype also lays the groundwork for **Stage 2**, where user-defined per-field merge policies could be added with minimal changes to the internals. The most promising direction here seems to be a declarative configuration via `@SyncedTable` / `@SyncedField` (as discussed in #352), since macros can express per-field policies ergonomically and exhaustively. This would, however, require some additional infrastructure work around macro expansion.

The prototype is not yet integrated into the CloudKit sync pipeline. It is intentionally kept in a standalone file with tests to validate the model and discuss details before further integration work.

## Scope of this PR

This PR extracts conflict resolution into a small, self-contained model that performs a proper three-way merge between ancestor, client, and server versions of a row.

The prototype introduces a few supporting types to model conflicts explicitly:
- `MergeConflict<Table>` bundles the ancestor, client, and server row versions for three-way merge.
- `RowVersion<Table>` wraps a decoded row together with per-field modification timestamps.
- `FieldVersion<Value>` represents a single field’s value paired with its modification timestamp.
- `FieldMergePolicy<Value>` provides an extensible mechanism for merging conflicting field values.

When a conflict is detected, a `MergeConflict` is constructed with three concrete row versions:
- _ancestor_: Decoded from the last-known server record represented as `CKRecord`
- _client_: Created from the current database row, the row-level `userModificationTime`, and the ancestor version (to obtain modification timestamps for unchanged fields)
- _server_: Decoded from the incoming server record represented as `CKRecord`

The choice to use value types is primarily for ease of reasoning and testing. It also leaves open the possibility of making some of these types public in **Stage 2**, so that users could resolve conflicts against Swift types rather than raw record data. Supporting custom per-field merge policies would at minimum require exposing `FieldVersion` and `FieldMergePolicy`, and potentially `RowVersion` as well (see section on custom merge method below).

Since table types cannot currently be constructed dynamically (other than via `T.init(decoder:)` & `QueryDecoder`), the prototype decodes rows from `CKRecord` instances by performing a SQL `SELECT` query with literal values, leveraging the existing decoding infrastructure.

When a `MergeConflict` is available, resolution proceeds by iterating over all fields and performing equality checks. Equality is determined via `QueryBinding`, so field values do not need to conform to `Equatable`. Trivial cases such as _no change_ or _one-sided change_ are short-circuited. The field merge policy is consulted only when both the client and server diverge from the ancestor.

The prototype comes with an abstraction for per-field merge policies and includes three concrete implementations:
- `.latest`: Last edit wins, favoring the edited value with the newest modification timestamp.
- `.counter`: Combines independent increments and decrements in integer fields from both edited sides.
- `.set`: Merges set fields by preserving elements not deleted on either side and adding any new elements.

In **Stage 1**, only `.latest` is intended to be used, as it matches the current behavior in the library (but with clearer semantics). In particular, the merge logic avoids “reviving” ancestor values during conflict resolution, since `.latest` only compares edited client and server versions.

The additional policies serve primarily to show how the abstraction generalizes and what **Stage 2** could unlock. All policies are exercised in the tests for the `Post` type, where `.latest`, `.counter`, and `.set` are applied to different fields.

After resolving all fields, the merged values must be written back to the database. The prototype does this by generating an `UPDATE` statement that writes the merged field values directly into the existing row. No upsert is needed here, as a conflicting row is guaranteed to exist in the database.

Earlier drafts explored producing a full `Table` instance and then generating an `UPDATE` statement from it, but that path does not seem viable in the current design (see section on custom merge methods below).

For tests, there is a helper method that performs the whole roundtrip of inserting the client row, applying the merge update, fetching the resulting row, and asserting on its values.

## Integration

As mentioned above, the prototype isn’t wired to the CloudKit sync pipeline yet. If this model were to be integrated in **Stage 1**, it would mean expressing the existing “last edit wins” semantics through the three-way merge model. Concretely, this would require a few targeted changes in the conflict handling paths:

- Align conflict resolution behavior between production and test environments per [#356](https://github.com/pointfreeco/sqlite-data/issues/356) to form a consistent baseline for the three-way merge model.
- Ensure the last-known server record contains only confirmed server state and is never polluted with pending local changes, making it suitable to serve as the ancestor in a three-way merge. More on that in [this document](https://github.com/structuredpath/sqlite-data-sync-notes/blob/main/CurrentBehavior.md).
- Detect conflicts at the record level for both conflict-on-send and conflict-on-fetch scenarios, and handle them separately from non-conflict upserts, which should propagate server state directly without invoking merge logic. More on conflict detection in [this comment](https://github.com/pointfreeco/sqlite-data/discussions/272#discussioncomment-14975219).
- Invoke the `.latest` field merge policy only for fields that diverge from the ancestor on both sides. One-sided edits and unchanged fields should bypass the policy.
- Consequently, timestamp comparisons are only consulted for conflicting fields, and are skipped entirely for non-conflicting fields as well as regular upserts.

For **Stage 2**, where users could annotate individual fields with merge policies, a few additional pieces would be needed:

- Resolve the transition toward CloudKit-aware macros `@SyncedTable` / `@SyncedField` so that per-field merge policies can be specified declaratively. More on this in [#352](https://github.com/pointfreeco/sqlite-data/discussions/352).
- Ensure the specified per-field merge policies are surfaced to the conflict resolution logic. This could take the form of a lookup table of merge policies for each field or a generated merge function. See next section for more on that.
- Finalize the set of built-in merge policies the library ships with.

## Merge method returning `T`?

While [ideating on the API design initially](https://github.com/pointfreeco/sqlite-data/discussions/272#discussioncomment-15170263), the motivating idea was to express conflict resolution as a method that receives a `MergeConflict` containing the three row versions and returns a merged row instance of `T` (or `T.Draft`) to be written back to the database.

This approach turned out not to be viable in **Stage 1**, as there does not seem to be a way to dynamically construct a row instance by inspecting its columns and assigning values to fields, other than going through a database statement and the `T.init(decoder:)` initializer (as seen in `CKRecord` decoding)[^1]. For this reason, the prototype resolves conflicts by generating an `UPDATE` statement that writes merged field values directly to the existing row, without constructing a new row instance.

In **Stage 2**, with macros allowing users to specify per-field merge policies, the current approach of producing an `UPDATE` statement could be preserved. In that design, table types would expose the specified merge policies so that the conflict resolution logic can apply them field-by-field.

Alternatively, the macro could generate a merge function in its expansion, iterating over all fields, computing the merged values, and constructing a new row instance. To fully deliver on the original motivation, the library could even allow users to override this with a custom declaration (e.g. via a `CustomMergeConflictResolvable` protocol).

This direction hasn’t been explored in depth, but opening up a custom merge function comes with some downsides. It competes with macro-defined merge policies and introduces opportunities to omit fields or fall back to default values by accident. The macro-generated path therefore seems more promising.

The only use case for a custom merge function that comes to mind is when multiple fields need to be considered together, e.g. `startDate` and `endDate` where `endDate` must always be greater than or equal to `startDate`. Such cases can be addressed by (a) grouping the data into a single structure and serializing it as JSON, or (b) installing a trigger that enforces the invariant before updating the row. Both approaches apply more generally, not only in the context of conflict resolution.

It is not entirely clear where **Stage 2** should ultimately land, but detecting conflicts at the row level while allowing the user to merge at the field level seems like a reasonable and pragmatic approach.

## Open topics

- Asset handling in the `CKRecord` → `RowVersion` decoding path. Asset-backed fields are routed through the prototype’s decoding path but are not exercised in tests yet.
- Conflicts without an ancestor. There are cases where no last-known server record is available and both client and server diverge, which becomes a two-way merge problem (reconciliation or [salvaging](https://drewmccormack.github.io/Forked/Forked/documentation/forked/mergeable/salvaging(from:))). For **Stage 1**, the logic is simple, but for **Stage 2** it is unclear whether there should be a dedicated hook in the `FieldMergePolicy` API for such cases.

[^1]:	Updating values on an existing instance, e.g. the client row, is not viable either, as this would require `WritableKeyPaths`. It is also perfectly fine for a conflicting field to be represented as a `let` property in Swift, since the value in the database can still be mutated regardless of mutability in the Swift type.