### PR TITLE
Switch to grdb-flex dependency for multi-platform support and add platforms CI

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -1,0 +1,51 @@
+name: platforms ci
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - '*'
+  schedule:
+    - cron: '0 12 * * *'
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: "Test Swift Package Linux"
+        run: swift test
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Free Disk Space"
+        run: |
+          sudo rm -rf /opt/microsoft /opt/google /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL
+          docker image prune --all --force
+          docker builder prune -a
+      - uses: actions/checkout@v6
+      - name: "Test Swift Package Android"
+        uses: skiptools/swift-android-action@v2
+  ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: "Test Swift Package iOS"
+        run: xcodebuild test -sdk "iphonesimulator" -destination "platform=iOS Simulator,name=iPhone 17" -project GRDB.xcodeproj -scheme GRDB
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: "Test Swift Package macOS"
+        run: swift test
+  windows:
+    runs-on: windows-2022
+    steps:
+      - uses: compnerd/gha-setup-swift@main
+        with:
+          swift-version: swift-6.2.3-release
+          swift-build: 6.2.3-RELEASE
+      - uses: actions/checkout@v6
+      - name: "Test Swift Package Windows"
+        run: swift test
+

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -1,7 +1,7 @@
 name: platforms ci
 on:
   push:
-    branches: [ main ]
+    branches: [ * ]
   workflow_dispatch:
   pull_request:
     branches:

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -1,7 +1,7 @@
 name: platforms ci
 on:
   push:
-    branches: [ * ]
+    branches: '*'
   workflow_dispatch:
   pull_request:
     branches:

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "56d285438747111db875a66988e33e778b76a32eff70e5ac8e5f8622d0cc47ff",
+  "originHash" : "3e185480096846c15fc1227e25219b8af8c08d28987ad22e1223ee3ed586f5ec",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -11,12 +11,12 @@
       }
     },
     {
-      "identity" : "grdb.swift",
+      "identity" : "grdb-flex",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/groue/GRDB.swift",
+      "location" : "https://github.com/swift-everywhere/grdb-flex",
       "state" : {
-        "revision" : "aa0079aeb82a4bf00324561a40bffe68c6fe1c26",
-        "version" : "7.9.0"
+        "branch" : "custom-sqlite",
+        "revision" : "180c1fbaaef5bfee4b2ac1da35a97f281ff572c8"
       }
     },
     {
@@ -125,6 +125,15 @@
       "state" : {
         "revision" : "bf8d8c27f0f0c6d5e77bff0db76ab68f2050d15d",
         "version" : "1.18.9"
+      }
+    },
+    {
+      "identity" : "swift-sqlcipher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/skiptools/swift-sqlcipher",
+      "state" : {
+        "branch" : "sqlite-traits",
+        "revision" : "58193dbad7c9965072d47fadf1e61680c242eb2a"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
-    .package(url: "https://github.com/groue/GRDB.swift", from: "7.6.0"),
+    .package(url: "https://github.com/swift-everywhere/grdb-flex", branch: "custom-sqlite"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.9.0"),
@@ -51,7 +51,7 @@ let package = Package(
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "GRDB", package: "GRDB.swift"),
+        .product(name: "GRDB", package: "grdb-flex"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         .product(name: "OrderedCollections", package: "swift-collections"),
         .product(name: "Perception", package: "swift-perception"),


### PR DESCRIPTION
This experimental PR updates the GRDB dependency to instead use https://github.com/swift-everywhere/grdb-flex, which in turn is based on a multiplatform-capable and SQLCipher-supporting source build of SQLite at https://github.com/skiptools/swift-sqlcipher.