### PR TITLE
Add missing package dependencies to resolve non-SPM linker failures

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,6 +58,7 @@ let package = Package(
         .product(name: "Sharing", package: "swift-sharing"),
         .product(name: "StructuredQueriesCore", package: "swift-structured-queries"),
         .product(name: "StructuredQueriesSQLite", package: "swift-structured-queries"),
+        .product(name: "StructuredQueriesSQLiteCore", package: "swift-structured-queries"),
         .product(
           name: "Tagged",
           package: "swift-tagged",

--- a/Package.swift
+++ b/Package.swift
@@ -56,6 +56,7 @@ let package = Package(
         .product(name: "OrderedCollections", package: "swift-collections"),
         .product(name: "Perception", package: "swift-perception"),
         .product(name: "Sharing", package: "swift-sharing"),
+        .product(name: "StructuredQueriesCore", package: "swift-structured-queries"),
         .product(name: "StructuredQueriesSQLite", package: "swift-structured-queries"),
         .product(
           name: "Tagged",

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -41,6 +41,7 @@ let package = Package(
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         .product(name: "OrderedCollections", package: "swift-collections"),
         .product(name: "Sharing", package: "swift-sharing"),
+        .product(name: "StructuredQueriesCore", package: "swift-structured-queries"),
         .product(name: "StructuredQueriesSQLite", package: "swift-structured-queries"),
       ]
     ),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -43,6 +43,7 @@ let package = Package(
         .product(name: "Sharing", package: "swift-sharing"),
         .product(name: "StructuredQueriesCore", package: "swift-structured-queries"),
         .product(name: "StructuredQueriesSQLite", package: "swift-structured-queries"),
+        .product(name: "StructuredQueriesSQLiteCore", package: "swift-structured-queries"),
       ]
     ),
     .target(


### PR DESCRIPTION
## Summary

Fixes linker issues when non-SPM targets depend on `SqliteData` by explicitly declaring missing package dependencies.

## Details

When linking non-SPM targets to `SqliteData`, builds can fail due to undeclared dependencies in the `sqlite-data` package:

- `StructuredQueriesCore` is directly imported in multiple source files but is not listed in the package manifest.
- `StructuredQueriesSQLiteCore` is not explicitly imported, but is resolved transitively by Swift Package Manager. However, this transitive resolution does not carry over to non-SPM targets, resulting in missing symbol linker errors (especially in test builds).

A typical failing dependency chain:

    (.xctest, .xcframework, .appex)
        → (internal SPM library)
            → (sqlite-data)

In these cases:
- Compilation succeeds and dependencies appear resolved.
- Linking fails in test builds or produces warnings in non-test builds.

## Environment

- Xcode 26.4 (17E192)  
- swift-driver 1.148.6  
- Apple Swift 6.3 (swiftlang-6.3.0.123.5 clang-2100.0.123.102)  
- Target: arm64-apple-macosx26.0  

## Resolution

This PR explicitly adds the missing dependencies to the package manifest, ensuring consistent linking behavior across both SPM and non-SPM targets.