### PR TITLE
Fix CloudKit data loss on delete-then-reinsert

### DIFF
--- a/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
@@ -125,6 +125,30 @@
       )
       .execute(db)
     }
+    migrator.registerMigration("Replace _isDeleted with _pendingStatus") { db in
+      try #sql(
+        """
+        ALTER TABLE "\(raw: .sqliteDataCloudKitSchemaName)_metadata"
+        ADD COLUMN "_pendingStatus" INTEGER
+        """
+      )
+      .execute(db)
+      try #sql(
+        """
+        UPDATE "\(raw: .sqliteDataCloudKitSchemaName)_metadata"
+        SET "_pendingStatus" = 0
+        WHERE "_isDeleted" = 1
+        """
+      )
+      .execute(db)
+      try #sql(
+        """
+        ALTER TABLE "\(raw: .sqliteDataCloudKitSchemaName)_metadata"
+        DROP COLUMN "_isDeleted"
+        """
+      )
+      .execute(db)
+    }
     #if DEBUG
       try metadatabase.read { db in
         let hasSchemaChanges = try migrator.hasSchemaChanges(db)

--- a/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
@@ -141,13 +141,6 @@
         """
       )
       .execute(db)
-      try #sql(
-        """
-        ALTER TABLE "\(raw: .sqliteDataCloudKitSchemaName)_metadata"
-        DROP COLUMN "_isDeleted"
-        """
-      )
-      .execute(db)
     }
     #if DEBUG
       try metadatabase.read { db in

--- a/Sources/SQLiteData/CloudKit/Internal/MockSyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/MockSyncEngine.swift
@@ -136,12 +136,12 @@
   package final class MockSyncEngineState: CKSyncEngineStateProtocol {
     package let changeTag = LockIsolated(0)
     package let _pendingRecordZoneChanges = LockIsolated<
-      OrderedSet<CKSyncEngine.PendingRecordZoneChange>
-    >([]
+      OrderedDictionary<CKRecord.ID, CKSyncEngine.PendingRecordZoneChange>
+    >([:]
     )
     package let _pendingDatabaseChanges = LockIsolated<
-      OrderedSet<CKSyncEngine.PendingDatabaseChange>
-    >([])
+      OrderedDictionary<CKRecordZone.ID, CKSyncEngine.PendingDatabaseChange>
+    >([:])
     private let fileID: StaticString
     private let filePath: StaticString
     private let line: UInt
@@ -160,11 +160,11 @@
     }
 
     package var pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange] {
-      _pendingRecordZoneChanges.withValue { Array($0) }
+      _pendingRecordZoneChanges.withValue { Array($0.values) }
     }
 
     package var pendingDatabaseChanges: [CKSyncEngine.PendingDatabaseChange] {
-      _pendingDatabaseChanges.withValue { Array($0) }
+      _pendingDatabaseChanges.withValue { Array($0.values) }
     }
 
     package func removePendingChanges() {
@@ -173,26 +173,58 @@
     }
 
     package func add(pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange]) {
-      self._pendingRecordZoneChanges.withValue {
-        $0.append(contentsOf: pendingRecordZoneChanges)
+      self._pendingRecordZoneChanges.withValue { dict in
+        for change in pendingRecordZoneChanges {
+          switch change {
+          case .saveRecord(let id), .deleteRecord(let id):
+            dict.updateValue(change, forKey: id)
+          @unknown default:
+            fatalError("Unsupported pendingRecordZoneChange: \(change)")
+          }
+        }
       }
     }
 
     package func remove(pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange]) {
-      self._pendingRecordZoneChanges.withValue {
-        $0.subtract(pendingRecordZoneChanges)
+      self._pendingRecordZoneChanges.withValue { dict in
+        for change in pendingRecordZoneChanges {
+          switch change {
+          case .saveRecord(let id), .deleteRecord(let id):
+            if dict[id] == change { dict.removeValue(forKey: id) }
+          @unknown default:
+            fatalError("Unsupported pendingRecordZoneChange: \(change)")
+          }
+        }
       }
     }
 
     package func add(pendingDatabaseChanges: [CKSyncEngine.PendingDatabaseChange]) {
-      self._pendingDatabaseChanges.withValue {
-        $0.append(contentsOf: pendingDatabaseChanges)
+      self._pendingDatabaseChanges.withValue { dict in
+        for change in pendingDatabaseChanges {
+          switch change {
+          case .saveZone(let zone):
+            dict.updateValue(change, forKey: zone.zoneID)
+          case .deleteZone(let zoneID):
+            dict.updateValue(change, forKey: zoneID)
+          @unknown default:
+            fatalError("Unsupported pendingDatabaseChange: \(change)")
+          }
+        }
       }
     }
 
     package func remove(pendingDatabaseChanges: [CKSyncEngine.PendingDatabaseChange]) {
-      self._pendingDatabaseChanges.withValue {
-        $0.subtract(pendingDatabaseChanges)
+      self._pendingDatabaseChanges.withValue { dict in
+        for change in pendingDatabaseChanges {
+          switch change {
+          case .saveZone(let zone):
+            if dict[zone.zoneID] == change { dict.removeValue(forKey: zone.zoneID) }
+          case .deleteZone(let zoneID):
+            if dict[zoneID] == change { dict.removeValue(forKey: zoneID) }
+          @unknown default:
+            fatalError("Unsupported pendingDatabaseChange: \(change)")
+          }
+        }
       }
     }
   }

--- a/Sources/SQLiteData/CloudKit/Internal/Triggers.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Triggers.swift
@@ -54,7 +54,7 @@
               $0.recordPrimaryKey.eq(#sql("\(old.primaryKey)"))
                 && $0.recordType.eq(tableName)
             }
-            .update { $0._isDeleted = true }
+            .update { $0._pendingStatus = #bind(.deleted) }
         } when: { old, new in
           old.primaryKey.neq(new.primaryKey)
         }
@@ -82,6 +82,16 @@
             defaultZone: defaultZone,
             privateTables: privateTables
           )
+          SyncMetadata
+            .where {
+              $0.recordPrimaryKey.eq(#sql("\(new.primaryKey)"))
+                && $0.recordType.eq(tableName)
+                && $0._pendingStatus.eq(PendingStatus.deleted)
+            }
+            .update {
+              $0._pendingStatus = #bind(.reinserted)
+              $0.userModificationTime = $currentTime()
+            }
         }
       )
     }
@@ -139,7 +149,7 @@
               $0.recordPrimaryKey.eq(#sql("\(old.primaryKey)"))
                 && $0.recordType.eq(tableName)
             }
-            .update { $0._isDeleted = true }
+            .update { $0._pendingStatus = #bind(.deleted) }
         } when: { _ in
           !SyncEngine.$isSynchronizing
         }
@@ -242,6 +252,7 @@
         afterZoneUpdateTrigger(),
         afterUpdateTrigger(for: syncEngine),
         afterSoftDeleteTrigger(for: syncEngine),
+        afterReinsertTrigger(for: syncEngine),
       ]
     }
 
@@ -323,7 +334,7 @@
             )
           )
         } when: { old, new in
-          old._isDeleted.eq(new._isDeleted) && !SyncEngine.$isSynchronizing
+          old._pendingStatus.is(new._pendingStatus) && !SyncEngine.$isSynchronizing
         }
       )
     }
@@ -334,7 +345,7 @@
       createTemporaryTrigger(
         "\(String.sqliteDataCloudKitSchemaName)_after_delete_on_sqlitedata_icloud_metadata",
         ifNotExists: true,
-        after: .update(of: \._isDeleted) { _, new in
+        after: .update(of: \._pendingStatus) { _, new in
           Values(
             syncEngine.$didDelete(
               recordName: new.recordName,
@@ -344,7 +355,34 @@
             )
           )
         } when: { old, new in
-          !old._isDeleted && new._isDeleted && !SyncEngine.$isSynchronizing
+          (old._pendingStatus.is(nil) || old._pendingStatus.neq(PendingStatus.deleted))
+            && new._pendingStatus.eq(PendingStatus.deleted)
+            && !SyncEngine.$isSynchronizing
+        }
+      )
+    }
+
+    fileprivate static func afterReinsertTrigger(
+      for syncEngine: SyncEngine
+    ) -> TemporaryTrigger<Self> {
+      createTemporaryTrigger(
+        "\(String.sqliteDataCloudKitSchemaName)_after_reinsert_on_sqlitedata_icloud_metadata",
+        ifNotExists: true,
+        after: .update(of: \._pendingStatus) { _, new in
+          Values(
+            syncEngine.$didUpdate(
+              recordName: new.recordName,
+              zoneName: new.zoneName,
+              ownerName: new.ownerName,
+              oldZoneName: new.zoneName,
+              oldOwnerName: new.ownerName,
+              descendantRecordNames: #bind(nil)
+            )
+          )
+        } when: { old, new in
+          old._pendingStatus.eq(PendingStatus.deleted)
+            && new._pendingStatus.eq(PendingStatus.reinserted)
+            && !SyncEngine.$isSynchronizing
         }
       )
     }

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -1125,13 +1125,12 @@
 
       let batch = await syncEngine.recordZoneChangeBatch(pendingChanges: changes) { recordID in
         guard
-          let (metadata, allFields) = await withErrorReporting(
+          let metadata = await withErrorReporting(
             .sqliteDataCloudKitFailure,
             catching: {
               try await metadatabase.read { db in
                 try SyncMetadata
                   .find(recordID)
-                  .select { ($0, $0._lastKnownServerRecordAllFields) }
                   .fetchOne(db)
               }
             }
@@ -1198,7 +1197,7 @@
           }
 
           let record =
-            allFields
+            metadata.allFieldsRecord
             ?? CKRecord(
               recordType: metadata.recordType,
               recordID: recordID
@@ -1221,7 +1220,17 @@
             with: T(queryOutput: row),
             userModificationTime: metadata.userModificationTime
           )
-          await refreshLastKnownServerRecord(record)
+          await withErrorReporting(.sqliteDataCloudKitFailure) {
+            try await userDatabase.write { db in
+              try refreshLastKnownServerRecord(record, db: db)
+              if metadata._pendingStatus == .reinserted {
+                try SyncMetadata
+                  .find(record.recordID)
+                  .update { $0._pendingStatus = #bind(nil) }
+                  .execute(db)
+              }
+            }
+          }
           sentRecord = recordID
           return record
         }
@@ -1952,9 +1961,12 @@
         func open<T>(_ table: some SynchronizableTable<T>) throws {
           var columnNames: [String] = T.TableColumns.writableColumns.map(\.name)
           if !force,
-            let allFields = metadata._lastKnownServerRecordAllFields,
+            let allFields = metadata.allFieldsRecord,
             let row = try T.unscoped.find(#sql("\(bind: metadata.recordPrimaryKey)")).fetchOne(db)
           {
+            if metadata._pendingStatus == .reinserted {
+              allFields.update(with: T(queryOutput: row), userModificationTime: metadata.userModificationTime)
+            }
             serverRecord.update(
               with: allFields,
               row: T(queryOutput: row),
@@ -1974,6 +1986,12 @@
               .find(serverRecord.recordID)
               .update { $0.setLastKnownServerRecord(serverRecord) }
               .execute(db)
+            if metadata._pendingStatus == .reinserted {
+              try SyncMetadata
+                .find(serverRecord.recordID)
+                .update { $0._pendingStatus = #bind(nil) }
+                .execute(db)
+            }
           } catch {
             guard
               let error = error as? DatabaseError,
@@ -1996,22 +2014,25 @@
     private func refreshLastKnownServerRecord(_ record: CKRecord) async {
       await withErrorReporting(.sqliteDataCloudKitFailure) {
         try await userDatabase.write { db in
-          let metadata = try SyncMetadata.find(record.recordID).fetchOne(db)
-          func updateLastKnownServerRecord() throws {
-            try SyncMetadata
-              .find(record.recordID)
-              .update { $0.setLastKnownServerRecord(record) }
-              .execute(db)
-          }
-
-          if let lastKnownDate = metadata?.lastKnownServerRecord?.modificationDate {
-            if let recordDate = record.modificationDate, lastKnownDate < recordDate {
-              try updateLastKnownServerRecord()
-            }
-          } else {
-            try updateLastKnownServerRecord()
-          }
+          try refreshLastKnownServerRecord(record, db: db)
         }
+      }
+    }
+    
+    private func refreshLastKnownServerRecord(_ record: CKRecord, db: Database) throws {
+      let metadata = try SyncMetadata.find(record.recordID).fetchOne(db)
+      func updateLastKnownServerRecord() throws {
+        try SyncMetadata
+          .find(record.recordID)
+          .update { $0.setLastKnownServerRecord(record) }
+          .execute(db)
+      }
+      if let lastKnownDate = metadata?.lastKnownServerRecord?.modificationDate {
+        if let recordDate = record.modificationDate, lastKnownDate < recordDate {
+          try updateLastKnownServerRecord()
+        }
+      } else {
+        try updateLastKnownServerRecord()
       }
     }
 

--- a/Sources/SQLiteData/CloudKit/SyncMetadata.swift
+++ b/Sources/SQLiteData/CloudKit/SyncMetadata.swift
@@ -1,6 +1,17 @@
 #if canImport(CloudKit)
   import CloudKit
 
+  /// Represents the pending synchronization state of a record.
+  public enum PendingStatus: Int, Hashable, Sendable, QueryBindable, QueryDecodable, QueryRepresentable {
+    /// Indicates the metadata has been "soft" deleted. It will be fully deleted once the
+    /// next batch of pending changes is processed.
+    case deleted = 0
+    /// Indicates the record has been reinserted after being soft-deleted. This status
+    /// will be cleared after the next batch of pending changes is processed or server
+    /// record changes are applied.
+    case reinserted = 1
+  }
+
   /// A table that tracks metadata related to synchronized data.
   ///
   /// Each row of this table represents a synchronized record across all tables synchronized with
@@ -93,9 +104,23 @@
     @Column(as: CKShare?.SystemFieldsRepresentation.self)
     public let share: CKShare?
 
-    /// Determines if the metadata has been "soft" deleted. It will be fully deleted once the
-    /// next batch of pending changes is processed.
-    public let _isDeleted: Bool
+    /// The pending synchronization state of the record which can require special handling.
+    ///
+    /// `nil` indicates a normal record with standard sync behavior.
+    public let _pendingStatus: PendingStatus?
+
+    /// The appropriate all-fields record to use as a base when building a `CKRecord` for upload.
+    ///
+    /// For reinserted rows, returns `lastKnownServerRecord` (system fields only)
+    /// For all others, returns `_lastKnownServerRecordAllFields`.
+    var allFieldsRecord: CKRecord? {
+      switch _pendingStatus {
+      case .reinserted:
+        lastKnownServerRecord
+      case nil, .deleted:
+        _lastKnownServerRecordAllFields
+      }
+    }
 
     @Column("hasLastKnownServerRecord", generated: .virtual)
     public let _hasLastKnownServerRecord: Bool
@@ -191,7 +216,7 @@
       self._hasLastKnownServerRecord = lastKnownServerRecord != nil
       self._isShared = share != nil
       self.userModificationTime = userModificationTime
-      self._isDeleted = false
+      self._pendingStatus = nil
     }
 
     package static func find(_ recordID: CKRecord.ID) -> Where<Self> {

--- a/Tests/SQLiteDataTests/CloudKitTests/AccountLifecycleTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/AccountLifecycleTests.swift
@@ -173,7 +173,7 @@
         │     title: "Personal"                                              │
         │   ),                                                               │
         │   share: nil,                                                      │
-        │   _isDeleted: false,                                               │
+        │   _pendingStatus: nil,                                             │
         │   _hasLastKnownServerRecord: true,                                 │
         │   _isShared: false,                                                │
         │   userModificationTime: 0                                          │
@@ -195,7 +195,7 @@
         │   lastKnownServerRecord: nil,                                      │
         │   _lastKnownServerRecordAllFields: nil,                            │
         │   share: nil,                                                      │
-        │   _isDeleted: false,                                               │
+        │   _pendingStatus: nil,                                             │
         │   _hasLastKnownServerRecord: false,                                │
         │   _isShared: false,                                                │
         │   userModificationTime: 0                                          │
@@ -259,7 +259,7 @@
         │     title: "Personal"                                                                   │
         │   ),                                                                                    │
         │   share: nil,                                                                           │
-        │   _isDeleted: false,                                                                    │
+        │   _pendingStatus: nil,                                                                  │
         │   _hasLastKnownServerRecord: true,                                                      │
         │   _isShared: false,                                                                     │
         │   userModificationTime: 0                                                               │
@@ -295,7 +295,7 @@
         │     title: "Get milk"                                                                   │
         │   ),                                                                                    │
         │   share: nil,                                                                           │
-        │   _isDeleted: false,                                                                    │
+        │   _pendingStatus: nil,                                                                  │
         │   _hasLastKnownServerRecord: true,                                                      │
         │   _isShared: false,                                                                     │
         │   userModificationTime: 0                                                               │
@@ -424,7 +424,7 @@
         │     parent: nil,                                                                                    │
         │     share: nil                                                                                      │
         │   ),                                                                                                │
-        │   _isDeleted: false,                                                                                │
+        │   _pendingStatus: nil,                                                                              │
         │   _hasLastKnownServerRecord: true,                                                                  │
         │   _isShared: true,                                                                                  │
         │   userModificationTime: 0                                                                           │
@@ -446,7 +446,7 @@
         │   lastKnownServerRecord: nil,                                                                       │
         │   _lastKnownServerRecordAllFields: nil,                                                             │
         │   share: nil,                                                                                       │
-        │   _isDeleted: false,                                                                                │
+        │   _pendingStatus: nil,                                                                              │
         │   _hasLastKnownServerRecord: false,                                                                 │
         │   _isShared: false,                                                                                 │
         │   userModificationTime: 0                                                                           │
@@ -521,7 +521,7 @@
         │     parent: nil,                                                                                    │
         │     share: nil                                                                                      │
         │   ),                                                                                                │
-        │   _isDeleted: false,                                                                                │
+        │   _pendingStatus: nil,                                                                              │
         │   _hasLastKnownServerRecord: true,                                                                  │
         │   _isShared: true,                                                                                  │
         │   userModificationTime: 0                                                                           │
@@ -557,7 +557,7 @@
         │     title: "Get milk"                                                                               │
         │   ),                                                                                                │
         │   share: nil,                                                                                       │
-        │   _isDeleted: false,                                                                                │
+        │   _pendingStatus: nil,                                                                              │
         │   _hasLastKnownServerRecord: true,                                                                  │
         │   _isShared: false,                                                                                 │
         │   userModificationTime: 0                                                                           │

--- a/Tests/SQLiteDataTests/CloudKitTests/AttachedMetadatabaseTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/AttachedMetadatabaseTests.swift
@@ -57,7 +57,7 @@
           │                     │     title: "Personal"                                              │
           │                     │   ),                                                               │
           │                     │   share: nil,                                                      │
-          │                     │   _isDeleted: false,                                               │
+          │                     │   _pendingStatus: nil,                                             │
           │                     │   _hasLastKnownServerRecord: true,                                 │
           │                     │   _isShared: false,                                                │
           │                     │   userModificationTime: 0                                          │

--- a/Tests/SQLiteDataTests/CloudKitTests/ChangeSupersessionTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ChangeSupersessionTests.swift
@@ -1,0 +1,772 @@
+#if canImport(CloudKit)
+  import CloudKit
+  import ConcurrencyExtrasTestSupport
+  import CustomDump
+  import InlineSnapshotTesting
+  import OrderedCollections
+  import SQLiteData
+  import SnapshotTestingCustomDump
+  import Testing
+
+  extension BaseCloudKitTests {
+    @MainActor
+    func fetchReminderListMetadata(_ recordID: RemindersList.ID) async throws -> SyncMetadata? {
+      try await self.syncEngine.metadatabase.read {
+        try SyncMetadata.find(RemindersList.recordID(for: recordID)).fetchOne($0)
+      }
+    }
+    
+    @MainActor
+    func fetchReminderMetadata(_ recordID: Reminder.ID) async throws -> SyncMetadata? {
+      try await self.syncEngine.metadatabase.read {
+        try SyncMetadata.find(Reminder.recordID(for: recordID)).fetchOne($0)
+      }
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    func expectMetadataServerRecord(
+      _ metadata: SyncMetadata,
+      matchesContainerRecord recordID: CKRecord.ID,
+      fileID: StaticString = #fileID,
+      filePath: StaticString = #filePath,
+      line: UInt = #line,
+      column: UInt = #column
+    ) throws {
+      let containerRecord = try container.privateCloudDatabase.record(for: recordID)
+      var containerRecordDump = ""
+      var metadataServerRecordDump = ""
+      customDump(containerRecord, to: &containerRecordDump)
+      customDump(metadata._lastKnownServerRecordAllFields, to: &metadataServerRecordDump)
+      expectNoDifference(
+        metadataServerRecordDump, containerRecordDump,
+        fileID: fileID, filePath: filePath, line: line, column: column
+      )
+    }
+    
+    @MainActor
+    final class ChangeSupersessionTests: BaseCloudKitTests, @unchecked Sendable {
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func insertThenDelete_deletes() async throws {
+        try await userDatabase.userWrite { db in
+          try RemindersList.insert { RemindersList(id: 1, title: "Personal") }.execute(db)
+          try RemindersList.find(1).delete().execute(db)
+        }
+        #expect(try #require(await fetchReminderListMetadata(1))._pendingStatus == .deleted)
+
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+        
+        #expect(try await fetchReminderListMetadata(1) == nil)
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: []
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func updateThenDelete_deletes() async throws {
+        try await userDatabase.userWrite { db in
+          try db.seed { RemindersList(id: 1, title: "Original") }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        try await userDatabase.userWrite { db in
+          try RemindersList.find(1).update { $0.title = "Updated" }.execute(db)
+          try RemindersList.find(1).delete().execute(db)
+        }
+        #expect(try #require(await fetchReminderListMetadata(1))._pendingStatus == .deleted)
+
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+        
+        #expect(try await fetchReminderListMetadata(1) == nil)
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: []
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+      
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func deleteThenReinsertThenDelete_deletes() async throws {
+        try await userDatabase.userWrite { db in
+          try db.seed { RemindersList(id: 1, title: "Original") }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        try await userDatabase.userWrite { db in
+          try RemindersList.find(1).delete().execute(db)
+          try RemindersList.insert { RemindersList(id: 1, title: "Reinserted") }.execute(db)
+          try RemindersList.find(1).delete().execute(db)
+        }
+        
+        #expect(try #require(await fetchReminderListMetadata(1))._pendingStatus == .deleted)
+        
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+        
+        #expect(try await fetchReminderListMetadata(1) == nil)
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: []
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+      
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func insertThenDeleteThenReinsert_saves() async throws {
+        try await userDatabase.userWrite { db in
+          try RemindersList.insert { RemindersList(id: 1, title: "Original") }.execute(db)
+          try RemindersList.find(1).delete().execute(db)
+          try RemindersList.insert { RemindersList(id: 1, title: "Reinserted") }.execute(db)
+        }
+        #expect(try #require(await fetchReminderListMetadata(1))._pendingStatus == .reinserted)
+
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+        
+        let metadata = try #require(await fetchReminderListMetadata(1))
+        #expect(metadata._pendingStatus == nil)
+        try expectMetadataServerRecord(metadata, matchesContainerRecord: RemindersList.recordID(for: 1))
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  title: "Reinserted"
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test(.taskLocal(CKRecord._$printTimestamps, true))
+      func deleteThenReinsertInSingleWrite_savesWithUpdatedTimestamps()
+        async throws
+      {
+        try await userDatabase.userWrite { db in
+          try db.seed {
+            RemindersList(id: 1, title: "Original")
+          }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        try await withDependencies {
+          $0.currentTime.now += 1
+        } operation: {
+          try await userDatabase.userWrite { db in
+            try RemindersList.find(1).delete().execute(db)
+            try RemindersList.insert { RemindersList(id: 1, title: "Reinserted") }.execute(db)
+          }
+
+          #expect(try #require(await fetchReminderListMetadata(1))._pendingStatus == .reinserted)
+
+          try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+        }
+
+        let metadata = try #require(await fetchReminderListMetadata(1))
+        #expect(metadata._pendingStatus == nil)
+
+        try expectMetadataServerRecord(metadata, matchesContainerRecord: RemindersList.recordID(for: 1))
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  id🗓️: 1,
+                  title: "Reinserted",
+                  title🗓️: 1,
+                  🗓️: 1
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test(.taskLocal(CKRecord._$printTimestamps, true))
+      func deleteThenReinsertInSeparateWrites_savesWithUpdatedTimestamps()
+        async throws
+      {
+        try await userDatabase.userWrite { db in
+          try db.seed {
+            RemindersList(id: 1, title: "Original")
+          }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        try await withDependencies {
+          $0.currentTime.now += 1
+        } operation: {
+          try await userDatabase.userWrite { db in
+            try RemindersList.find(1).delete().execute(db)
+          }
+          try await withDependencies {
+            $0.currentTime.now += 1
+          } operation: {
+            try await userDatabase.userWrite { db in
+              try RemindersList.insert { RemindersList(id: 1, title: "Reinserted") }.execute(db)
+            }
+            
+            #expect(try #require(await fetchReminderListMetadata(1))._pendingStatus == .reinserted)
+
+            try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+          }
+        }
+        
+        let metadata = try #require(await fetchReminderListMetadata(1))
+        #expect(metadata._pendingStatus == nil)
+
+        try expectMetadataServerRecord(metadata, matchesContainerRecord: RemindersList.recordID(for: 1))
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  id🗓️: 2,
+                  title: "Reinserted",
+                  title🗓️: 2,
+                  🗓️: 2
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+      
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test(.taskLocal(CKRecord._$printTimestamps, true))
+      func deleteThenReinsertThenUpdateInSeparateWrites_allFieldsSavedWithLatestTimestamp()
+        async throws
+      {
+        try await userDatabase.userWrite { db in
+          try db.seed {
+            RemindersList(id: 1, title: "Personal")
+            Reminder(id: 1, dueDate: Date(timeIntervalSince1970: Double(0)), title: "Get milk", remindersListID: 1)
+          }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        try await withDependencies {
+          $0.currentTime.now += 1
+        } operation: {
+          try await userDatabase.userWrite { db in
+            try Reminder.find(1).delete().execute(db)
+          }
+          try await withDependencies {
+            $0.currentTime.now += 1
+          } operation: {
+            try await userDatabase.userWrite { db in
+              try Reminder.insert {
+                Reminder(id: 1, dueDate: Date(timeIntervalSince1970: Double(30)), title: "(Reinserted) Get milk", remindersListID: 1)
+              }.execute(db)
+            }
+            try await withDependencies {
+              $0.currentTime.now += 1
+            } operation: {
+              try await userDatabase.userWrite { db in
+                try Reminder.update {
+                  $0.title = "(Updated) Get milk"
+                }.execute(db)
+              }
+              
+              #expect(try #require(await fetchReminderMetadata(1))._pendingStatus == .reinserted)
+
+              try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+            }
+          }
+        }
+        
+        let metadata = try #require(await fetchReminderMetadata(1))
+        #expect(metadata._pendingStatus == nil)
+
+        try expectMetadataServerRecord(metadata, matchesContainerRecord: Reminder.recordID(for: 1))
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                  recordType: "reminders",
+                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                  share: nil,
+                  dueDate: Date(1970-01-01T00:00:30.000Z),
+                  dueDate🗓️: 3,
+                  id: 1,
+                  id🗓️: 3,
+                  isCompleted: 0,
+                  isCompleted🗓️: 3,
+                  priority🗓️: 3,
+                  remindersListID: 1,
+                  remindersListID🗓️: 3,
+                  title: "(Updated) Get milk",
+                  title🗓️: 3,
+                  🗓️: 3
+                ),
+                [1]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  id🗓️: 0,
+                  title: "Personal",
+                  title🗓️: 0,
+                  🗓️: 0
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test(.taskLocal(CKRecord._$printTimestamps, true))
+      func updateThenDeleteThenReinsert_savesWithUpdatedTimestamps()
+        async throws
+      {
+        try await userDatabase.userWrite { db in
+          try db.seed { RemindersList(id: 1, title: "Original") }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        try await withDependencies {
+          $0.currentTime.now += 1
+        } operation: {
+          try await userDatabase.userWrite { db in
+            try RemindersList.find(1).update { $0.title = "Updated" }.execute(db)
+            try RemindersList.find(1).delete().execute(db)
+            try RemindersList.insert { RemindersList(id: 1, title: "Reinserted") }.execute(db)
+          }
+          
+          #expect(try #require(await fetchReminderListMetadata(1))._pendingStatus == .reinserted)
+
+          try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+        }
+        
+        let metadata = try #require(await fetchReminderListMetadata(1))
+        #expect(metadata._pendingStatus == nil)
+
+        try expectMetadataServerRecord(metadata, matchesContainerRecord: RemindersList.recordID(for: 1))
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  id🗓️: 1,
+                  title: "Reinserted",
+                  title🗓️: 1,
+                  🗓️: 1
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test(.taskLocal(CKRecord._$printTimestamps, true))
+      func deleteThenReinsertWithSameValue_savesWithUpdatedTimestamps()
+        async throws
+      {
+        try await userDatabase.userWrite { db in
+          try db.seed { RemindersList(id: 1, title: "Original") }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        try await withDependencies {
+          $0.currentTime.now += 1
+        } operation: {
+          try await userDatabase.userWrite { db in
+            try RemindersList.find(1).delete().execute(db)
+            try RemindersList.insert { RemindersList(id: 1, title: "Original") }.execute(db)
+          }
+          
+          #expect(try #require(await fetchReminderListMetadata(1))._pendingStatus == .reinserted)
+
+          try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+        }
+        
+        let metadata = try #require(await fetchReminderListMetadata(1))
+        #expect(metadata._pendingStatus == nil)
+
+        try expectMetadataServerRecord(metadata, matchesContainerRecord: RemindersList.recordID(for: 1))
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  id🗓️: 1,
+                  title: "Original",
+                  title🗓️: 1,
+                  🗓️: 1
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test(.taskLocal(CKRecord._$printTimestamps, true))
+      func twoDeleteReinsertCyclesInSameWrite_savesLatestWithUpdatedTimestamps()
+        async throws
+      {
+        try await userDatabase.userWrite { db in
+          try db.seed { RemindersList(id: 1, title: "Original") }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        try await withDependencies {
+          $0.currentTime.now += 1
+        } operation: {
+          try await userDatabase.userWrite { db in
+            try RemindersList.find(1).delete().execute(db)
+            try RemindersList.insert { RemindersList(id: 1, title: "Middle") }.execute(db)
+            try RemindersList.find(1).delete().execute(db)
+            try RemindersList.insert { RemindersList(id: 1, title: "Final") }.execute(db)
+          }
+          
+          #expect(try #require(await fetchReminderListMetadata(1))._pendingStatus == .reinserted)
+
+          try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+        }
+        
+        let metadata = try #require(await fetchReminderListMetadata(1))
+        #expect(metadata._pendingStatus == nil)
+
+        try expectMetadataServerRecord(metadata, matchesContainerRecord: RemindersList.recordID(for: 1))
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  id🗓️: 1,
+                  title: "Final",
+                  title🗓️: 1,
+                  🗓️: 1
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test(.taskLocal(CKRecord._$printTimestamps, true))
+      func twoDeleteReinsertCyclesInSeparateBatches_savesLatestWithUpdatedTimestamps()
+        async throws
+      {
+        try await userDatabase.userWrite { db in
+          try db.seed { RemindersList(id: 1, title: "Original") }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        try await withDependencies {
+          $0.currentTime.now += 1
+        } operation: {
+          try await userDatabase.userWrite { db in
+            try RemindersList.find(1).delete().execute(db)
+            try RemindersList.insert { RemindersList(id: 1, title: "Cycle1") }.execute(db)
+          }
+          try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+          
+          try await withDependencies {
+            $0.currentTime.now += 1
+          } operation: {
+            try await userDatabase.userWrite { db in
+              try RemindersList.find(1).delete().execute(db)
+              try RemindersList.insert { RemindersList(id: 1, title: "Cycle2") }.execute(db)
+            }
+            
+            #expect(try #require(await fetchReminderListMetadata(1))._pendingStatus == .reinserted)
+            
+            try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+          }
+        }
+        
+        let metadata = try #require(await fetchReminderListMetadata(1))
+        #expect(metadata._pendingStatus == nil)
+
+        try expectMetadataServerRecord(metadata, matchesContainerRecord: RemindersList.recordID(for: 1))
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  id🗓️: 2,
+                  title: "Cycle2",
+                  title🗓️: 2,
+                  🗓️: 2
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test(.taskLocal(CKRecord._$printTimestamps, true))
+      func reinsertedRecord_staleServerUpdate_localWins() async throws {
+        try await userDatabase.userWrite { db in
+          try db.seed { RemindersList(id: 1, title: "Original") }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        try await withDependencies {
+          $0.currentTime.now += 1
+        } operation: {
+          try await userDatabase.userWrite { db in
+            try RemindersList.find(1).delete().execute(db)
+            try RemindersList.insert { RemindersList(id: 1, title: "Reinserted") }.execute(db)
+          }
+          
+          #expect(try #require(await fetchReminderListMetadata(1))._pendingStatus == .reinserted)
+
+          let record = try syncEngine.private.database.record(for: RemindersList.recordID(for: 1))
+          record.setValue("Server", forKey: "title", at: 0)
+          try await syncEngine.modifyRecords(scope: .private, saving: [record]).notify()
+          
+          let metadata = try #require(await fetchReminderListMetadata(1))
+          #expect(metadata._pendingStatus == nil)
+          #expect(metadata.userModificationTime == 1)
+
+          let row = try await userDatabase.read { db in
+            try RemindersList.find(1).fetchOne(db)
+          }
+          #expect(row?.title == "Reinserted")
+
+          try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+        }
+        
+        let metadata = try #require(await fetchReminderListMetadata(1))
+        #expect(metadata._pendingStatus == nil)
+        #expect(metadata.userModificationTime == 1)
+
+        try expectMetadataServerRecord(metadata, matchesContainerRecord: RemindersList.recordID(for: 1))
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  id🗓️: 0,
+                  title: "Reinserted",
+                  title🗓️: 1,
+                  🗓️: 1
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test(.taskLocal(CKRecord._$printTimestamps, true))
+      func reinsertedRecord_freshServerUpdate_serverWins() async throws {
+        try await userDatabase.userWrite { db in
+          try db.seed { RemindersList(id: 1, title: "Original") }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        try await withDependencies {
+          $0.currentTime.now += 1
+        } operation: {
+          try await userDatabase.userWrite { db in
+            try RemindersList.find(1).delete().execute(db)
+            try RemindersList.insert { RemindersList(id: 1, title: "Reinserted") }.execute(db)
+          }
+          
+          #expect(try #require(await fetchReminderListMetadata(1))._pendingStatus == .reinserted)
+
+          let record = try syncEngine.private.database.record(for: RemindersList.recordID(for: 1))
+          record.setValue("Server", forKey: "title", at: 2)
+          try await syncEngine.modifyRecords(scope: .private, saving: [record]).notify()
+          
+          #expect(try #require(await fetchReminderListMetadata(1))._pendingStatus == nil)
+
+          let row = try await userDatabase.read { db in
+            try RemindersList.find(1).fetchOne(db)
+          }
+          #expect(row?.title == "Server")
+
+          try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+        }
+        
+        let metadata = try #require(await fetchReminderListMetadata(1))
+        #expect(metadata._pendingStatus == nil)
+
+        try expectMetadataServerRecord(metadata, matchesContainerRecord: RemindersList.recordID(for: 1))
+
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  id🗓️: 0,
+                  title: "Server",
+                  title🗓️: 2,
+                  🗓️: 2
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+    }
+  }
+#endif
+

--- a/Tests/SQLiteDataTests/CloudKitTests/FetchRecordZoneChangesTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/FetchRecordZoneChangesTests.swift
@@ -545,7 +545,7 @@
           │     title: "tag"                                           │
           │   ),                                                       │
           │   share: nil,                                              │
-          │   _isDeleted: false,                                       │
+          │   _pendingStatus: nil,                                     │
           │   _hasLastKnownServerRecord: true,                         │
           │   _isShared: false,                                        │
           │   userModificationTime: 0                                  │
@@ -628,7 +628,7 @@
           │     title: "tag"                                           │
           │   ),                                                       │
           │   share: nil,                                              │
-          │   _isDeleted: false,                                       │
+          │   _pendingStatus: nil,                                     │
           │   _hasLastKnownServerRecord: true,                         │
           │   _isShared: false,                                        │
           │   userModificationTime: 0                                  │
@@ -698,7 +698,7 @@
           │     title: "weekend"                                           │
           │   ),                                                           │
           │   share: nil,                                                  │
-          │   _isDeleted: false,                                           │
+          │   _pendingStatus: nil,                                         │
           │   _hasLastKnownServerRecord: true,                             │
           │   _isShared: false,                                            │
           │   userModificationTime: 0                                      │

--- a/Tests/SQLiteDataTests/CloudKitTests/MetadataTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MetadataTests.swift
@@ -236,7 +236,7 @@
           │     tagID: "weekend"                                                                    │
           │   ),                                                                                    │
           │   share: nil,                                                                           │
-          │   _isDeleted: false,                                                                    │
+          │   _pendingStatus: nil,                                                                  │
           │   _hasLastKnownServerRecord: true,                                                      │
           │   _isShared: false,                                                                     │
           │   userModificationTime: 0                                                               │
@@ -272,7 +272,7 @@
           │     title: "Groceries"                                                                  │
           │   ),                                                                                    │
           │   share: nil,                                                                           │
-          │   _isDeleted: false,                                                                    │
+          │   _pendingStatus: nil,                                                                  │
           │   _hasLastKnownServerRecord: true,                                                      │
           │   _isShared: false,                                                                     │
           │   userModificationTime: 0                                                               │
@@ -303,7 +303,7 @@
           │     title: "Personal"                                                                   │
           │   ),                                                                                    │
           │   share: nil,                                                                           │
-          │   _isDeleted: false,                                                                    │
+          │   _pendingStatus: nil,                                                                  │
           │   _hasLastKnownServerRecord: true,                                                      │
           │   _isShared: false,                                                                     │
           │   userModificationTime: 0                                                               │
@@ -335,7 +335,7 @@
           │     tagID: "weekend"                                                                    │
           │   ),                                                                                    │
           │   share: nil,                                                                           │
-          │   _isDeleted: false,                                                                    │
+          │   _pendingStatus: nil,                                                                  │
           │   _hasLastKnownServerRecord: true,                                                      │
           │   _isShared: false,                                                                     │
           │   userModificationTime: 0                                                               │
@@ -371,7 +371,7 @@
           │     title: "Take a walk"                                                                │
           │   ),                                                                                    │
           │   share: nil,                                                                           │
-          │   _isDeleted: false,                                                                    │
+          │   _pendingStatus: nil,                                                                  │
           │   _hasLastKnownServerRecord: true,                                                      │
           │   _isShared: false,                                                                     │
           │   userModificationTime: 0                                                               │
@@ -402,7 +402,7 @@
           │     title: "Business"                                                                   │
           │   ),                                                                                    │
           │   share: nil,                                                                           │
-          │   _isDeleted: false,                                                                    │
+          │   _pendingStatus: nil,                                                                  │
           │   _hasLastKnownServerRecord: true,                                                      │
           │   _isShared: false,                                                                     │
           │   userModificationTime: 0                                                               │
@@ -434,7 +434,7 @@
           │     tagID: "optional"                                                                   │
           │   ),                                                                                    │
           │   share: nil,                                                                           │
-          │   _isDeleted: false,                                                                    │
+          │   _pendingStatus: nil,                                                                  │
           │   _hasLastKnownServerRecord: true,                                                      │
           │   _isShared: false,                                                                     │
           │   userModificationTime: 0                                                               │
@@ -470,7 +470,7 @@
           │     title: "Call accountant"                                                            │
           │   ),                                                                                    │
           │   share: nil,                                                                           │
-          │   _isDeleted: false,                                                                    │
+          │   _pendingStatus: nil,                                                                  │
           │   _hasLastKnownServerRecord: true,                                                      │
           │   _isShared: false,                                                                     │
           │   userModificationTime: 0                                                               │
@@ -500,7 +500,7 @@
           │     title: "optional"                                                                   │
           │   ),                                                                                    │
           │   share: nil,                                                                           │
-          │   _isDeleted: false,                                                                    │
+          │   _pendingStatus: nil,                                                                  │
           │   _hasLastKnownServerRecord: true,                                                      │
           │   _isShared: false,                                                                     │
           │   userModificationTime: 0                                                               │
@@ -530,7 +530,7 @@
           │     title: "weekend"                                                                    │
           │   ),                                                                                    │
           │   share: nil,                                                                           │
-          │   _isDeleted: false,                                                                    │
+          │   _pendingStatus: nil,                                                                  │
           │   _hasLastKnownServerRecord: true,                                                      │
           │   _isShared: false,                                                                     │
           │   userModificationTime: 0                                                               │
@@ -583,7 +583,7 @@
           │                     │     title: "Personal"                                              │
           │                     │   ),                                                               │
           │                     │   share: nil,                                                      │
-          │                     │   _isDeleted: false,                                               │
+          │                     │   _pendingStatus: nil,                                             │
           │                     │   _hasLastKnownServerRecord: true,                                 │
           │                     │   _isShared: false,                                                │
           │                     │   userModificationTime: 0                                          │
@@ -614,7 +614,7 @@
           │                     │     title: "Work"                                                  │
           │                     │   ),                                                               │
           │                     │   share: nil,                                                      │
-          │                     │   _isDeleted: false,                                               │
+          │                     │   _pendingStatus: nil,                                             │
           │                     │   _hasLastKnownServerRecord: true,                                 │
           │                     │   _isShared: false,                                                │
           │                     │   userModificationTime: 0                                          │

--- a/Tests/SQLiteDataTests/CloudKitTests/MockSyncEngineStateTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MockSyncEngineStateTests.swift
@@ -1,0 +1,98 @@
+#if canImport(CloudKit)
+  import CloudKit
+  import SQLiteData
+  import Testing
+
+  @Suite struct MockSyncEngineStateTests {
+    let recordIDa = CKRecord.ID(recordName: "A")
+    let recordIDb = CKRecord.ID(recordName: "B")
+    let zoneIDa = CKRecordZone.ID(zoneName: "A", ownerName: CKCurrentUserDefaultName)
+    let zoneIDb = CKRecordZone.ID(zoneName: "B", ownerName: CKCurrentUserDefaultName)
+
+    @Suite struct PendingRecordZoneChanges {
+      let state = MockSyncEngineState()
+      let idA = CKRecord.ID(recordName: "A")
+      let idB = CKRecord.ID(recordName: "B")
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func sameType_isDeduplicatedAtOriginalPosition() {
+        state.add(pendingRecordZoneChanges: [.saveRecord(idA), .saveRecord(idB)])
+        state.add(pendingRecordZoneChanges: [.saveRecord(idA)])
+        #expect(state.pendingRecordZoneChanges == [.saveRecord(idA), .saveRecord(idB)])
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func saveThenDelete_deleteSupersedes() {
+        state.add(pendingRecordZoneChanges: [.saveRecord(idA)])
+        state.add(pendingRecordZoneChanges: [.deleteRecord(idA)])
+        #expect(state.pendingRecordZoneChanges == [.deleteRecord(idA)])
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func deleteThenSave_saveSupersedes() {
+        state.add(pendingRecordZoneChanges: [.deleteRecord(idA)])
+        state.add(pendingRecordZoneChanges: [.saveRecord(idA)])
+        #expect(state.pendingRecordZoneChanges == [.saveRecord(idA)])
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func deleteThenSaveThenDelete_lastDeleteWins() {
+        state.add(pendingRecordZoneChanges: [.deleteRecord(idA)])
+        state.add(pendingRecordZoneChanges: [.saveRecord(idA)])
+        state.add(pendingRecordZoneChanges: [.deleteRecord(idA)])
+        #expect(state.pendingRecordZoneChanges == [.deleteRecord(idA)])
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func crossTypeSupersession_doesNotAffectOtherRecords() {
+        state.add(pendingRecordZoneChanges: [.saveRecord(idA), .saveRecord(idB)])
+        state.add(pendingRecordZoneChanges: [.deleteRecord(idA)])
+        #expect(state.pendingRecordZoneChanges == [.deleteRecord(idA), .saveRecord(idB)])
+      }
+    }
+
+    @Suite struct PendingDatabaseChanges {
+      let state = MockSyncEngineState()
+      let zoneA = CKRecordZone(zoneName: "A")
+      let zoneB = CKRecordZone(zoneName: "B")
+      var zoneAID: CKRecordZone.ID { zoneA.zoneID }
+      var zoneBID: CKRecordZone.ID { zoneB.zoneID }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func sameType_isDeduplicatedAtOriginalPosition() {
+        state.add(pendingDatabaseChanges: [.saveZone(zoneA), .saveZone(zoneB)])
+        state.add(pendingDatabaseChanges: [.saveZone(zoneA)])
+        #expect(state.pendingDatabaseChanges == [.saveZone(zoneA), .saveZone(zoneB)])
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func saveThenDelete_deleteSupersedes() {
+        state.add(pendingDatabaseChanges: [.saveZone(zoneA)])
+        state.add(pendingDatabaseChanges: [.deleteZone(zoneAID)])
+        #expect(state.pendingDatabaseChanges == [.deleteZone(zoneAID)])
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func deleteThenSave_saveSupersedes() {
+        state.add(pendingDatabaseChanges: [.deleteZone(zoneAID)])
+        state.add(pendingDatabaseChanges: [.saveZone(zoneA)])
+        #expect(state.pendingDatabaseChanges == [.saveZone(zoneA)])
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func deleteThenSaveThenDelete_lastDeleteWins() {
+        state.add(pendingDatabaseChanges: [.deleteZone(zoneAID)])
+        state.add(pendingDatabaseChanges: [.saveZone(zoneA)])
+        state.add(pendingDatabaseChanges: [.deleteZone(zoneAID)])
+        #expect(state.pendingDatabaseChanges == [.deleteZone(zoneAID)])
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func crossTypeSupersession_doesNotAffectOtherZones() {
+        state.add(pendingDatabaseChanges: [.saveZone(zoneA), .saveZone(zoneB)])
+        state.add(pendingDatabaseChanges: [.deleteZone(zoneAID)])
+        #expect(state.pendingDatabaseChanges == [.deleteZone(zoneAID), .saveZone(zoneB)])
+      }
+    }
+  }
+#endif

--- a/Tests/SQLiteDataTests/CloudKitTests/SchemaChangeTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SchemaChangeTests.swift
@@ -162,7 +162,7 @@
           │     title: "My Stuff"                                              │
           │   ),                                                               │
           │   share: nil,                                                      │
-          │   _isDeleted: false,                                               │
+          │   _pendingStatus: nil,                                             │
           │   _hasLastKnownServerRecord: true,                                 │
           │   _isShared: false,                                                │
           │   userModificationTime: 0                                          │
@@ -506,7 +506,7 @@
           │     title: "My Stuff"                                              │
           │   ),                                                               │
           │   share: nil,                                                      │
-          │   _isDeleted: false,                                               │
+          │   _pendingStatus: nil,                                             │
           │   _hasLastKnownServerRecord: true,                                 │
           │   _isShared: false,                                                │
           │   userModificationTime: 1                                          │
@@ -618,7 +618,7 @@
           │     title: "Personal"                                              │
           │   ),                                                               │
           │   share: nil,                                                      │
-          │   _isDeleted: false,                                               │
+          │   _pendingStatus: nil,                                             │
           │   _hasLastKnownServerRecord: true,                                 │
           │   _isShared: false,                                                │
           │   userModificationTime: 0                                          │
@@ -665,7 +665,7 @@
           │     title: "My Stuff"                                              │
           │   ),                                                               │
           │   share: nil,                                                      │
-          │   _isDeleted: false,                                               │
+          │   _pendingStatus: nil,                                             │
           │   _hasLastKnownServerRecord: true,                                 │
           │   _isShared: false,                                                │
           │   userModificationTime: 0                                          │

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -500,7 +500,7 @@
           │     parent: nil,                                                                                    │
           │     share: nil                                                                                      │
           │   ),                                                                                                │
-          │   _isDeleted: false,                                                                                │
+          │   _pendingStatus: nil,                                                                              │
           │   _hasLastKnownServerRecord: true,                                                                  │
           │   _isShared: true,                                                                                  │
           │   userModificationTime: 0                                                                           │
@@ -583,7 +583,7 @@
           │     parent: nil,                                                                             │
           │     share: nil                                                                               │
           │   ),                                                                                         │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: true,                                                                           │
           │   userModificationTime: 0                                                                    │
@@ -618,7 +618,7 @@
           │     modelAID: 1                                                                              │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 60                                                                   │
@@ -653,7 +653,7 @@
           │     title: ""                                                                                │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 60                                                                   │
@@ -1249,7 +1249,7 @@
           │     parent: nil,                                                                                    │
           │     share: nil                                                                                      │
           │   ),                                                                                                │
-          │   _isDeleted: false,                                                                                │
+          │   _pendingStatus: nil,                                                                              │
           │   _hasLastKnownServerRecord: true,                                                                  │
           │   _isShared: true,                                                                                  │
           │   userModificationTime: 0                                                                           │
@@ -1285,7 +1285,7 @@
           │     title: "Get milk"                                                                               │
           │   ),                                                                                                │
           │   share: nil,                                                                                       │
-          │   _isDeleted: false,                                                                                │
+          │   _pendingStatus: nil,                                                                              │
           │   _hasLastKnownServerRecord: true,                                                                  │
           │   _isShared: false,                                                                                 │
           │   userModificationTime: 0                                                                           │
@@ -1932,7 +1932,7 @@
           │     id: 1                                                                                    │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 0                                                                    │
@@ -1968,7 +1968,7 @@
           │     parent: nil,                                                                             │
           │     share: nil                                                                               │
           │   ),                                                                                         │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: true,                                                                           │
           │   userModificationTime: 0                                                                    │
@@ -2003,7 +2003,7 @@
           │     modelAID: 2                                                                              │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 1                                                                    │
@@ -2038,7 +2038,7 @@
           │     title: "Blob"                                                                            │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 0                                                                    │
@@ -2237,7 +2237,7 @@
           │     id: 1                                                                                    │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 0                                                                    │
@@ -2273,7 +2273,7 @@
           │     parent: nil,                                                                             │
           │     share: nil                                                                               │
           │   ),                                                                                         │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: true,                                                                           │
           │   userModificationTime: 0                                                                    │
@@ -2308,7 +2308,7 @@
           │     modelAID: 2                                                                              │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 0                                                                    │
@@ -2343,7 +2343,7 @@
           │     title: "Blob"                                                                            │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 0                                                                    │
@@ -2542,7 +2542,7 @@
           │     id: 1                                                                                    │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 0                                                                    │
@@ -2578,7 +2578,7 @@
           │     parent: nil,                                                                             │
           │     share: nil                                                                               │
           │   ),                                                                                         │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: true,                                                                           │
           │   userModificationTime: 0                                                                    │
@@ -2613,7 +2613,7 @@
           │     modelAID: 2                                                                              │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 0                                                                    │
@@ -2648,7 +2648,7 @@
           │     title: "Blob"                                                                            │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 0                                                                    │
@@ -2827,7 +2827,7 @@
           │     id: 1                                                                                    │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 0                                                                    │
@@ -2863,7 +2863,7 @@
           │     parent: nil,                                                                             │
           │     share: nil                                                                               │
           │   ),                                                                                         │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: true,                                                                           │
           │   userModificationTime: 0                                                                    │
@@ -2898,7 +2898,7 @@
           │     modelAID: 1                                                                              │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 1                                                                    │
@@ -3070,7 +3070,7 @@
           │     id: 1                                                                                    │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 0                                                                    │
@@ -3106,7 +3106,7 @@
           │     parent: nil,                                                                             │
           │     share: nil                                                                               │
           │   ),                                                                                         │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: true,                                                                           │
           │   userModificationTime: 0                                                                    │
@@ -3141,7 +3141,7 @@
           │     modelAID: 2                                                                              │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 1                                                                    │
@@ -3176,7 +3176,7 @@
           │     title: "Blob"                                                                            │
           │   ),                                                                                         │
           │   share: nil,                                                                                │
-          │   _isDeleted: false,                                                                         │
+          │   _pendingStatus: nil,                                                                       │
           │   _hasLastKnownServerRecord: true,                                                           │
           │   _isShared: false,                                                                          │
           │   userModificationTime: 0                                                                    │

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineDelegateTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineDelegateTests.swift
@@ -65,7 +65,7 @@
           │     title: "Personal"                                              │
           │   ),                                                               │
           │   share: nil,                                                      │
-          │   _isDeleted: false,                                               │
+          │   _pendingStatus: nil,                                             │
           │   _hasLastKnownServerRecord: true,                                 │
           │   _isShared: false,                                                │
           │   userModificationTime: 0                                          │
@@ -139,7 +139,7 @@
           │     title: "Personal"                                              │
           │   ),                                                               │
           │   share: nil,                                                      │
-          │   _isDeleted: false,                                               │
+          │   _pendingStatus: nil,                                             │
           │   _hasLastKnownServerRecord: true,                                 │
           │   _isShared: false,                                                │
           │   userModificationTime: 0                                          │

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineLifecycleTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineLifecycleTests.swift
@@ -49,7 +49,7 @@
             │   lastKnownServerRecord: nil,            │
             │   _lastKnownServerRecordAllFields: nil,  │
             │   share: nil,                            │
-            │   _isDeleted: false,                     │
+            │   _pendingStatus: nil,                   │
             │   _hasLastKnownServerRecord: false,      │
             │   _isShared: false,                      │
             │   userModificationTime: 0                │
@@ -71,7 +71,7 @@
             │   lastKnownServerRecord: nil,            │
             │   _lastKnownServerRecordAllFields: nil,  │
             │   share: nil,                            │
-            │   _isDeleted: false,                     │
+            │   _pendingStatus: nil,                   │
             │   _hasLastKnownServerRecord: false,      │
             │   _isShared: false,                      │
             │   userModificationTime: 0                │
@@ -329,7 +329,7 @@
             │     parent: nil,                                                                                    │
             │     share: nil                                                                                      │
             │   ),                                                                                                │
-            │   _isDeleted: false,                                                                                │
+            │   _pendingStatus: nil,                                                                              │
             │   _hasLastKnownServerRecord: true,                                                                  │
             │   _isShared: true,                                                                                  │
             │   userModificationTime: 0                                                                           │
@@ -351,7 +351,7 @@
             │   lastKnownServerRecord: nil,                                                                       │
             │   _lastKnownServerRecordAllFields: nil,                                                             │
             │   share: nil,                                                                                       │
-            │   _isDeleted: false,                                                                                │
+            │   _pendingStatus: nil,                                                                              │
             │   _hasLastKnownServerRecord: false,                                                                 │
             │   _isShared: false,                                                                                 │
             │   userModificationTime: 60                                                                          │
@@ -608,7 +608,7 @@
             │   lastKnownServerRecord: nil,            │
             │   _lastKnownServerRecordAllFields: nil,  │
             │   share: nil,                            │
-            │   _isDeleted: false,                     │
+            │   _pendingStatus: nil,                   │
             │   _hasLastKnownServerRecord: false,      │
             │   _isShared: false,                      │
             │   userModificationTime: 0                │
@@ -630,7 +630,7 @@
             │   lastKnownServerRecord: nil,            │
             │   _lastKnownServerRecordAllFields: nil,  │
             │   share: nil,                            │
-            │   _isDeleted: false,                     │
+            │   _pendingStatus: nil,                   │
             │   _hasLastKnownServerRecord: false,      │
             │   _isShared: false,                      │
             │   userModificationTime: 0                │
@@ -686,7 +686,7 @@
             │     title: "Personal"                                                                   │
             │   ),                                                                                    │
             │   share: nil,                                                                           │
-            │   _isDeleted: false,                                                                    │
+            │   _pendingStatus: nil,                                                                  │
             │   _hasLastKnownServerRecord: true,                                                      │
             │   _isShared: false,                                                                     │
             │   userModificationTime: 0                                                               │
@@ -722,7 +722,7 @@
             │     title: "Get milk"                                                                   │
             │   ),                                                                                    │
             │   share: nil,                                                                           │
-            │   _isDeleted: false,                                                                    │
+            │   _pendingStatus: nil,                                                                  │
             │   _hasLastKnownServerRecord: true,                                                      │
             │   _isShared: false,                                                                     │
             │   userModificationTime: 0                                                               │

--- a/Tests/SQLiteDataTests/CloudKitTests/TriggerTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/TriggerTests.swift
@@ -43,7 +43,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('childWithOnDeleteSetDefaults')));
               END
               """,
@@ -72,7 +72,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('childWithOnDeleteSetNulls')));
               END
               """,
@@ -101,7 +101,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('modelAs')));
               END
               """,
