### PR TITLE
Fix metadatabase crash in tests on macOS 15

### DIFF
--- a/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
@@ -25,7 +25,12 @@
       throw InMemoryDatabase()
     }
 
-    let metadatabase = try DatabasePool(path: url.path(percentEncoded: false))
+    let metadatabase: any DatabaseWriter =
+      if url.isInMemory {
+        try DatabaseQueue(path: url.absoluteString)
+      } else {
+        try DatabasePool(path: url.path(percentEncoded: false))
+      }
     try migrate(metadatabase: metadatabase)
     return metadatabase
   }


### PR DESCRIPTION
This PR reverts a change made in #367, which dropped the `DatabaseQueue` path for in-memory database creation for the metadatabase, leading to a crash when running the test suite on macOS 15. See [this comment](https://github.com/pointfreeco/sqlite-data/pull/367#discussion_r2867236715) for more details.

The fix can be verified by running the test suite on macOS 15 (no longer configured in the CI).