### PR TITLE
Rename CKRecord.setValue overload to setBytes to fix unexpected Xcode 26.4 overload resolution

### DIFF
--- a/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
@@ -190,7 +190,7 @@
     }
 
     @discardableResult
-    package func setValue(
+    package func setBytes(
       _ newValue: [UInt8],
       forKey key: CKRecord.FieldKey,
       at userModificationTime: Int64
@@ -252,7 +252,7 @@
           let value = Value(queryOutput: row[keyPath: keyPath])
           switch value.queryBinding {
           case .blob(let value):
-            setValue(value, forKey: column.name, at: userModificationTime)
+            setBytes(value, forKey: column.name, at: userModificationTime)
           case .bool(let value):
             setValue(value, forKey: column.name, at: userModificationTime)
           case .double(let value):

--- a/Tests/SQLiteDataTests/CloudKitTests/AssetsTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/AssetsTests.swift
@@ -285,7 +285,7 @@
           recordID: RemindersListAsset.recordID(for: 1)
         )
         remindersListAssetRecord.setValue("1", forKey: "id", at: now)
-        remindersListAssetRecord.setValue(
+        remindersListAssetRecord.setBytes(
           Array("image".utf8),
           forKey: "coverImage",
           at: now

--- a/Tests/SQLiteDataTests/CloudKitTests/SchemaChangeTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SchemaChangeTests.swift
@@ -716,7 +716,7 @@
           let personalListRecord = try syncEngine.private.database.record(
             for: RemindersList.recordID(for: 1)
           )
-          personalListRecord.setValue(Array("image".utf8), forKey: "image", at: now)
+          personalListRecord.setBytes(Array("image".utf8), forKey: "image", at: now)
 
           try await syncEngine.modifyRecords(
             scope: .private,
@@ -775,15 +775,15 @@
           let personalListRecord = try syncEngine.private.database.record(
             for: RemindersList.recordID(for: 1)
           )
-          personalListRecord.setValue(Array("personal-image".utf8), forKey: "image", at: now)
+          personalListRecord.setBytes(Array("personal-image".utf8), forKey: "image", at: now)
           let businessListRecord = try syncEngine.private.database.record(
             for: RemindersList.recordID(for: 2)
           )
-          businessListRecord.setValue(Array("business-image".utf8), forKey: "image", at: now)
+          businessListRecord.setBytes(Array("business-image".utf8), forKey: "image", at: now)
           let secretListRecord = try syncEngine.private.database.record(
             for: RemindersList.recordID(for: 3)
           )
-          secretListRecord.setValue(Array("secret-image".utf8), forKey: "image", at: now)
+          secretListRecord.setBytes(Array("secret-image".utf8), forKey: "image", at: now)
 
           try await syncEngine.modifyRecords(
             scope: .private,


### PR DESCRIPTION
## Problem
Unit tests are failing with Xcode 26.4 (I'm on Xcode 26.4 RC 17E192).

When calling `CKRecord.setValue(_ newValue:forKey:at)` with a value of bytes (`[UInt8]`), building with Xcode 26.4 results in an unexpected `setValue` overload being invoked, causing test failures in `SchemaChangeTests` and `AssetsTests`.

**With Xcode 26.3**, the expected overload accepting `[UInt8]` is invoked. This overload saves the bytes in a `CKAsset` and then saves the asset as a regular field on the record.
https://github.com/pointfreeco/sqlite-data/blob/65502acdb033ec8025a0bcc443abf2f4ca0598f9/Sources/SQLiteData/CloudKit/CloudKit%2BStructuredQueries.swift#L193-L194

**With Xcode 26.4**, the overload accepting `some CKRecordValueProtocol & Equatable` is invoked instead. This overload writes the value directly to `encryptedValues`, no `CKAsset`.
https://github.com/pointfreeco/sqlite-data/blob/65502acdb033ec8025a0bcc443abf2f4ca0598f9/Sources/SQLiteData/CloudKit/CloudKit%2BStructuredQueries.swift#L154-L155

## Solution

Rename the overload which accepts bytes to `setBytes` and update all callers. The new name sidesteps the compiler having to resolve the overload and better reflects there being a distinct behavioral difference compared to plain `setValue`.

## Testing
With Xcode 26.4 selected, `swift test`. All tests pass including previously failing `SchemaChangeTests` and `AssetsTests`.