@@ -130,7 +130,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('modelBs')));
               END
               """,
@@ -159,7 +159,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('modelCs')));
               END
               """,
@@ -188,7 +188,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('parents')));
               END
               """,
@@ -217,7 +217,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('reminderTags')));
               END
               """,
@@ -246,7 +246,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListAssets')));
               END
               """,
@@ -275,7 +275,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListPrivates')));
               END
               """,
@@ -304,7 +304,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersLists')));
               END
               """,
@@ -333,7 +333,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('reminders')));
               END
               """,
@@ -362,14 +362,14 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('scopedModels')));
               END
               """,
               [24]: """
               CREATE TRIGGER "sqlitedata_icloud_after_delete_on_sqlitedata_icloud_metadata"
-              AFTER UPDATE OF "_isDeleted" ON "sqlitedata_icloud_metadata"
-              FOR EACH ROW WHEN ((NOT ("old"."_isDeleted")) AND ("new"."_isDeleted")) AND (NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) BEGIN
+              AFTER UPDATE OF "_pendingStatus" ON "sqlitedata_icloud_metadata"
+              FOR EACH ROW WHEN (((("old"."_pendingStatus") IS (NULL)) OR (("old"."_pendingStatus") <> (0))) AND (("new"."_pendingStatus") = (0))) AND (NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) BEGIN
                 SELECT "sqlitedata_icloud_didDelete"("new"."recordName", coalesce("new"."lastKnownServerRecord", (
                   WITH "ancestorMetadatas" AS (
                     SELECT "sqlitedata_icloud_metadata"."recordName" AS "recordName", "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."lastKnownServerRecord" AS "lastKnownServerRecord"
@@ -411,7 +411,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."title")) AND (("sqlitedata_icloud_metadata"."recordType") = ('tags')));
               END
               """,
@@ -439,6 +439,9 @@
                 FROM "sqlitedata_icloud_metadata"
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."parentID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('parents'))))), '__defaultOwner__'), "new"."parentID", 'parents'
                 ON CONFLICT DO NOTHING;
+                UPDATE "sqlitedata_icloud_metadata"
+                SET "_pendingStatus" = 1, "userModificationTime" = "sqlitedata_icloud_currentTime"()
+                WHERE (((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('childWithOnDeleteSetDefaults'))) AND (("sqlitedata_icloud_metadata"."_pendingStatus") = (0)));
               END
               """,
               [28]: """
@@ -465,6 +468,9 @@
                 FROM "sqlitedata_icloud_metadata"
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."parentID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('parents'))))), '__defaultOwner__'), "new"."parentID", 'parents'
                 ON CONFLICT DO NOTHING;
+                UPDATE "sqlitedata_icloud_metadata"
+                SET "_pendingStatus" = 1, "userModificationTime" = "sqlitedata_icloud_currentTime"()
+                WHERE (((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('childWithOnDeleteSetNulls'))) AND (("sqlitedata_icloud_metadata"."_pendingStatus") = (0)));
               END
               """,
               [29]: """
@@ -487,6 +493,9 @@
                 ("recordPrimaryKey", "recordType", "zoneName", "ownerName", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'modelAs', coalesce("sqlitedata_icloud_currentZoneName"(), 'zone'), coalesce("sqlitedata_icloud_currentOwnerName"(), '__defaultOwner__'), NULL, NULL
                 ON CONFLICT DO NOTHING;
+                UPDATE "sqlitedata_icloud_metadata"
+                SET "_pendingStatus" = 1, "userModificationTime" = "sqlitedata_icloud_currentTime"()
+                WHERE (((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('modelAs'))) AND (("sqlitedata_icloud_metadata"."_pendingStatus") = (0)));
               END
               """,
               [30]: """
@@ -513,6 +522,9 @@
                 FROM "sqlitedata_icloud_metadata"
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."modelAID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('modelAs'))))), '__defaultOwner__'), "new"."modelAID", 'modelAs'
                 ON CONFLICT DO NOTHING;
+                UPDATE "sqlitedata_icloud_metadata"
+                SET "_pendingStatus" = 1, "userModificationTime" = "sqlitedata_icloud_currentTime"()
+                WHERE (((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('modelBs'))) AND (("sqlitedata_icloud_metadata"."_pendingStatus") = (0)));
               END
               """,
               [31]: """
@@ -539,6 +551,9 @@
                 FROM "sqlitedata_icloud_metadata"
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."modelBID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('modelBs'))))), '__defaultOwner__'), "new"."modelBID", 'modelBs'
                 ON CONFLICT DO NOTHING;
+                UPDATE "sqlitedata_icloud_metadata"
+                SET "_pendingStatus" = 1, "userModificationTime" = "sqlitedata_icloud_currentTime"()
+                WHERE (((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('modelCs'))) AND (("sqlitedata_icloud_metadata"."_pendingStatus") = (0)));
               END
               """,
               [32]: """
@@ -561,6 +576,9 @@
                 ("recordPrimaryKey", "recordType", "zoneName", "ownerName", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'parents', coalesce("sqlitedata_icloud_currentZoneName"(), 'zone'), coalesce("sqlitedata_icloud_currentOwnerName"(), '__defaultOwner__'), NULL, NULL
                 ON CONFLICT DO NOTHING;
+                UPDATE "sqlitedata_icloud_metadata"
+                SET "_pendingStatus" = 1, "userModificationTime" = "sqlitedata_icloud_currentTime"()
+                WHERE (((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('parents'))) AND (("sqlitedata_icloud_metadata"."_pendingStatus") = (0)));
               END
               """,
               [33]: """
@@ -583,6 +601,9 @@
                 ("recordPrimaryKey", "recordType", "zoneName", "ownerName", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'reminderTags', coalesce("sqlitedata_icloud_currentZoneName"(), 'zone'), coalesce("sqlitedata_icloud_currentOwnerName"(), '__defaultOwner__'), NULL, NULL
                 ON CONFLICT DO NOTHING;
+                UPDATE "sqlitedata_icloud_metadata"
+                SET "_pendingStatus" = 1, "userModificationTime" = "sqlitedata_icloud_currentTime"()
+                WHERE (((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('reminderTags'))) AND (("sqlitedata_icloud_metadata"."_pendingStatus") = (0)));
               END
               """,
               [34]: """
@@ -609,6 +630,9 @@
                 FROM "sqlitedata_icloud_metadata"
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersLists'))))), '__defaultOwner__'), "new"."remindersListID", 'remindersLists'
                 ON CONFLICT DO NOTHING;
+                UPDATE "sqlitedata_icloud_metadata"
+                SET "_pendingStatus" = 1, "userModificationTime" = "sqlitedata_icloud_currentTime"()
+                WHERE (((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('reminders'))) AND (("sqlitedata_icloud_metadata"."_pendingStatus") = (0)));
               END
               """,
               [35]: """
@@ -635,6 +659,9 @@
                 FROM "sqlitedata_icloud_metadata"
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersLists'))))), '__defaultOwner__'), "new"."remindersListID", 'remindersLists'
                 ON CONFLICT DO NOTHING;
+                UPDATE "sqlitedata_icloud_metadata"
+                SET "_pendingStatus" = 1, "userModificationTime" = "sqlitedata_icloud_currentTime"()
+                WHERE (((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListAssets'))) AND (("sqlitedata_icloud_metadata"."_pendingStatus") = (0)));
               END
               """,
               [36]: """
@@ -661,6 +688,9 @@
                 FROM "sqlitedata_icloud_metadata"
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersLists'))))), '__defaultOwner__'), "new"."remindersListID", 'remindersLists'
                 ON CONFLICT DO NOTHING;
+                UPDATE "sqlitedata_icloud_metadata"
+                SET "_pendingStatus" = 1, "userModificationTime" = "sqlitedata_icloud_currentTime"()
+                WHERE (((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListPrivates'))) AND (("sqlitedata_icloud_metadata"."_pendingStatus") = (0)));
               END
               """,
               [37]: """
@@ -683,6 +713,9 @@
                 ("recordPrimaryKey", "recordType", "zoneName", "ownerName", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'remindersLists', coalesce("sqlitedata_icloud_currentZoneName"(), 'zone'), coalesce("sqlitedata_icloud_currentOwnerName"(), '__defaultOwner__'), NULL, NULL
                 ON CONFLICT DO NOTHING;
+                UPDATE "sqlitedata_icloud_metadata"
+                SET "_pendingStatus" = 1, "userModificationTime" = "sqlitedata_icloud_currentTime"()
+                WHERE (((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersLists'))) AND (("sqlitedata_icloud_metadata"."_pendingStatus") = (0)));
               END
               """,
               [38]: """
@@ -705,6 +738,9 @@
                 ("recordPrimaryKey", "recordType", "zoneName", "ownerName", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."id", 'scopedModels', coalesce("sqlitedata_icloud_currentZoneName"(), 'zone'), coalesce("sqlitedata_icloud_currentOwnerName"(), '__defaultOwner__'), NULL, NULL
                 ON CONFLICT DO NOTHING;
+                UPDATE "sqlitedata_icloud_metadata"
+                SET "_pendingStatus" = 1, "userModificationTime" = "sqlitedata_icloud_currentTime"()
+                WHERE (((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('scopedModels'))) AND (("sqlitedata_icloud_metadata"."_pendingStatus") = (0)));
               END
               """,
               [39]: """
@@ -736,6 +772,9 @@
                 ("recordPrimaryKey", "recordType", "zoneName", "ownerName", "parentRecordPrimaryKey", "parentRecordType")
                 SELECT "new"."title", 'tags', coalesce("sqlitedata_icloud_currentZoneName"(), 'zone'), coalesce("sqlitedata_icloud_currentOwnerName"(), '__defaultOwner__'), NULL, NULL
                 ON CONFLICT DO NOTHING;
+                UPDATE "sqlitedata_icloud_metadata"
+                SET "_pendingStatus" = 1, "userModificationTime" = "sqlitedata_icloud_currentTime"()
+                WHERE (((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."title")) AND (("sqlitedata_icloud_metadata"."recordType") = ('tags'))) AND (("sqlitedata_icloud_metadata"."_pendingStatus") = (0)));
               END
               """,
               [41]: """
@@ -755,7 +794,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('childWithOnDeleteSetDefaults')));
               END
               """,
@@ -776,7 +815,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('childWithOnDeleteSetNulls')));
               END
               """,
@@ -797,7 +836,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('modelAs')));
               END
               """,
