### PR TITLE
Add metadatabase URL override for CloudKit sync

### DIFF
--- a/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
@@ -13,11 +13,12 @@
       open "\(url.path(percentEncoded: false))"
       """
     )
-    try FileManager.default.createDirectory(
-      at: .applicationSupportDirectory,
-      withIntermediateDirectories: true
-    )
-
+    #if !os(tvOS)
+      try FileManager.default.createDirectory(
+        at: .applicationSupportDirectory,
+        withIntermediateDirectories: true
+      )
+    #endif
     @Dependency(\.context) var context
     guard !url.isInMemory || context != .live
     else {

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -2239,10 +2239,12 @@
         containerIdentifier: containerIdentifier
       )
       let path = url.isInMemory ? url.absoluteString : url.path(percentEncoded: false)
-      try FileManager.default.createDirectory(
-        at: .applicationSupportDirectory,
-        withIntermediateDirectories: true
-      )
+      #if !os(tvOS)
+        try FileManager.default.createDirectory(
+          at: .applicationSupportDirectory,
+          withIntermediateDirectories: true
+        )
+      #endif
       let database: any DatabaseWriter =
         url.isInMemory
         ? try DatabaseQueue(path: path)


### PR DESCRIPTION
## Summary

Adds an optional `metadatabaseURL` override to SQLiteData's CloudKit APIs so callers can choose where the CloudKit metadata database lives.

## Changes

- Add `metadatabaseURL: URL? = nil` to:
  - `SyncEngine.init(for:tables:privateTables:containerIdentifier:metadatabaseURL:defaultZone:startImmediately:delegate:logger:)`
  - `Database.attachMetadatabase(containerIdentifier:metadatabaseURL:)`
- Preserve existing behavior when no override is provided.
- Create the parent directory of the resolved metadata URL instead of always creating `Application Support`.

## Motivation

Some platforms, notably tvOS, may not allow the current hardcoded `Application Support` behavior for this metadata database. The main user database may already be configured to live somewhere else, but CloudKit setup still fails because the metadata store is not configurable.

This change keeps the default behavior intact for existing apps while allowing callers to explicitly provide a writable location when needed.

## Example

```swift
let metadataURL = FileManager.default
  .urls(for: .cachesDirectory, in: .userDomainMask)
  .first?
  .appendingPathComponent(".SQLiteData.metadata.sqlite")

var configuration = Configuration()
configuration.prepareDatabase { db in
  try db.attachMetadatabase(metadatabaseURL: metadataURL)
}

let database = try SQLiteData.defaultDatabase(
  path: databaseURL.path,
  configuration: configuration
)

let syncEngine = try SyncEngine(
  for: database,
  privateTables: MyTable.self,
  metadatabaseURL: metadataURL
)
```
