### PR TITLE
Add a test for what happens with outside records.

### DIFF
--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -38,7 +38,7 @@
     private let notificationsObserver = LockIsolated<(any NSObjectProtocol)?>(nil)
     private let activityCounts = LockIsolated(ActivityCounts())
     private let startTask = LockIsolated<Task<Void, Never>?>(nil)
-    #if canImport(DeveloperToolsSupport)
+    #if DEBUG && canImport(DeveloperToolsSupport)
       private let previewTimerTask = LockIsolated<Task<Void, Never>?>(nil)
     #endif
 
@@ -423,7 +423,7 @@
     /// You must start the sync engine again using ``start()`` to synchronize the changes.
     public func stop() {
       guard isRunning else { return }
-      #if canImport(DeveloperToolsSupport)
+      #if DEBUG && canImport(DeveloperToolsSupport)
         previewTimerTask.withValue {
           $0?.cancel()
           $0 = nil
@@ -503,7 +503,7 @@
         }
       )
 
-      #if canImport(DeveloperToolsSupport)
+      #if DEBUG && canImport(DeveloperToolsSupport)
         @Dependency(\.context) var context
         @Dependency(\.continuousClock) var clock
         if context == .preview {
@@ -1893,7 +1893,9 @@
     ) {
       withErrorReporting(.sqliteDataCloudKitFailure) {
         guard let recordPrimaryKey = serverRecord.recordID.recordPrimaryKey
-        else { return }
+        else {
+          return
+        }
 
         try SyncMetadata.insert {
           SyncMetadata(

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -1892,7 +1892,9 @@
       db: Database
     ) {
       withErrorReporting(.sqliteDataCloudKitFailure) {
-        guard let recordPrimaryKey = serverRecord.recordID.recordPrimaryKey
+        guard
+          let recordPrimaryKey = serverRecord.recordID.recordPrimaryKey,
+          serverRecord.encryptedValues[CKRecord.userModificationTimeKey] != nil
         else {
           return
         }

--- a/Tests/SQLiteDataTests/CloudKitTests/CloudKitTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/CloudKitTests.swift
@@ -860,7 +860,7 @@
         }
 
         let record = try syncEngine.private.database.record(for: ModelA.recordID(for: 1))
-        record.encryptedValues["isEven"] = false
+        record.setValue(false, forKey: "isEven", at: 0)
         try await syncEngine.modifyRecords(scope: .private, saving: [record]).notify()
 
         assertInlineSnapshot(of: container, as: .customDump) {

--- a/Tests/SQLiteDataTests/CloudKitTests/FetchRecordZoneChangesTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/FetchRecordZoneChangesTests.swift
@@ -405,7 +405,7 @@
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func receiveRecord_SingleFieldPrimaryKey() async throws {
         let tagRecord = CKRecord(recordType: "tags", recordID: Tag.recordID(for: "weekend"))
-        tagRecord.encryptedValues["title"] = "weekend"
+        tagRecord.setValue("weekend", forKey: "title", at: 0)
         try await syncEngine.modifyRecords(scope: .private, saving: [tagRecord]).notify()
 
         try await userDatabase.read { db in
@@ -508,7 +508,7 @@
           recordType: Tag.tableName,
           recordID: Tag.recordID(for: "tag")
         )
-        tagRecord.encryptedValues["title"] = "tag"
+        tagRecord.setValue("tag", forKey: "title", at: 0)
         try await syncEngine.modifyRecords(scope: .private, saving: [tagRecord]).notify()
 
         assertQuery(Tag.all, database: userDatabase.database) {
@@ -583,7 +583,7 @@
           recordType: Tag.tableName,
           recordID: Tag.recordID(for: "tag")
         )
-        tagRecord.encryptedValues["title"] = "tag"
+        tagRecord.setValue("tag", forKey: "title", at: 0)
         let modifications = try syncEngine.modifyRecords(scope: .private, saving: [tagRecord])
 
         try await userDatabase.userWrite { db in

--- a/Tests/SQLiteDataTests/CloudKitTests/ForeignKeyConstraintTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ForeignKeyConstraintTests.swift
@@ -119,10 +119,13 @@
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func remoteCreatesRecordABC_localReceivesAC_remoteDeletesBC() async throws {
         let modelARecord = CKRecord(recordType: ModelA.tableName, recordID: ModelA.recordID(for: 1))
+        modelARecord.setValue(1, forKey: "id", at: 0)
         let modelBRecord = CKRecord(recordType: ModelB.tableName, recordID: ModelB.recordID(for: 1))
+        modelBRecord.setValue(1, forKey: "id", at: 0)
         modelBRecord.setValue(1, forKey: "modelAID", at: now)
         modelBRecord.parent = CKRecord.Reference(record: modelARecord, action: .none)
         let modelCRecord = CKRecord(recordType: ModelC.tableName, recordID: ModelC.recordID(for: 1))
+        modelCRecord.setValue(1, forKey: "id", at: 0)
         modelCRecord.setValue(1, forKey: "modelBID", at: now)
         modelCRecord.parent = CKRecord.Reference(record: modelBRecord, action: .none)
 
@@ -205,7 +208,8 @@
                   recordID: CKRecord.ID(1:modelAs/zone/__defaultOwner__),
                   recordType: "modelAs",
                   parent: nil,
-                  share: nil
+                  share: nil,
+                  id: 1
                 )
               ]
             ),

--- a/Tests/SQLiteDataTests/CloudKitTests/PreviewTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/PreviewTests.swift
@@ -1,4 +1,4 @@
-#if canImport(CloudKit)
+#if DEBUG && canImport(DeveloperToolsSupport) && canImport(CloudKit)
   import DependenciesTestSupport
   import InlineSnapshotTesting
   import SnapshotTestingCustomDump

--- a/Tests/SQLiteDataTests/CloudKitTests/SchemaChangeTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SchemaChangeTests.swift
@@ -720,12 +720,10 @@
           )
         )
         try await syncEngine.modifyRecords(scope: .private, saving: [customRecord]).notify()
-        withKnownIssue("We should have a way to not sync this record's metadata") {
-          assertQuery(SyncMetadata.all, database: syncEngine.metadatabase) {
-            """
-            (No results)
-            """
-          }
+        assertQuery(SyncMetadata.all, database: syncEngine.metadatabase) {
+          """
+          (No results)
+          """
         }
       }
     }

--- a/Tests/SQLiteDataTests/CloudKitTests/SchemaChangeTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SchemaChangeTests.swift
@@ -709,6 +709,25 @@
           """
         }
       }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func outsideRecordWithColon() async throws {
+        let customRecord = CKRecord(
+          recordType: "customRecord",
+          recordID: CKRecord.ID(
+            recordName: "1:customRecord",
+            zoneID: SyncEngine.defaultTestZone.zoneID
+          )
+        )
+        try await syncEngine.modifyRecords(scope: .private, saving: [customRecord]).notify()
+        withKnownIssue("We should have a way to not sync this record's metadata") {
+          assertQuery(SyncMetadata.all, database: syncEngine.metadatabase) {
+            """
+            (No results)
+            """
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This [discussion here](https://github.com/pointfreeco/sqlite-data/discussions/130#discussioncomment-15582365) got me thinking about what happens when unrecognized records are received by the sync engine that will _never_ be recognized. Right now it behaves how we want, but only incidentally because we skip any records whose record ID is not of the form "{id}:{type}". But if anyone created outside records with a colon in their ID, we would start saving that sync metadata even though we do not need to.

This PR just adds some test coverage on the current behavior, including an expected failure that would be nice to fix in the future.