@@ -818,7 +857,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('modelBs')));
               END
               """,
@@ -839,7 +878,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('modelCs')));
               END
               """,
@@ -860,7 +899,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('parents')));
               END
               """,
@@ -881,7 +920,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('reminderTags')));
               END
               """,
@@ -902,7 +941,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('reminders')));
               END
               """,
@@ -923,7 +962,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListAssets')));
               END
               """,
@@ -944,7 +983,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListPrivates')));
               END
               """,
@@ -965,7 +1004,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersLists')));
               END
               """,
@@ -986,7 +1025,7 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('scopedModels')));
               END
               """,
@@ -1007,11 +1046,18 @@
                 FROM "rootShares"
                 WHERE (((NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) AND (("rootShares"."parentRecordName") IS (NULL))) AND (NOT ("sqlitedata_icloud_hasPermission"("rootShares"."share"))));
                 UPDATE "sqlitedata_icloud_metadata"
-                SET "_isDeleted" = 1
+                SET "_pendingStatus" = 0
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("old"."title")) AND (("sqlitedata_icloud_metadata"."recordType") = ('tags')));
               END
               """,
               [54]: """
+              CREATE TRIGGER "sqlitedata_icloud_after_reinsert_on_sqlitedata_icloud_metadata"
+              AFTER UPDATE OF "_pendingStatus" ON "sqlitedata_icloud_metadata"
+              FOR EACH ROW WHEN ((("old"."_pendingStatus") = (0)) AND (("new"."_pendingStatus") = (1))) AND (NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) BEGIN
+                SELECT "sqlitedata_icloud_didUpdate"("new"."recordName", "new"."zoneName", "new"."ownerName", "new"."zoneName", "new"."ownerName", NULL);
+              END
+              """,
+              [55]: """
               CREATE TRIGGER "sqlitedata_icloud_after_update_on_childWithOnDeleteSetDefaults"
               AFTER UPDATE ON "childWithOnDeleteSetDefaults"
               FOR EACH ROW BEGIN
@@ -1044,7 +1090,7 @@
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('childWithOnDeleteSetDefaults')));
               END
               """,
