### PR TITLE
Qualify _OptionalProtocol.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "93a8aa4937030b606de42f44b17870249f49af0b",
-        "version" : "1.3.4"
+        "revision" : "91be35a71a9890246f2a8f0dd1ee9bdf7157645d",
+        "version" : "1.4.0"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "a8b7c5e0ed33d8ab8887d1654d9b59f2cbad529b",
-        "version" : "1.18.7"
+        "revision" : "cc051f1c07a414cf36b3d45fc8d00f2a8086ca5e",
+        "version" : "1.18.8"
       }
     },
     {

--- a/Sources/SQLiteData/CloudKit/Internal/MockSyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockSyncEngine.swift
@@ -201,7 +201,6 @@
   extension SyncEngine {
     package struct SendRecordsCallback {
       fileprivate let operation: @Sendable () async -> Void
-      @discardableResult
       package func receive() async {
         await operation()
       }

--- a/Sources/SQLiteData/FetchOne.swift
+++ b/Sources/SQLiteData/FetchOne.swift
@@ -121,7 +121,7 @@ public struct FetchOne<Value: Sendable>: Sendable {
     database: (any DatabaseReader)? = nil
   )
   where
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     Value: StructuredQueriesCore.Table,
     Value.QueryOutput == Value
   {
@@ -230,7 +230,7 @@ public struct FetchOne<Value: Sendable>: Sendable {
     database: (any DatabaseReader)? = nil
   )
   where
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     Value == S.From.QueryOutput?,
     S.QueryValue == (),
     S.Joins == ()
@@ -255,9 +255,9 @@ public struct FetchOne<Value: Sendable>: Sendable {
     database: (any DatabaseReader)? = nil
   )
   where
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     S.QueryValue: QueryRepresentable,
-    S.QueryValue: _OptionalProtocol,
+    S.QueryValue: StructuredQueriesCore._OptionalProtocol,
     Value == S.QueryValue.QueryOutput
   {
     sharedReader = SharedReader(
@@ -283,7 +283,7 @@ public struct FetchOne<Value: Sendable>: Sendable {
   )
   where
     Value: QueryRepresentable,
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     Value.QueryOutput == Value
   {
     sharedReader = SharedReader(
@@ -368,7 +368,7 @@ public struct FetchOne<Value: Sendable>: Sendable {
     database: (any DatabaseReader)? = nil
   ) async throws -> FetchSubscription
   where
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     Value == S.From.QueryOutput?,
     S.QueryValue == (),
     S.Joins == ()
@@ -393,9 +393,9 @@ public struct FetchOne<Value: Sendable>: Sendable {
     database: (any DatabaseReader)? = nil
   ) async throws -> FetchSubscription
   where
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     S.QueryValue: QueryRepresentable,
-    S.QueryValue: _OptionalProtocol,
+    S.QueryValue: StructuredQueriesCore._OptionalProtocol,
     Value == S.QueryValue.QueryOutput
   {
     try await sharedReader.load(
@@ -418,7 +418,7 @@ public struct FetchOne<Value: Sendable>: Sendable {
   ) async throws -> FetchSubscription
   where
     Value: QueryRepresentable,
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     Value.QueryOutput == Value
   {
     try await sharedReader.load(
@@ -449,7 +449,7 @@ extension FetchOne {
     scheduler: some ValueObservationScheduler & Hashable
   )
   where
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     Value: _Selection,
     Value.QueryOutput == Value
   {
@@ -497,7 +497,7 @@ extension FetchOne {
     scheduler: some ValueObservationScheduler & Hashable
   )
   where
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     Value: StructuredQueriesCore.Table,
     Value.QueryOutput == Value
   {
@@ -637,7 +637,7 @@ extension FetchOne {
     scheduler: some ValueObservationScheduler & Hashable
   )
   where
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     Value == S.From.QueryOutput?,
     S.QueryValue == (),
     S.Joins == ()
@@ -669,9 +669,9 @@ extension FetchOne {
     scheduler: some ValueObservationScheduler & Hashable
   )
   where
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     S.QueryValue: QueryRepresentable,
-    S.QueryValue: _OptionalProtocol,
+    S.QueryValue: StructuredQueriesCore._OptionalProtocol,
     Value == S.QueryValue.QueryOutput
   {
     sharedReader = SharedReader(
@@ -701,7 +701,7 @@ extension FetchOne {
   )
   where
     Value: QueryRepresentable,
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     Value.QueryOutput == Value
   {
     sharedReader = SharedReader(
@@ -810,7 +810,7 @@ extension FetchOne {
     scheduler: some ValueObservationScheduler & Hashable
   ) async throws -> FetchSubscription
   where
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     Value == S.From.QueryOutput?,
     S.QueryValue == (),
     S.Joins == ()
@@ -842,9 +842,9 @@ extension FetchOne {
     scheduler: some ValueObservationScheduler & Hashable
   ) async throws -> FetchSubscription
   where
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     S.QueryValue: QueryRepresentable,
-    S.QueryValue: _OptionalProtocol,
+    S.QueryValue: StructuredQueriesCore._OptionalProtocol,
     Value == S.QueryValue.QueryOutput
   {
     try await sharedReader.load(
@@ -874,7 +874,7 @@ extension FetchOne {
   ) async throws -> FetchSubscription
   where
     Value: QueryRepresentable,
-    Value: _OptionalProtocol,
+    Value: StructuredQueriesCore._OptionalProtocol,
     Value.QueryOutput == Value
   {
     try await sharedReader.load(
@@ -926,7 +926,7 @@ extension FetchOne: Equatable where Value: Equatable {
       animation: Animation
     )
     where
-      Value: _OptionalProtocol,
+      Value: StructuredQueriesCore._OptionalProtocol,
       Value: _Selection,
       Value.QueryOutput == Value
     {
@@ -968,7 +968,7 @@ extension FetchOne: Equatable where Value: Equatable {
       animation: Animation
     )
     where
-      Value: _OptionalProtocol,
+      Value: StructuredQueriesCore._OptionalProtocol,
       Value: StructuredQueriesCore.Table,
       Value.QueryOutput == Value
     {
@@ -1103,7 +1103,7 @@ extension FetchOne: Equatable where Value: Equatable {
       animation: Animation
     )
     where
-      Value: _OptionalProtocol,
+      Value: StructuredQueriesCore._OptionalProtocol,
       Value == S.From.QueryOutput?,
       S.QueryValue == (),
       S.Joins == ()
@@ -1133,9 +1133,9 @@ extension FetchOne: Equatable where Value: Equatable {
       animation: Animation
     )
     where
-      Value: _OptionalProtocol,
+      Value: StructuredQueriesCore._OptionalProtocol,
       S.QueryValue: QueryRepresentable,
-      S.QueryValue: _OptionalProtocol,
+      S.QueryValue: StructuredQueriesCore._OptionalProtocol,
       Value == S.QueryValue.QueryOutput
     {
       self.init(
@@ -1164,7 +1164,7 @@ extension FetchOne: Equatable where Value: Equatable {
     )
     where
       Value: QueryRepresentable,
-      Value: _OptionalProtocol,
+      Value: StructuredQueriesCore._OptionalProtocol,
       Value.QueryOutput == Value
     {
       self.init(
@@ -1260,7 +1260,7 @@ extension FetchOne: Equatable where Value: Equatable {
       animation: Animation
     ) async throws -> FetchSubscription
     where
-      Value: _OptionalProtocol,
+      Value: StructuredQueriesCore._OptionalProtocol,
       Value == S.From.QueryOutput?,
       S.QueryValue == (),
       S.Joins == ()
@@ -1285,9 +1285,9 @@ extension FetchOne: Equatable where Value: Equatable {
       animation: Animation
     ) async throws -> FetchSubscription
     where
-      Value: _OptionalProtocol,
+      Value: StructuredQueriesCore._OptionalProtocol,
       S.QueryValue: QueryRepresentable,
-      S.QueryValue: _OptionalProtocol,
+      S.QueryValue: StructuredQueriesCore._OptionalProtocol,
       Value == S.QueryValue.QueryOutput
     {
       try await load(statement, database: database, scheduler: .animation(animation))
@@ -1311,7 +1311,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ) async throws -> FetchSubscription
     where
       Value: QueryRepresentable,
-      Value: _OptionalProtocol,
+      Value: StructuredQueriesCore._OptionalProtocol,
       Value.QueryOutput == Value
     {
       try await load(statement, database: database, scheduler: .animation(animation))
@@ -1344,8 +1344,8 @@ private struct FetchOneStatementOptionalValueRequest<Value: QueryRepresentable>:
 }
 
 private struct FetchOneStatementOptionalProtocolRequest<
-  Value: QueryRepresentable & _OptionalProtocol
->: StatementKeyRequest where Value.QueryOutput: _OptionalProtocol {
+  Value: QueryRepresentable & StructuredQueriesCore._OptionalProtocol
+>: StatementKeyRequest where Value.QueryOutput: StructuredQueriesCore._OptionalProtocol {
   let statement: SQLQueryExpression<Value>
   init(statement: some StructuredQueriesCore.Statement<Value>) {
     self.statement = SQLQueryExpression(statement)


### PR DESCRIPTION
We unfortunately have two `public protocol _OptionalProtocol`'s in our ecosystem, and with the changes in 1.5.1 it is possible for both to be visible at the same time. We should explore a more holistic approach, but for now we can explicitly qualify the usage.