### PR TITLE
Change write connection to read connection in attachMetadatabase

### DIFF
--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -2241,7 +2241,7 @@
         url.isInMemory
         ? try DatabaseQueue(path: path)
         : try DatabasePool(path: path)
-      _ = try database.write { db in
+      _ = try database.read { db in
         try #sql("SELECT 1").execute(db)
       }
       try #sql(


### PR DESCRIPTION
When connections are created inside GRDB `DatabasePool` instances, they are done lazily for both read and write connections.

At the moment, in `attachMetadatabase`, we are creating a short-lived `DatabasePool` and instantly using it for a write connection to execute `SELECT 1` in order to ensure the database exists and is functional.

The issue with this is that write connections require an exclusive lock on the file; usually, this is not an issue as when using a single `DatabasePool` instance, these are queued serially, but if one of these lazy connections is created at the same time as another `DatabasePool` instance has the database locked, we end up with a SQLite exception:

```
SQLite error 5: database is locked - while executing `BEGIN IMMEDIATE TRANSACTION`
```

This PR changes that connection to a read one, which, with WAL enabled databases, can leverage the shared memory file and "play nicely" with other threads.

Fixes #394 