-              [55]: """
+              [56]: """
               CREATE TRIGGER "sqlitedata_icloud_after_update_on_childWithOnDeleteSetNulls"
               AFTER UPDATE ON "childWithOnDeleteSetNulls"
               FOR EACH ROW BEGIN
@@ -1077,7 +1123,7 @@
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('childWithOnDeleteSetNulls')));
               END
               """,
-              [56]: """
+              [57]: """
               CREATE TRIGGER "sqlitedata_icloud_after_update_on_modelAs"
               AFTER UPDATE ON "modelAs"
               FOR EACH ROW BEGIN
@@ -1102,7 +1148,7 @@
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('modelAs')));
               END
               """,
-              [57]: """
+              [58]: """
               CREATE TRIGGER "sqlitedata_icloud_after_update_on_modelBs"
               AFTER UPDATE ON "modelBs"
               FOR EACH ROW BEGIN
@@ -1135,7 +1181,7 @@
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('modelBs')));
               END
               """,
-              [58]: """
+              [59]: """
               CREATE TRIGGER "sqlitedata_icloud_after_update_on_modelCs"
               AFTER UPDATE ON "modelCs"
               FOR EACH ROW BEGIN
@@ -1168,7 +1214,7 @@
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('modelCs')));
               END
               """,
-              [59]: """
+              [60]: """
               CREATE TRIGGER "sqlitedata_icloud_after_update_on_parents"
               AFTER UPDATE ON "parents"
               FOR EACH ROW BEGIN
