### PR TITLE
Make animation optional in load endpoints

### DIFF
--- a/Sources/SQLiteData/Fetch.swift
+++ b/Sources/SQLiteData/Fetch.swift
@@ -205,7 +205,7 @@ extension Fetch: Equatable where Value: Equatable {
     public func load(
       _ request: some FetchKeyRequest<Value>,
       database: (any DatabaseReader)? = nil,
-      animation: Animation
+      animation: Animation?
     ) async throws -> FetchSubscription {
       try await sharedReader.load(.fetch(request, database: database, animation: animation))
       return FetchSubscription(sharedReader: sharedReader)

--- a/Sources/SQLiteData/FetchAll.swift
+++ b/Sources/SQLiteData/FetchAll.swift
@@ -531,7 +531,7 @@ extension FetchAll: Equatable where Element: Equatable {
     public func load<S: SelectStatement>(
       _ statement: S,
       database: (any DatabaseReader)? = nil,
-      animation: Animation
+      animation: Animation?
     ) async throws -> FetchSubscription
     where
       Element == S.From.QueryOutput,
@@ -557,7 +557,7 @@ extension FetchAll: Equatable where Element: Equatable {
     public func load<V: QueryRepresentable>(
       _ statement: some StructuredQueriesCore.Statement<V>,
       database: (any DatabaseReader)? = nil,
-      animation: Animation
+      animation: Animation?
     ) async throws -> FetchSubscription
     where
       Element == V.QueryOutput,

--- a/Sources/SQLiteData/FetchOne.swift
+++ b/Sources/SQLiteData/FetchOne.swift
@@ -1189,7 +1189,7 @@ extension FetchOne: Equatable where Value: Equatable {
     public func load<S: SelectStatement>(
       _ statement: S,
       database: (any DatabaseReader)? = nil,
-      animation: Animation
+      animation: Animation?
     ) async throws -> FetchSubscription
     where
       Value == S.From.QueryOutput,
@@ -1213,7 +1213,7 @@ extension FetchOne: Equatable where Value: Equatable {
     public func load<V: QueryRepresentable>(
       _ statement: some StructuredQueriesCore.Statement<V>,
       database: (any DatabaseReader)? = nil,
-      animation: Animation
+      animation: Animation?
     ) async throws -> FetchSubscription
     where
       Value == V.QueryOutput
@@ -1235,7 +1235,7 @@ extension FetchOne: Equatable where Value: Equatable {
     public func load<V: QueryRepresentable>(
       _ statement: some StructuredQueriesCore.Statement<V>,
       database: (any DatabaseReader)? = nil,
-      animation: Animation
+      animation: Animation?
     ) async throws -> FetchSubscription
     where
       Value == V.QueryOutput?
@@ -1257,7 +1257,7 @@ extension FetchOne: Equatable where Value: Equatable {
     public func load<S: SelectStatement>(
       _ statement: S,
       database: (any DatabaseReader)? = nil,
-      animation: Animation
+      animation: Animation?
     ) async throws -> FetchSubscription
     where
       Value: StructuredQueriesCore._OptionalProtocol,
@@ -1282,7 +1282,7 @@ extension FetchOne: Equatable where Value: Equatable {
     public func load<S: StructuredQueriesCore.Statement>(
       _ statement: S,
       database: (any DatabaseReader)? = nil,
-      animation: Animation
+      animation: Animation?
     ) async throws -> FetchSubscription
     where
       Value: StructuredQueriesCore._OptionalProtocol,
@@ -1307,7 +1307,7 @@ extension FetchOne: Equatable where Value: Equatable {
     public func load(
       _ statement: some StructuredQueriesCore.Statement<Value>,
       database: (any DatabaseReader)? = nil,
-      animation: Animation
+      animation: Animation?
     ) async throws -> FetchSubscription
     where
       Value: QueryRepresentable,

--- a/Sources/SQLiteData/Internal/FetchKey+SwiftUI.swift
+++ b/Sources/SQLiteData/Internal/FetchKey+SwiftUI.swift
@@ -7,7 +7,7 @@
     static func fetch<Value>(
       _ request: some FetchKeyRequest<Value>,
       database: (any DatabaseReader)? = nil,
-      animation: Animation
+      animation: Animation?
     ) -> Self
     where Self == FetchKey<Value> {
       .fetch(request, database: database, scheduler: .animation(animation))
@@ -16,7 +16,7 @@
     static func fetch<Records: RangeReplaceableCollection>(
       _ request: some FetchKeyRequest<Records>,
       database: (any DatabaseReader)? = nil,
-      animation: Animation
+      animation: Animation?
     ) -> Self
     where Self == FetchKey<Records>.Default {
       .fetch(request, database: database, scheduler: .animation(animation))
@@ -24,7 +24,7 @@
   }
 
   package struct AnimatedScheduler: ValueObservationScheduler, Equatable {
-    let animation: Animation
+    let animation: Animation?
     package func immediateInitialValue() -> Bool { true }
     package func schedule(_ action: @escaping @Sendable () -> Void) {
       DispatchQueue.main.async {
@@ -39,7 +39,7 @@
   extension AnimatedScheduler: Hashable {}
 
   extension ValueObservationScheduler where Self == AnimatedScheduler {
-    package static func animation(_ animation: Animation) -> Self {
+    package static func animation(_ animation: Animation?) -> Self {
       AnimatedScheduler(animation: animation)
     }
   }


### PR DESCRIPTION
Fixes #462, allowing `nil` to be supplied to `load` so that you can turn animation off.