### PR TITLE
Add hint to DependenciesTestSupport in test examples

### DIFF
--- a/Sources/SQLiteData/Documentation.docc/Articles/PreparingDatabase.md
+++ b/Sources/SQLiteData/Documentation.docc/Articles/PreparingDatabase.md
@@ -290,7 +290,8 @@ It is also important to prepare the database in Xcode previews. This can be done
 }
 ```
 
-And similarly, in tests, this can be done using the `.dependency` testing trait:
+And similarly, in tests, this can be done using the `.dependency` testing trait 
+from [DependenciesTestSupport](https://github.com/pointfreeco/swift-dependencies):
 
 ```swift
 @Test(.dependency(\.defaultDatabase, try appDatabase())

--- a/Sources/SQLiteData/Documentation.docc/Articles/PreparingDatabase.md
+++ b/Sources/SQLiteData/Documentation.docc/Articles/PreparingDatabase.md
@@ -294,6 +294,10 @@ And similarly, in tests, this can be done using the `.dependency` testing trait
 from [DependenciesTestSupport](https://github.com/pointfreeco/swift-dependencies):
 
 ```swift
+import DependenciesTestSupport
+import SQLiteData
+import Testing
+
 @Test(.dependency(\.defaultDatabase, try appDatabase())
 func feature() {
   // ...


### PR DESCRIPTION
I had some trouble while following the examples in the documentation. This hint might be useful for others following the article