@@ -1193,7 +1239,7 @@
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('parents')));
               END
               """,
-              [60]: """
+              [61]: """
               CREATE TRIGGER "sqlitedata_icloud_after_update_on_reminderTags"
               AFTER UPDATE ON "reminderTags"
               FOR EACH ROW BEGIN
@@ -1218,7 +1264,7 @@
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('reminderTags')));
               END
               """,
-              [61]: """
+              [62]: """
               CREATE TRIGGER "sqlitedata_icloud_after_update_on_reminders"
               AFTER UPDATE ON "reminders"
               FOR EACH ROW BEGIN
@@ -1251,7 +1297,7 @@
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('reminders')));
               END
               """,
-              [62]: """
+              [63]: """
               CREATE TRIGGER "sqlitedata_icloud_after_update_on_remindersListAssets"
               AFTER UPDATE ON "remindersListAssets"
               FOR EACH ROW BEGIN
@@ -1284,7 +1330,7 @@
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListAssets')));
               END
               """,
-              [63]: """
+              [64]: """
               CREATE TRIGGER "sqlitedata_icloud_after_update_on_remindersListPrivates"
               AFTER UPDATE ON "remindersListPrivates"
               FOR EACH ROW BEGIN
@@ -1317,7 +1363,7 @@
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."remindersListID")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersListPrivates')));
               END
               """,
-              [64]: """
+              [65]: """
               CREATE TRIGGER "sqlitedata_icloud_after_update_on_remindersLists"
               AFTER UPDATE ON "remindersLists"
               FOR EACH ROW BEGIN
@@ -1342,7 +1388,7 @@
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('remindersLists')));
               END
               """,
