### PR TITLE
Fix SyncEngine retain cycle causing file descriptor exhaustion

### DIFF
--- a/Sources/SQLiteData/CloudKit/Internal/Triggers.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Triggers.swift
@@ -236,24 +236,25 @@
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension SyncMetadata {
-    static func callbackTriggers(for syncEngine: SyncEngine) -> [TemporaryTrigger<Self>] {
+    static func callbackTriggers(for context: FunctionContext) -> [TemporaryTrigger<Self>] {
       [
-        afterInsertTrigger(for: syncEngine),
+        afterInsertTrigger(for: context),
         afterZoneUpdateTrigger(),
-        afterUpdateTrigger(for: syncEngine),
-        afterSoftDeleteTrigger(for: syncEngine),
+        afterUpdateTrigger(for: context),
+        afterSoftDeleteTrigger(for: context),
       ]
     }
 
-    fileprivate static func afterInsertTrigger(for syncEngine: SyncEngine) -> TemporaryTrigger<Self>
-    {
+    fileprivate static func afterInsertTrigger(
+      for context: FunctionContext
+    ) -> TemporaryTrigger<Self> {
       createTemporaryTrigger(
         "\(String.sqliteDataCloudKitSchemaName)_after_insert_on_sqlitedata_icloud_metadata",
         ifNotExists: true,
         after: .insert { new in
           validate(recordName: new.recordName)
           Values(
-            syncEngine.$didUpdate(
+            context.$didUpdate(
               recordName: new.recordName,
               zoneName: new.zoneName,
               ownerName: new.ownerName,
@@ -297,8 +298,9 @@
       )
     }
 
-    fileprivate static func afterUpdateTrigger(for syncEngine: SyncEngine) -> TemporaryTrigger<Self>
-    {
+    fileprivate static func afterUpdateTrigger(
+      for context: FunctionContext
+    ) -> TemporaryTrigger<Self> {
       createTemporaryTrigger(
         "\(String.sqliteDataCloudKitSchemaName)_after_update_on_sqlitedata_icloud_metadata",
         ifNotExists: true,
@@ -313,7 +315,7 @@
 
           validate(recordName: new.recordName)
           Values(
-            syncEngine.$didUpdate(
+            context.$didUpdate(
               recordName: new.recordName,
               zoneName: new.zoneName,
               ownerName: new.ownerName,
@@ -329,14 +331,14 @@
     }
 
     fileprivate static func afterSoftDeleteTrigger(
-      for syncEngine: SyncEngine
+      for context: FunctionContext
     ) -> TemporaryTrigger<Self> {
       createTemporaryTrigger(
         "\(String.sqliteDataCloudKitSchemaName)_after_delete_on_sqlitedata_icloud_metadata",
         ifNotExists: true,
         after: .update(of: \._isDeleted) { _, new in
           Values(
-            syncEngine.$didDelete(
+            context.$didDelete(
               recordName: new.recordName,
               record: new.lastKnownServerRecord
                 ?? rootServerRecord(recordName: new.recordName),

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -351,15 +351,16 @@
         )
         .execute(db)
       }
+      let context = FunctionContext(self)
       db.add(function: $currentTime)
       db.add(function: SyncEngine.$isSynchronizing)
-      db.add(function: $didUpdate)
-      db.add(function: $didDelete)
+      db.add(function: context.$didUpdate)
+      db.add(function: context.$didDelete)
       db.add(function: $hasPermission)
       db.add(function: $currentZoneName)
       db.add(function: $currentOwnerName)
 
-      for trigger in SyncMetadata.callbackTriggers(for: self) {
+      for trigger in SyncMetadata.callbackTriggers(for: context) {
         try trigger.execute(db)
       }
 
@@ -734,7 +735,7 @@
           try table.base
             .dropTriggers(defaultZone: defaultZone, privateTables: privateTables, db: db)
         }
-        for trigger in SyncMetadata.callbackTriggers(for: self).reversed() {
+        for trigger in SyncMetadata.callbackTriggers(for: FunctionContext(self)).reversed() {
           try trigger.drop().execute(db)
         }
       }
@@ -768,114 +769,6 @@
         }
       }
       try await start()
-    }
-
-    @DatabaseFunction(
-      "sqlitedata_icloud_didUpdate",
-      as: ((
-        String,
-        String,
-        String,
-        String,
-        String,
-        [String]?.JSONRepresentation
-      ) -> Void).self
-    )
-    func didUpdate(
-      recordName: String,
-      zoneName: String,
-      ownerName: String,
-      oldZoneName: String,
-      oldOwnerName: String,
-      descendantRecordNames: [String]?
-    ) {
-      var oldChanges: [CKSyncEngine.PendingRecordZoneChange] = []
-      var newChanges: [CKSyncEngine.PendingRecordZoneChange] = []
-
-      let oldZoneID = CKRecordZone.ID(zoneName: oldZoneName, ownerName: oldOwnerName)
-      let zoneID = CKRecordZone.ID(zoneName: zoneName, ownerName: ownerName)
-
-      if oldZoneID != zoneID {
-        oldChanges.append(.deleteRecord(CKRecord.ID(recordName: recordName, zoneID: oldZoneID)))
-        for descendantRecordName in descendantRecordNames ?? [] {
-          oldChanges.append(
-            .deleteRecord(CKRecord.ID(recordName: descendantRecordName, zoneID: oldZoneID))
-          )
-        }
-        newChanges.append(.saveRecord(CKRecord.ID(recordName: recordName, zoneID: zoneID)))
-        for descendantRecordName in descendantRecordNames ?? [] {
-          newChanges.append(
-            .saveRecord(CKRecord.ID(recordName: descendantRecordName, zoneID: zoneID))
-          )
-        }
-      } else {
-        newChanges.append(
-          .saveRecord(CKRecord.ID(recordName: recordName, zoneID: zoneID))
-        )
-      }
-
-      guard isRunning else {
-        // TODO: Perform this work in a trigger instead of a task.
-        Task { [changes = oldChanges + newChanges] in
-          await withErrorReporting(.sqliteDataCloudKitFailure) {
-            try await userDatabase.write { db in
-              try PendingRecordZoneChange
-                .insert {
-                  for change in changes {
-                    PendingRecordZoneChange(change)
-                  }
-                }
-                .execute(db)
-            }
-          }
-        }
-        return
-      }
-      let oldSyncEngine = self.syncEngines.withValue {
-        oldZoneID.ownerName == CKCurrentUserDefaultName ? $0.private : $0.shared
-      }
-      let syncEngine = self.syncEngines.withValue {
-        zoneID.ownerName == CKCurrentUserDefaultName ? $0.private : $0.shared
-      }
-      oldSyncEngine?.state.add(pendingRecordZoneChanges: oldChanges)
-      syncEngine?.state.add(pendingRecordZoneChanges: newChanges)
-    }
-
-    @DatabaseFunction(
-      "sqlitedata_icloud_didDelete",
-      as: ((String, CKRecord?.SystemFieldsRepresentation, CKShare?.SystemFieldsRepresentation)
-        -> Void).self
-    )
-    func didDelete(recordName: String, record: CKRecord?, share: CKShare?) {
-      let zoneID = record?.recordID.zoneID ?? defaultZone.zoneID
-      var changes: [CKSyncEngine.PendingRecordZoneChange] = [
-        .deleteRecord(
-          CKRecord.ID(
-            recordName: recordName,
-            zoneID: zoneID
-          )
-        )
-      ]
-      if let share {
-        changes.append(.deleteRecord(share.recordID))
-      }
-      guard isRunning else {
-        Task { [changes] in
-          await withErrorReporting(.sqliteDataCloudKitFailure) {
-            try await userDatabase.write { db in
-              try PendingRecordZoneChange
-                .insert { changes.map { PendingRecordZoneChange($0) } }
-                .execute(db)
-            }
-          }
-        }
-        return
-      }
-
-      let syncEngine = self.syncEngines.withValue {
-        zoneID.ownerName == CKCurrentUserDefaultName ? $0.private : $0.shared
-      }
-      syncEngine?.state.add(pendingRecordZoneChanges: changes)
     }
 
     package func acceptShare(metadata: ShareMetadata) async throws {
@@ -2508,17 +2401,6 @@
   @TaskLocal package var _isSynchronizingChanges = false
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   @TaskLocal package var _currentZoneID: CKRecordZone.ID?
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  @DatabaseFunction("sqlitedata_icloud_currentZoneName")
-  func currentZoneName() -> String? {
-    _currentZoneID?.zoneName
-  }
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  @DatabaseFunction("sqlitedata_icloud_currentOwnerName")
-  func currentOwnerName() -> String? {
-    _currentZoneID?.ownerName
-  }
-
   private struct ActivityCounts {
     var sendingChangesCount = 0
     var fetchingChangesCount = 0
@@ -2558,4 +2440,135 @@
       }
     }
   #endif
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  @DatabaseFunction("sqlitedata_icloud_currentZoneName")
+  func currentZoneName() -> String? {
+    _currentZoneID?.zoneName
+  }
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  @DatabaseFunction("sqlitedata_icloud_currentOwnerName")
+  func currentOwnerName() -> String? {
+    _currentZoneID?.ownerName
+  }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  final class FunctionContext: @unchecked Sendable {
+    private let _syncEngine = IsolatedWeakVar<SyncEngine>()
+    var syncEngine: SyncEngine? { _syncEngine.value }
+    init(_ syncEngine: SyncEngine) {
+      _syncEngine.set(syncEngine)
+    }
+
+    @DatabaseFunction(
+      "sqlitedata_icloud_didUpdate",
+      as: ((
+        String,
+        String,
+        String,
+        String,
+        String,
+        [String]?.JSONRepresentation
+      ) -> Void).self
+    )
+    func didUpdate(
+      recordName: String,
+      zoneName: String,
+      ownerName: String,
+      oldZoneName: String,
+      oldOwnerName: String,
+      descendantRecordNames: [String]?
+    ) {
+      guard let syncEngine else { return }
+      var oldChanges: [CKSyncEngine.PendingRecordZoneChange] = []
+      var newChanges: [CKSyncEngine.PendingRecordZoneChange] = []
+
+      let oldZoneID = CKRecordZone.ID(zoneName: oldZoneName, ownerName: oldOwnerName)
+      let zoneID = CKRecordZone.ID(zoneName: zoneName, ownerName: ownerName)
+
+      if oldZoneID != zoneID {
+        oldChanges.append(.deleteRecord(CKRecord.ID(recordName: recordName, zoneID: oldZoneID)))
+        for descendantRecordName in descendantRecordNames ?? [] {
+          oldChanges.append(
+            .deleteRecord(CKRecord.ID(recordName: descendantRecordName, zoneID: oldZoneID))
+          )
+        }
+        newChanges.append(.saveRecord(CKRecord.ID(recordName: recordName, zoneID: zoneID)))
+        for descendantRecordName in descendantRecordNames ?? [] {
+          newChanges.append(
+            .saveRecord(CKRecord.ID(recordName: descendantRecordName, zoneID: zoneID))
+          )
+        }
+      } else {
+        newChanges.append(
+          .saveRecord(CKRecord.ID(recordName: recordName, zoneID: zoneID))
+        )
+      }
+
+      guard syncEngine.isRunning else {
+        // TODO: Perform this work in a trigger instead of a task.
+        Task { [changes = oldChanges + newChanges, userDatabase = syncEngine.userDatabase] in
+          await withErrorReporting(.sqliteDataCloudKitFailure) {
+            try await userDatabase.write { db in
+              try PendingRecordZoneChange
+                .insert {
+                  for change in changes {
+                    PendingRecordZoneChange(change)
+                  }
+                }
+                .execute(db)
+            }
+          }
+        }
+        return
+      }
+      let oldSyncEngine = syncEngine.syncEngines.withValue {
+        oldZoneID.ownerName == CKCurrentUserDefaultName ? $0.private : $0.shared
+      }
+      let newSyncEngine = syncEngine.syncEngines.withValue {
+        zoneID.ownerName == CKCurrentUserDefaultName ? $0.private : $0.shared
+      }
+      oldSyncEngine?.state.add(pendingRecordZoneChanges: oldChanges)
+      newSyncEngine?.state.add(pendingRecordZoneChanges: newChanges)
+    }
+
+    @DatabaseFunction(
+      "sqlitedata_icloud_didDelete",
+      as: ((String, CKRecord?.SystemFieldsRepresentation, CKShare?.SystemFieldsRepresentation)
+        -> Void).self
+    )
+    func didDelete(recordName: String, record: CKRecord?, share: CKShare?) {
+      guard let syncEngine else { return }
+      let zoneID = record?.recordID.zoneID ?? syncEngine.defaultZone.zoneID
+      var changes: [CKSyncEngine.PendingRecordZoneChange] = [
+        .deleteRecord(
+          CKRecord.ID(
+            recordName: recordName,
+            zoneID: zoneID
+          )
+        )
+      ]
+      if let share {
+        changes.append(.deleteRecord(share.recordID))
+      }
+      guard syncEngine.isRunning else {
+        Task { [changes, userDatabase = syncEngine.userDatabase] in
+          await withErrorReporting(.sqliteDataCloudKitFailure) {
+            try await userDatabase.write { db in
+              try PendingRecordZoneChange
+                .insert { changes.map { PendingRecordZoneChange($0) } }
+                .execute(db)
+            }
+          }
+        }
+        return
+      }
+
+      let ckSyncEngine = syncEngine.syncEngines.withValue {
+        zoneID.ownerName == CKCurrentUserDefaultName ? $0.private : $0.shared
+      }
+      ckSyncEngine?.state.add(pendingRecordZoneChanges: changes)
+    }
+
+  }
 #endif

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineLifecycleTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineLifecycleTests.swift
@@ -763,6 +763,70 @@
           }
         }
       }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func syncEngineIsReleasedWhenReferencesAreDropped() async throws {
+        weak var weakSyncEngine: SyncEngine?
+        do {
+          let containerIdentifier = "iCloud.co.pointfree.Testing.\(UUID())"
+          let userDatabase = UserDatabase(
+            database: try database(
+              containerIdentifier: containerIdentifier,
+              attachMetadatabase: false
+            )
+          )
+          let privateDatabase = MockCloudDatabase(databaseScope: .private)
+          let sharedDatabase = MockCloudDatabase(databaseScope: .shared)
+          let container = MockCloudContainer(
+            containerIdentifier: containerIdentifier,
+            privateCloudDatabase: privateDatabase,
+            sharedCloudDatabase: sharedDatabase
+          )
+          privateDatabase.set(container: container)
+          sharedDatabase.set(container: container)
+          let syncEngine = try await SyncEngine(
+            container: container,
+            userDatabase: userDatabase,
+            tables: Reminder.self, RemindersList.self,
+            startImmediately: false
+          )
+          weakSyncEngine = syncEngine
+        }
+        #expect(weakSyncEngine == nil)
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func manySyncEnginesDoNotExhaustFileDescriptors() async throws {
+        for i in 0..<100 {
+          do {
+            let containerIdentifier = "iCloud.co.pointfree.Testing.\(UUID())"
+            let userDatabase = UserDatabase(
+              database: try database(
+                containerIdentifier: containerIdentifier,
+                attachMetadatabase: false
+              )
+            )
+            let privateDatabase = MockCloudDatabase(databaseScope: .private)
+            let sharedDatabase = MockCloudDatabase(databaseScope: .shared)
+            let container = MockCloudContainer(
+              containerIdentifier: containerIdentifier,
+              privateCloudDatabase: privateDatabase,
+              sharedCloudDatabase: sharedDatabase
+            )
+            privateDatabase.set(container: container)
+            sharedDatabase.set(container: container)
+            _ = try await SyncEngine(
+              container: container,
+              userDatabase: userDatabase,
+              tables: Reminder.self, RemindersList.self,
+              startImmediately: false
+            )
+          } catch {
+            Issue.record("Failed at iteration \(i): \(error)")
+            return
+          }
+        }
+      }
     }
   }
 #endif


### PR DESCRIPTION
Follow up to earlier [discussion](https://github.com/pointfreeco/sqlite-data/discussions/416).

SyncEngine's `@DatabaseFunction` instance methods (`didUpdate`, `didDelete`) capture `self` strongly via their projected values. Since `db.add(function:)` retains these via `Unmanaged.passRetained`, this creates a cycle:

    SyncEngine → userDatabase → database functions → self (SyncEngine)

This prevents deallocation, leaking file descriptors until the process hits "SQLite error 14: unable to open database file". This can be an issue if running a a large number of unit tests that bootstrap a sync engine.

The fix introduces `FunctionContext`, a lightweight proxy that holds a weak reference (via `IsolatedWeakVar`) back to `SyncEngine`. Only `didUpdate` and `didDelete` are moved to `FunctionContext` — these are the two instance methods that capture `self`. Module-level functions (`currentZoneName`, `currentOwnerName`, `currentTime`, `hasPermission`) and the static `isSynchronizing` don't participate in the cycle and are unchanged.

When `SyncEngine` is deallocated the weak reference nils out and the database functions safely no-op via `guard let syncEngine else { return }`.