### PR TITLE
Fix `MockCloudDatabase` record mutation in modify callback

### DIFF
--- a/Tests/SQLiteDataTests/CloudKitTests/MergeConflictTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MergeConflictTests.swift
@@ -357,6 +357,51 @@
           }
         }
         await modificationCallback.notify()
+        
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                  recordType: "reminders",
+                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                  share: nil,
+                  dueDate🗓️: 0,
+                  id: 1,
+                  id🗓️: 0,
+                  isCompleted: 0,
+                  isCompleted🗓️: 0,
+                  priority🗓️: 0,
+                  remindersListID: 1,
+                  remindersListID🗓️: 0,
+                  title: "Buy milk",
+                  title🗓️: 30,
+                  🗓️: 30
+                ),
+                [1]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  id🗓️: 0,
+                  title: "",
+                  title🗓️: 0,
+                  🗓️: 0
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+        
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
         assertInlineSnapshot(of: container, as: .customDump) {

--- a/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
@@ -93,7 +93,10 @@ extension SyncEngine {
     return ModifyRecordsCallback {
       await syncEngine.parentSyncEngine.handleEvent(
         .fetchedRecordZoneChanges(
-          modifications: saveResults.values.compactMap { try? $0.get() },
+          modifications: saveResults.values.compactMap {
+            guard let record = try? $0.get() else { return nil }
+            return record.copy() as? CKRecord
+          },
           deletions: deleteResults.compactMap { recordID, result in
             (recordsToDeleteByID[recordID]?.recordType).flatMap { recordType in
               (try? result.get()) != nil


### PR DESCRIPTION
When calling `MockCloudDatabase.modifyRecords(…)`, the returned callback currently passes the saved records to the sync engine as-is (i.e. the internally copied and stored `CKRecord` instances). This effectively shares the same `CKRecord` objects with the sync engine.

Mutations performed on these records by the sync engine (such as updating `userModificationTime` as part of the upsert logic[^1]) are therefore reflected in the `MockCloudDatabase`. As a result, the mock database can report incorrect results, as demonstrated by the newly introduced assertion in one of the merge conflict tests.

This PR fixes the issue by returning copies of the records in the modify callback, preventing the coupling between the sync engine and `MockCloudDatabase`.

[^1]: One could question whether directly mutating the `CKRecord` in the upsert logic is appropriate, and whether a better approach exists (see [#370](https://github.com/pointfreeco/sqlite-data/pull/370)). However, that’s a separate topic.