-              [65]: """
+              [66]: """
               CREATE TRIGGER "sqlitedata_icloud_after_update_on_scopedModels"
               AFTER UPDATE ON "scopedModels"
               FOR EACH ROW BEGIN
@@ -1367,10 +1413,10 @@
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."id")) AND (("sqlitedata_icloud_metadata"."recordType") = ('scopedModels')));
               END
               """,
-              [66]: """
+              [67]: """
               CREATE TRIGGER "sqlitedata_icloud_after_update_on_sqlitedata_icloud_metadata"
               AFTER UPDATE ON "sqlitedata_icloud_metadata"
-              FOR EACH ROW WHEN (("old"."_isDeleted") = ("new"."_isDeleted")) AND (NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) BEGIN
+              FOR EACH ROW WHEN (("old"."_pendingStatus") IS ("new"."_pendingStatus")) AND (NOT ("sqlitedata_icloud_syncEngineIsSynchronizingChanges"())) BEGIN
                 SELECT RAISE(ABORT, 'co.pointfree.SQLiteData.CloudKit.invalid-record-name-error')
                 WHERE NOT (((substr("new"."recordName", 1, 1)) <> ('_')) AND ((octet_length("new"."recordName")) <= (255))) AND ((octet_length("new"."recordName")) = (length("new"."recordName")));
                 SELECT "sqlitedata_icloud_didUpdate"("new"."recordName", "new"."zoneName", "new"."ownerName", "old"."zoneName", "old"."ownerName", CASE WHEN (("new"."zoneName") <> ("old"."zoneName")) OR (("new"."ownerName") <> ("old"."ownerName")) THEN (
@@ -1389,7 +1435,7 @@
                 ) END);
               END
               """,
