### PR TITLE
Support for ancestor records in mock cloud database

### DIFF
--- a/Sources/SQLiteData/CloudKit/Internal/MockCloudContainer.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockCloudContainer.swift
@@ -48,9 +48,9 @@
         : sharedCloudDatabase
 
       let rootRecord: CKRecord? = database.state.withValue {
-        $0.storage[share.recordID.zoneID]?.records.values.first { entry in
-          entry.current.share?.recordID == share.recordID
-        }?.current
+        $0.storage[share.recordID.zoneID]?.entries.values.first { entry in
+          entry.record.share?.recordID == share.recordID
+        }?.record
       }
 
       return ShareMetadata(

--- a/Sources/SQLiteData/CloudKit/Internal/MockCloudContainer.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockCloudContainer.swift
@@ -48,9 +48,9 @@
         : sharedCloudDatabase
 
       let rootRecord: CKRecord? = database.state.withValue {
-        $0.storage[share.recordID.zoneID]?.records.values.first { record in
-          record.share?.recordID == share.recordID
-        }
+        $0.storage[share.recordID.zoneID]?.records.values.first { entry in
+          entry.current.share?.recordID == share.recordID
+        }?.current
       }
 
       return ShareMetadata(

--- a/Sources/SQLiteData/CloudKit/Internal/MockCloudDatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockCloudDatabase.swift
@@ -20,20 +20,19 @@
       }
 
       mutating func saveRecord(_ record: CKRecord) {
-        guard let existingEntry = storage[record.recordID.zoneID]?.entries[record.recordID]
+        guard var existingEntry = storage[record.recordID.zoneID]?.entries[record.recordID]
         else {
           storage[record.recordID.zoneID]?.entries[record.recordID] =
             RecordEntry(record: record, history: [:])
           return
         }
-        var updatedEntry = existingEntry
         if let existingRecordChangeTag = existingEntry.record._recordChangeTag,
           let existingRecordCopy = existingEntry.record.copy() as? CKRecord
         {
-          updatedEntry.history[existingRecordChangeTag] = existingRecordCopy
+          existingEntry.history[existingRecordChangeTag] = existingRecordCopy
         }
-        updatedEntry.record = record
-        storage[record.recordID.zoneID]?.entries[record.recordID] = updatedEntry
+        existingEntry.record = record
+        storage[record.recordID.zoneID]?.entries[record.recordID] = existingEntry
       }
     }
 

--- a/Sources/SQLiteData/CloudKit/Internal/MockCloudDatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockCloudDatabase.swift
@@ -26,10 +26,8 @@
             RecordEntry(record: record, history: [:])
           return
         }
