### PR TITLE
Fix CloudKit documentation reference

### DIFF
--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -15,7 +15,7 @@
 
   /// An object that manages the synchronization of local and remote SQLite data.
   ///
-  /// See <doc:CloudKit> for more information.
+  /// See <doc:CloudKitSync> for more information.
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   public final class SyncEngine: Observable, Sendable {
     package let userDatabase: UserDatabase
@@ -896,7 +896,7 @@
 
     /// Whether or not the ``SyncEngine`` is currently writing changes to the database.
     ///
-    /// See <doc:CloudKit#Updating-triggers-to-be-compatible-with-synchronization> for more info.
+    /// See <doc:CloudKitSync#Updating-triggers-to-be-compatible-with-synchronization> for more info.
     @DatabaseFunction("sqlitedata_icloud_syncEngineIsSynchronizingChanges")
     public static var isSynchronizing: Bool {
       if _isCreatingTemporaryTrigger {
@@ -2193,7 +2193,7 @@
     /// Attaches the metadatabase to an existing database connection.
     ///
     /// Invoke this method when preparing your database connection in order to allow querying the
-    /// ``SyncMetadata`` table (see <doc:CloudKit#Accessing-CloudKit-metadata> for more info):
+    /// ``SyncMetadata`` table (see <doc:CloudKitSync#Accessing-CloudKit-metadata> for more info):
     ///
     /// ```swift
     /// func appDatabase() -> any DatabaseWriter {

--- a/Sources/SQLiteData/CloudKit/SyncMetadata.swift
+++ b/Sources/SQLiteData/CloudKit/SyncMetadata.swift
@@ -8,7 +8,7 @@
   /// application is the number of rows this one single table holds. However, this table is held
   /// in a database separate from your app's database.
   ///
-  /// See <doc:CloudKit#Accessing-CloudKit-metadata> for more info.
+  /// See <doc:CloudKitSync#Accessing-CloudKit-metadata> for more info.
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   @Table("sqlitedata_icloud_metadata")
   public struct SyncMetadata: Hashable, Identifiable, Sendable {

--- a/Sources/SQLiteData/Documentation.docc/Articles/AddingToGRDB.md
+++ b/Sources/SQLiteData/Documentation.docc/Articles/AddingToGRDB.md
@@ -8,7 +8,7 @@ Learn how to add SQLiteData to an existing app that uses GRDB.
 to interact with SQLite under the hood, such as performing queries and observing changes to the
 database. If you have an existing application using GRDB, and would like to use the tools of this
 library, such as [`@FetchAll`](<doc:FetchAll>), the SQL query builder, and
-[CloudKit synchronization](<doc:CloudKit>), then there are a few steps you must take.
+[CloudKit synchronization](<doc:CloudKitSync>), then there are a few steps you must take.
 
 ## Replace PersistableRecord and FetchableRecord with @Table
 
@@ -169,7 +169,7 @@ try Reminder.insert {
 
 ## CloudKit synchronization
 
-The library's [CloudKit](<doc:CloudKit>) synchronization tools require that the tables being
+The library's [CloudKit](<doc:CloudKitSync>) synchronization tools require that the tables being
 synchronized have a primary key, and this is enforced through the `PrimaryKeyedTable` protocol.
 The `@Table` macro automatically applies this protocol for you when your type has an `id` field,
 but if you use a different name for your primary key you will need to use the `@Column` macro
@@ -186,6 +186,6 @@ to specify that:
 The library further requires your tables use globally unique identifiers (such as UUID) for their
 primary keys, and in particular auto-incrementing integer IDs do _not_ work. You will need to
 migrate your tables to use UUIDs, see
-<doc:CloudKit#Preparing-an-existing-schema-for-synchronization> for more information.
+<doc:CloudKitSync#Preparing-an-existing-schema-for-synchronization> for more information.
 
 [GRDB]: http://github.com/groue/GRDB.swift

--- a/Sources/SQLiteData/Documentation.docc/Articles/CloudKitSharing.md
+++ b/Sources/SQLiteData/Documentation.docc/Articles/CloudKitSharing.md
@@ -179,7 +179,7 @@ you can share root records, like reminders lists. If you do invoke
 ``SyncEngine/share(record:configure:)`` with a non-root record, an error will be thrown.
 
 > Note: A reminder can still be shared as an association to a shared reminders list, as discussed
-> [in the next section](<doc:CloudKit#Sharing-foreign-key-relationships>). However, a single
+> [in the next section](<doc:CloudKitSync#Sharing-foreign-key-relationships>). However, a single
 > reminder cannot be shared on its own.
 
 For a more complex example, consider the following diagrammatic schema for a reminders app:
@@ -336,7 +336,7 @@ excels at.
 
 One-to-"at most one" relationships in SQLite allow you to associate zero or one records with
 another record. For an example of this, suppose we wanted to hold onto a cover image for reminders
-lists (see <doc:CloudKit#Assets> for more information on synchronizing assets such as images). It
+lists (see <doc:CloudKitSync#Assets> for more information on synchronizing assets such as images). It
 is perfectly fine to hold onto large binary data in SQLite, such as image data, but typically one
 should put this data in a separate table.
 
@@ -384,7 +384,7 @@ do {
 }
 ```
 
-See <doc:CloudKit#Accessing-CloudKit-metadata> for more information on accessing the metadata
+See <doc:CloudKitSync#Accessing-CloudKit-metadata> for more information on accessing the metadata
 associated with your user's data.
 
 Ideally your app would not allow the user to write to records that they do not have permissions for.

--- a/Sources/SQLiteData/Documentation.docc/Articles/CloudKitSync.md
+++ b/Sources/SQLiteData/Documentation.docc/Articles/CloudKitSync.md
@@ -117,7 +117,7 @@ This will allow you to query the ``SyncMetadata`` table, which gives you access 
 stored for each of your records, as well as the `CKShare` for any shared records.
 
 See the ``GRDB/Database/attachMetadatabase(containerIdentifier:)`` for more information, as well
-as <doc:CloudKit#Accessing-CloudKit-metadata> below.
+as <doc:CloudKitSync#Accessing-CloudKit-metadata> below.
 
 ## Designing your schema with synchronization in mind
 
@@ -538,7 +538,7 @@ exposed for you to query it in whichever way you want.
 > Important: In order to query the `SyncMetadata` table from your database connection you will need
 to attach the metadatabase to your database connection. This can be done with the
 ``GRDB/Database/attachMetadatabase(containerIdentifier:)`` method defined on `Database`. See
-<doc:CloudKit#Setting-up-a-SyncEngine> for more information on how to do this.
+<doc:CloudKitSync#Setting-up-a-SyncEngine> for more information on how to do this.
 
 With that done you can use the ``StructuredQueriesCore/PrimaryKeyedTable/syncMetadataID`` property
 to construct a SQL query for fetching the metadata associated with one of your records.
@@ -705,7 +705,7 @@ And in previews you can use it like so:
 
 If you have an existing app deployed to the app store using SQLite, then you may have to perform
 a migration on your schema to prepare it for synchronization. The most important requirement
-detailed above in <doc:CloudKit#Designing-your-schema-with-synchronization-in-mind> is that
+detailed above in <doc:CloudKitSync#Designing-your-schema-with-synchronization-in-mind> is that
 all tables _must_ have a primary key, and all primary keys must be globally unique identifiers
 such as UUID, and cannot be simple auto-incrementing integers.
 

--- a/Sources/SQLiteData/Documentation.docc/Articles/ComparisonWithSwiftData.md
+++ b/Sources/SQLiteData/Documentation.docc/Articles/ComparisonWithSwiftData.md
@@ -931,17 +931,17 @@ SQLiteData has only one of these limitations:
 * Unique constraints on columns (except for the primary key) cannot be upheld on a distributed
 schema. For example, if you have a `Tag` table with a unique `title` column, then what
 are you to do if two different devices create a tag with the title "family" at the same time?
-See <doc:CloudKit#Uniqueness-constraints> for more information.
+See <doc:CloudKitSync#Uniqueness-constraints> for more information.
 * Columns on freshly created tables do not need to have default values or be nullable. Only
 newly added columns to existing tables need to either be nullable or have a default. See
-<doc:CloudKit#Adding-columns> for more info.
+<doc:CloudKitSync#Adding-columns> for more info.
 * Relationships on freshly created do not need to be nullable. Only newly added columns to
-existing tables need to be nullable. See <doc:CloudKit#Adding-columns> for more info.
+existing tables need to be nullable. See <doc:CloudKitSync#Adding-columns> for more info.
 
 For more information about requirements of your schema in order to use CloudKit synchronization,
-see <doc:CloudKit#Designing-your-schema-with-synchronization-in-mind> and
-<doc:CloudKit#Backwards-compatible-migrations>, and for more general
-information about CloudKit synchronization, see <doc:CloudKit>.
+see <doc:CloudKitSync#Designing-your-schema-with-synchronization-in-mind> and
+<doc:CloudKitSync#Backwards-compatible-migrations>, and for more general
+information about CloudKit synchronization, see <doc:CloudKitSync>.
 
 ### Supported Apple platforms
 

--- a/Sources/SQLiteData/Documentation.docc/Articles/ManuallyMigratingPrimaryKeys.md
+++ b/Sources/SQLiteData/Documentation.docc/Articles/ManuallyMigratingPrimaryKeys.md
@@ -128,7 +128,7 @@ struct ReminderTag {
 ```
 
 And a migration must be run to add that column to the table. However, you must perform a multi-step
-migration similar to what is described above in <doc:CloudKit#Convert-Int-primary-keys-to-UUID>.
+migration similar to what is described above in <doc:CloudKitSync#Convert-Int-primary-keys-to-UUID>.
 You must 1) create a new table with the new primary key column, 2) copy data from the old table
 to the new table, 3) delete the old table, and finally 4) rename the new table.
 

--- a/Sources/SQLiteData/Documentation.docc/Articles/PreparingDatabase.md
+++ b/Sources/SQLiteData/Documentation.docc/Articles/PreparingDatabase.md
@@ -303,4 +303,4 @@ func feature() {
 
 If you plan on synchronizing your local database to CloudKit so that your user's data is available
 on all of their devices, there is an additional step you must take. See
-<doc:CloudKit> for more information.
+<doc:CloudKitSync> for more information.

--- a/Sources/SQLiteData/Documentation.docc/SQLiteData.md
+++ b/Sources/SQLiteData/Documentation.docc/SQLiteData.md
@@ -204,7 +204,7 @@ struct MyApp: App {
 ```
 
 > For more information on synchronizing the database to CloudKit and sharing records with iCloud
-> users, see <doc:CloudKit>.
+> users, see <doc:CloudKitSync>.
 
 This is all you need to know to get started with SQLiteData, but there's much more to learn. Read
 the [articles](#Essentials) below to learn how to best utilize this library.
@@ -311,7 +311,7 @@ with SQLite to take full advantage of GRDB and SQLiteData.
 
 ### CloudKit synchronization and sharing
 
-- <doc:CloudKit>
+- <doc:CloudKitSync>
 - <doc:CloudKitSharing>
 - ``SyncEngine``
 - ``SyncEngineDelegate``


### PR DESCRIPTION
As discussed [on Slack](https://pointfreecommunity.slack.com/archives/C08CZUG4Z9D/p1777481824395669), the sqlite-data documentation no longer lists the "Getting started with CloudKit" article. The PR resolves the issue by renaming the article file from `CloudKit.md` to `CloudKitSync.md` to avoid conflict with the existing "CloudKit" documentation module.

<img width="526" height="320" alt="Screenshot 2026-04-30 alle 16 32 37" src="https://github.com/user-attachments/assets/8fe34915-62f1-41a5-a272-ade2a7fabfea" />