-              [67]: """
+              [68]: """
               CREATE TRIGGER "sqlitedata_icloud_after_update_on_tags"
               AFTER UPDATE ON "tags"
               FOR EACH ROW BEGIN
@@ -1414,7 +1460,7 @@
                 WHERE ((("sqlitedata_icloud_metadata"."recordPrimaryKey") = ("new"."title")) AND (("sqlitedata_icloud_metadata"."recordType") = ('tags')));
               END
               """,
-              [68]: """
+              [69]: """
               CREATE TRIGGER "sqlitedata_icloud_after_zone_update_on_sqlitedata_icloud_metadata"
               AFTER UPDATE OF "zoneName", "ownerName" ON "sqlitedata_icloud_metadata"
               FOR EACH ROW WHEN (("new"."zoneName") <> ("old"."zoneName")) OR (("new"."ownerName") <> ("old"."ownerName")) BEGIN

--- a/Tests/SQLiteDataTests/Internal/CloudKit+CustomDump.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKit+CustomDump.swift
@@ -1,6 +1,7 @@
 #if canImport(CloudKit)
   import CustomDump
   import CloudKit
+  import OrderedCollections
   import SQLiteData
 
   extension CKDatabase.Scope: @retroactive CustomDumpStringConvertible {
@@ -175,13 +176,13 @@
         children: [
           (
             "pendingRecordZoneChanges",
-            _pendingRecordZoneChanges.withValue(\.self)
+            _pendingRecordZoneChanges.withValue { Array($0.values) }
               .sorted(by: comparePendingRecordZoneChange)
               as Any
           ),
           (
             "pendingDatabaseChanges",
-            _pendingDatabaseChanges.withValue(\.self)
+            _pendingDatabaseChanges.withValue { Array($0.values) }
               .sorted(by: comparePendingDatabaseChange) as Any
           ),
         ],

--- a/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
@@ -164,7 +164,7 @@ extension MockSyncEngineState {
     _pendingRecordZoneChanges.withValue {
       expectNoDifference(
         Set(changes),
-        Set($0),
+        Set($0.values),
         fileID: fileID,
         filePath: filePath,
         line: line,
@@ -184,7 +184,7 @@ extension MockSyncEngineState {
     _pendingDatabaseChanges.withValue {
       expectNoDifference(
         Set(changes),
-        Set($0),
+        Set($0.values),
         fileID: fileID,
         filePath: filePath,
         line: line,


### PR DESCRIPTION
Fixes #418 

### Root cause
Reinsertion of a record after a delete does not produce a new pending `.saveRecord` change entry due to missing undelete/reinsert state detection in `PrimaryKeyedTable.afterInsert` trigger. No new `.saveRecord` means that only the `.deleteRecord` is propagated.

### Solution

To fulfill the expected behavior of reinsertion resulting in a `.saveRecord` and assigning fresh timestamps to all fields, several changes are needed: one prerequisite change to test infrastructure `MockSyncEngineState`, and a four-part change to detect and handle reinsertion properly.

#### **Prerequisite change necessary for writing accurate tests**: Update `MockSyncEngineState` to deduplicate changes across types like the real `CKSyncEngine.State`

From `CKSyncEngine.State.add(pendingRecordZoneChanges:)` [documentation](https://developer.apple.com/documentation/cloudkit/cksyncengine-5sie5/state-swift.class/add(pendingrecordzonechanges:)?changes=_2,_2):
> Note
> The order in which you apply record zone changes is important.
> For example:
> * If you add `.saveRecord(recordA)` then `.deleteRecord(recordA)`, the sync engine 
> discards the save and sends only the delete change.
> * If you add `.deleteRecord(recordA)` then `.saveRecord(recordA)`, the sync engine
> discards the delete and sends only the save change.

`MockSyncEngineState.add(pendingRecordZoneChanges:)` deduplicates fully identical changes (type+ID) by virtue of the underlying `OrderedSet`, but does not deduplicate when the type (save vs delete) is different, as is described above with `CKSyncEngine.State`. `MockSyncEngineState.add(pendingDatabaseChanges:)` has a similar issue. The fix: update both to deduplicate based on ID alone which will allow for the cross-type deduplication described above, and add tests.

#### Changes to detect and handle reinsertion:
#### 1. Replace `SyncMetadata._isDeleted` with enum value `SyncMetadata._pendingStatus`
The `_isDeleted` field does not provide enough information about the current pending/transition status of the record. Introduce new enum value field `_pendingStatus` to replace `_isDeleted` with two cases: `.deleted` (soft-deleted) and `.reinserted` (row re-added while soft-deleted). 

#### 2. Detect reinsertion of soft-deleted record, update `_pendingStatus` and queue new `.saveRecord` change
Modify `PrimaryKeyedTable.afterInsert` trigger to update the `SyncMetadata` record when reinsertion of a soft-deleted row is detected (insert comes through while `_pendingStatus` is `.deleted`). Updates include:
* Setting `_pendingStatus` to `.reinserted`
   * This status will be used to trigger full re-hydration of `_lastKnownServerRecordAllFields` to be based on local, reinserted state when preparing an outbound record (see `#3` below) and before processing inbound server record (see `#4` below).
* Updating `userModificationTime`
   * Will be used as the modified time for all fields in the reinserted row when hydrating `_lastKnownServerRecordAllFields`

Hook up new `SyncMetadata.afterReinsertTrigger` to listen for reinsertions. This trigger is responsible for queuing a `.saveRecord` change via `syncEngine.$didUpdate` (the same as what happens after a normal insert or update).

#### 3. In `nextRecordZoneChangeBatch` (outbound record preparation), ensure record is built with reinserted row values

When preparing an outbound record for a `.reinserted` row, use `SyncMetadata.lastKnownServerRecord` (system fields only) as the base for building the record. Using `lastKnownServerRecord` as the base (vs `_lastKnownServerRecordAllFields` which would contain stale user field data) ensures the resulting all fields record is built up entirely from the current contents of the reinserted row + reinsert `userModificationTime`.

Additionally, as a cleanup step, upon saving the newly built record back into the metadata row, reset metadata `_pendingStatus` to nil. This ensures this "rebuild record from reinserted row" behavior will occur only once per reinsertion.

#### 4. In `upsertFromServerRecord` (inbound record processing), ensure local `allFields` state reflects reinserted row values prior to server record application

Since `upsertFromServerRecord` can occur *before* `nextRecordZoneChangeBatch`, we also need to ensure that the local metadata 'allFields' state is rebuilt and accurate when we encounter any `.reinserted` rows in this code path.

So before reconciling local metadata and user row with server record data, check if we're dealing with a `.reinserted` row, and if so, update the local `allFields` record to reflect all reinserted row values + reinsert `userModificationTime`. And similarly to the outbound path, clean up by setting `_pendingStatus` to nil at the conclusion of the upsert.

### Testing
In addition to new unit tests, performed a manual test with https://github.com/pointfreeco/sqlite-data/pull/417/changes/9ea5bdd88b79d7c9db88021e568c8a66789a21fa applied to verify that the data loss issue no longer occurs. Result (compare with [before](https://github.com/user-attachments/assets/173f1010-9353-43e6-a2ee-b0455800e85f)):

https://github.com/user-attachments/assets/da7d2907-dbda-4e21-be6d-d1512299bad6