-        if let existingRecordChangeTag = existingEntry.record._recordChangeTag,
-          let existingRecordCopy = existingEntry.record.copy() as? CKRecord
-        {
-          existingEntry.history[existingRecordChangeTag] = existingRecordCopy
+        if let existingRecordChangeTag = existingEntry.record._recordChangeTag {
+          existingEntry.history[existingRecordChangeTag] = existingEntry.record.copy() as? CKRecord
         }
         existingEntry.record = record
         storage[record.recordID.zoneID]?.entries[record.recordID] = existingEntry

--- a/Sources/SQLiteData/CloudKit/Internal/MockSyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockSyncEngine.swift
@@ -47,7 +47,7 @@
         zoneIDs.reduce(into: [CKRecord]()) {
           accum,
           zoneID in
-          accum += (state.storage[zoneID]?.records.values.map(\.current) ?? [])
+          accum += (state.storage[zoneID]?.entries.values.map(\.record) ?? [])
             .filter {
               precondition(
                 $0._recordChangeTag != nil,
@@ -201,7 +201,6 @@
   extension SyncEngine {
     package struct SendRecordsCallback {
       fileprivate let operation: @Sendable () async -> Void
-      @discardableResult
       package func receive() async {
         await operation()
       }

--- a/Sources/SQLiteData/CloudKit/Internal/MockSyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockSyncEngine.swift
@@ -47,7 +47,7 @@
         zoneIDs.reduce(into: [CKRecord]()) {
           accum,
           zoneID in
-          accum += ((state.storage[zoneID]?.records.values).map { Array($0) } ?? [])
+          accum += (state.storage[zoneID]?.records.values.map(\.current) ?? [])
             .filter {
               precondition(
                 $0._recordChangeTag != nil,

--- a/Tests/SQLiteDataTests/CloudKitTests/ForeignKeyConstraintTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ForeignKeyConstraintTests.swift
@@ -674,7 +674,7 @@
         assertInlineSnapshot(
           of: syncEngine.private.database.state.storage[syncEngine.defaultZone.zoneID]?.records[
             Reminder.recordID(for: 1)
-          ],
+          ]?.current,
           as: .customDump
         ) {
           """
@@ -769,7 +769,7 @@
         assertInlineSnapshot(
           of: syncEngine.private.database.state.storage[syncEngine.defaultZone.zoneID]?.records[
             Reminder.recordID(for: 1)
-          ],
+          ]?.current,
           as: .customDump
         ) {
           """

--- a/Tests/SQLiteDataTests/CloudKitTests/ForeignKeyConstraintTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ForeignKeyConstraintTests.swift
@@ -672,9 +672,9 @@
           """
         }
         assertInlineSnapshot(
-          of: syncEngine.private.database.state.storage[syncEngine.defaultZone.zoneID]?.records[
+          of: syncEngine.private.database.state.storage[syncEngine.defaultZone.zoneID]?.entries[
             Reminder.recordID(for: 1)
-          ]?.current,
+          ]?.record,
           as: .customDump
         ) {
           """
@@ -767,9 +767,9 @@
           """
         }
         assertInlineSnapshot(
-          of: syncEngine.private.database.state.storage[syncEngine.defaultZone.zoneID]?.records[
+          of: syncEngine.private.database.state.storage[syncEngine.defaultZone.zoneID]?.entries[
             Reminder.recordID(for: 1)
-          ]?.current,
+          ]?.record,
           as: .customDump
         ) {
           """

--- a/Tests/SQLiteDataTests/CloudKitTests/MockCloudDatabaseTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MockCloudDatabaseTests.swift
@@ -652,7 +652,7 @@
 
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func serverRecordChangedIncludesAncestorRecord() async throws {
-        let recordID = CKRecord.ID(recordName: "ancestor-test")
+        let recordID = CKRecord.ID(recordName: "1")
         let record = CKRecord(recordType: "A", recordID: recordID)
         record["value"] = 1
 

--- a/Tests/SQLiteDataTests/CloudKitTests/MockCloudDatabaseTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MockCloudDatabaseTests.swift
@@ -650,6 +650,38 @@
         }
       }
 
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func serverRecordChangedIncludesAncestorRecord() async throws {
+        let recordID = CKRecord.ID(recordName: "ancestor-test")
+        let record = CKRecord(recordType: "A", recordID: recordID)
+        record["value"] = 1
+
+        let (saveResults, _) = try syncEngine.private.database.modifyRecords(saving: [record])
+        #expect(saveResults.values.count(where: { (try? $0.get()) != nil }) == 1)
+
+        let clientRecord = try syncEngine.private.database.record(for: recordID)
+
+        let serverRecord = try syncEngine.private.database.record(for: recordID)
+        serverRecord["value"] = 2
+        _ = try syncEngine.private.database.modifyRecords(saving: [serverRecord])
+
+        clientRecord["value"] = 3
+        let (conflictResults, _) = try syncEngine.private.database.modifyRecords(
+          saving: [clientRecord]
+        )
+        let error = #expect(throws: CKError.self) {
+          try conflictResults[recordID]?.get()
+        }
+        #expect(error?.code == .serverRecordChanged)
+
+        let ancestor = error?.userInfo[CKRecordChangedErrorAncestorRecordKey] as? CKRecord
+        let server = error?.userInfo[CKRecordChangedErrorServerRecordKey] as? CKRecord
+        let client = error?.userInfo[CKRecordChangedErrorClientRecordKey] as? CKRecord
+        #expect(ancestor?["value"] as? Int == 1)
+        #expect(server?["value"] as? Int == 2)
+        #expect(client?["value"] as? Int == 3)
+      }
+
       @Test func limitExceeded_modifyRecords() async throws {
         let remindersListRecord = CKRecord(
           recordType: RemindersList.tableName,

--- a/Tests/SQLiteDataTests/CloudKitTests/MockCloudDatabaseTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MockCloudDatabaseTests.swift
@@ -682,6 +682,43 @@
         #expect(client?["value"] as? Int == 3)
       }
 
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func serverRecordChangedUsesChangeTagAncestor() async throws {
+        let recordID = CKRecord.ID(recordName: "1")
+        let record = CKRecord(recordType: "A", recordID: recordID)
+        record["value"] = 1
+
+        _ = try syncEngine.private.database.modifyRecords(saving: [record])
+
+        let clientRecord = try syncEngine.private.database.record(for: recordID)
+        let clientChangeTag = clientRecord._recordChangeTag
+
+        let serverRecordV2 = try syncEngine.private.database.record(for: recordID)
+        serverRecordV2["value"] = 2
+        _ = try syncEngine.private.database.modifyRecords(saving: [serverRecordV2])
+
+        let serverRecordV3 = try syncEngine.private.database.record(for: recordID)
+        serverRecordV3["value"] = 3
+        _ = try syncEngine.private.database.modifyRecords(saving: [serverRecordV3])
+
+        clientRecord["value"] = 99
+        let (conflictResults, _) = try syncEngine.private.database.modifyRecords(
+          saving: [clientRecord]
+        )
+        let error = #expect(throws: CKError.self) {
+          try conflictResults[recordID]?.get()
+        }
+        #expect(error?.code == .serverRecordChanged)
+
+        let ancestor = error?.userInfo[CKRecordChangedErrorAncestorRecordKey] as? CKRecord
+        let server = error?.userInfo[CKRecordChangedErrorServerRecordKey] as? CKRecord
+        let client = error?.userInfo[CKRecordChangedErrorClientRecordKey] as? CKRecord
+        #expect(ancestor?._recordChangeTag == clientChangeTag)
+        #expect(ancestor?["value"] as? Int == 1)
+        #expect(server?["value"] as? Int == 3)
+        #expect(client?["value"] as? Int == 99)
+      }
+
       @Test func limitExceeded_modifyRecords() async throws {
         let remindersListRecord = CKRecord(
           recordType: RemindersList.tableName,

--- a/Tests/SQLiteDataTests/Internal/CloudKit+CustomDump.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKit+CustomDump.swift
@@ -245,7 +245,7 @@
           "storage": state
             .value
             .storage
-            .flatMap { _, value in value.records.values.map(\.current) }
+            .flatMap { _, value in value.entries.values.map(\.record) }
             .sorted {
               ($0.recordType, $0.recordID.recordName) < ($1.recordType, $1.recordID.recordName)
             },

--- a/Tests/SQLiteDataTests/Internal/CloudKit+CustomDump.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKit+CustomDump.swift
@@ -245,7 +245,7 @@
           "storage": state
             .value
             .storage
-            .flatMap { _, value in value.records.values }
+            .flatMap { _, value in value.records.values.map(\.current) }
             .sorted {
               ($0.recordType, $0.recordID.recordName) < ($1.recordType, $1.recordID.recordName)
             },

--- a/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
@@ -77,7 +77,7 @@ extension SyncEngine {
     let recordsToDeleteByID = Dictionary(
       grouping: syncEngine.database.state.withValue { state in
         recordIDsToDelete.compactMap {
-          recordID in state.storage[recordID.zoneID]?.records[recordID]?.current
+          recordID in state.storage[recordID.zoneID]?.entries[recordID]?.record
         }
       },
       by: \.recordID

--- a/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
@@ -77,7 +77,7 @@ extension SyncEngine {
     let recordsToDeleteByID = Dictionary(
       grouping: syncEngine.database.state.withValue { state in
         recordIDsToDelete.compactMap {
-          recordID in state.storage[recordID.zoneID]?.records[recordID]
+          recordID in state.storage[recordID.zoneID]?.records[recordID]?.current
         }
       },
       by: \.recordID


### PR DESCRIPTION
If we wanna get into 3-way merging stuff we should have a representation of this in our mock cloud database.