### PR TITLE
Add Android GRDB SQLCipher support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,12 +11,12 @@
       }
     },
     {
-      "identity" : "grdb-sqlcipher",
+      "identity" : "grdb.swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-everywhere/grdb-sqlcipher.git",
+      "location" : "https://github.com/groue/GRDB.swift",
       "state" : {
-        "revision" : "1986ed29f5b367467b60f52134b266f44e65ab9b",
-        "version" : "7.5.0"
+        "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
+        "version" : "7.10.0"
       }
     },
     {
@@ -116,15 +116,6 @@
       "state" : {
         "revision" : "bf8d8c27f0f0c6d5e77bff0db76ab68f2050d15d",
         "version" : "1.18.9"
-      }
-    },
-    {
-      "identity" : "swift-sqlcipher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/skiptools/swift-sqlcipher.git",
-      "state" : {
-        "revision" : "8d376ade71f2ce83b4c8e3250c79b207db4eddf6",
-        "version" : "1.10.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2b95f254bb904411c5a0aba0e0402c157014542e9bd40eb5848c42c8598b80a9",
+  "originHash" : "1464a33ec5d6d5bf475cc815fedb831aec3a52c5f5d911bd6ccdf4b14db73807",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -11,12 +11,12 @@
       }
     },
     {
-      "identity" : "grdb.swift",
+      "identity" : "grdb-sqlcipher",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/groue/GRDB.swift",
+      "location" : "https://github.com/swift-everywhere/grdb-sqlcipher.git",
       "state" : {
-        "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
-        "version" : "7.10.0"
+        "revision" : "1986ed29f5b367467b60f52134b266f44e65ab9b",
+        "version" : "7.5.0"
       }
     },
     {
@@ -116,6 +116,15 @@
       "state" : {
         "revision" : "bf8d8c27f0f0c6d5e77bff0db76ab68f2050d15d",
         "version" : "1.18.9"
+      }
+    },
+    {
+      "identity" : "swift-sqlcipher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/skiptools/swift-sqlcipher.git",
+      "state" : {
+        "revision" : "8d376ade71f2ce83b4c8e3250c79b207db4eddf6",
+        "version" : "1.10.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,11 +24,22 @@ let package = Package(
     .trait(
       name: "SQLiteDataTagged",
       description: "Introduce SQLiteData conformances to the swift-tagged package."
+    ),
+    .trait(
+      name: "GRDBCIPHER",
+      description: "Use the SQLCipher-backed GRDB package."
     )
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
-    .package(url: "https://github.com/groue/GRDB.swift", from: "7.6.0"),
+    .package(
+      url: "https://github.com/swift-everywhere/grdb-sqlcipher.git",
+      from: "7.5.0",
+      traits: [
+        .trait(name: "GRDBCIPHER", condition: .when(traits: ["GRDBCIPHER"]))
+      ]
+    ),
+    .package(url: "https://github.com/skiptools/swift-sqlcipher.git", from: "1.3.0"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.9.0"),
@@ -51,11 +62,16 @@ let package = Package(
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "GRDB", package: "GRDB.swift"),
+        .product(name: "GRDB", package: "grdb-sqlcipher"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         .product(name: "OrderedCollections", package: "swift-collections"),
         .product(name: "Perception", package: "swift-perception"),
         .product(name: "Sharing", package: "swift-sharing"),
+        .product(
+          name: "SQLCipher",
+          package: "swift-sqlcipher",
+          condition: .when(traits: ["GRDBCIPHER"])
+        ),
         .product(name: "StructuredQueriesSQLite", package: "swift-structured-queries"),
         .product(
           name: "Tagged",
@@ -91,6 +107,7 @@ let package = Package(
 )
 
 let swiftSettings: [SwiftSetting] = [
+  .define("GRDBCIPHER", .when(traits: ["GRDBCIPHER"])),
   .enableUpcomingFeature("MemberImportVisibility")
   // .unsafeFlags([
   //   "-Xfrontend",

--- a/Package.swift
+++ b/Package.swift
@@ -121,7 +121,6 @@ let package = Package(
 )
 
 let swiftSettings: [SwiftSetting] = [
-  .define("GRDBCIPHER", .when(traits: ["GRDBCIPHER"])),
   .enableUpcomingFeature("MemberImportVisibility")
   // .unsafeFlags([
   //   "-Xfrontend",

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
 // swift-tools-version: 6.1
-
 import PackageDescription
 
 let package = Package(
@@ -21,6 +20,11 @@ let package = Package(
     ),
   ],
   traits: [
+    .default(enabledTraits: ["GRDB"]),
+    .trait(
+      name: "GRDB",
+      description: "Use the standard GRDB package."
+    ),
     .trait(
       name: "SQLiteDataTagged",
       description: "Introduce SQLiteData conformances to the swift-tagged package."
@@ -32,6 +36,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
+    .package(url: "https://github.com/groue/GRDB.swift", from: "7.6.0"),
     .package(
       url: "https://github.com/swift-everywhere/grdb-sqlcipher.git",
       from: "7.5.0",
@@ -62,7 +67,16 @@ let package = Package(
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "GRDB", package: "grdb-sqlcipher"),
+        .product(
+          name: "GRDB",
+          package: "GRDB.swift",
+          condition: .when(traits: ["GRDB"])
+        ),
+        .product(
+          name: "GRDB",
+          package: "grdb-sqlcipher",
+          condition: .when(traits: ["GRDBCIPHER"])
+        ),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         .product(name: "OrderedCollections", package: "swift-collections"),
         .product(name: "Perception", package: "swift-perception"),

--- a/Sources/SQLiteData/CloudKit/Internal/UserDatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/UserDatabase.swift
@@ -16,7 +16,7 @@
     }
 
     package func write<T: Sendable>(
-      _ updates: @Sendable (Database) throws -> T
+      _ updates: @escaping @Sendable (Database) throws -> T
     ) async throws -> T {
       try await database.write { db in
         try $_isSynchronizingChanges.withValue(true) {
@@ -26,7 +26,7 @@
     }
 
     package func read<T: Sendable>(
-      _ updates: @Sendable (Database) throws -> T
+      _ updates: @escaping @Sendable (Database) throws -> T
     ) async throws -> T {
       try await database.read { db in
         try updates(db)

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -756,7 +756,7 @@
       try tearDownSyncEngine()
       await withErrorReporting(.sqliteDataCloudKitFailure) {
         try await userDatabase.write { db in
-          for table in tables {
+          for table in self.tables {
             func open<T>(_: some SynchronizableTable<T>) {
               withErrorReporting(.sqliteDataCloudKitFailure) {
                 try T.delete().execute(db)
@@ -764,7 +764,7 @@
             }
             open(table)
           }
-          try setUpSyncEngine(writableDB: db)
+          try self.setUpSyncEngine(writableDB: db)
         }
       }
       try await start()
@@ -1591,7 +1591,7 @@
               if let share = record as? CKShare {
                 shares.append(.share(share))
               } else {
-                upsertFromServerRecord(record, db: db)
+                self.upsertFromServerRecord(record, db: db)
                 if let shareReference = record.share {
                   shares.append(.reference(shareReference))
                 }
@@ -1893,7 +1893,7 @@
     ) async {
       await withErrorReporting(.sqliteDataCloudKitFailure) {
         try await userDatabase.write { db in
-          upsertFromServerRecord(serverRecord, force: force, db: db)
+          self.upsertFromServerRecord(serverRecord, force: force, db: db)
         }
       }
     }

--- a/Sources/SQLiteData/StructuredQueries+GRDB/CustomFunctions.swift
+++ b/Sources/SQLiteData/StructuredQueries+GRDB/CustomFunctions.swift
@@ -1,5 +1,9 @@
 import Foundation
+#if GRDBCIPHER
+import SQLCipher
+#else
 import GRDBSQLite
+#endif
 
 extension Database {
   /// Adds a user-defined scalar `@DatabaseFunction` to a connection.

--- a/Sources/SQLiteData/StructuredQueries+GRDB/QueryCursor.swift
+++ b/Sources/SQLiteData/StructuredQueries+GRDB/QueryCursor.swift
@@ -1,6 +1,10 @@
 import Foundation
 import GRDB
+#if GRDBCIPHER
+import SQLCipher
+#else
 import GRDBSQLite
+#endif
 import StructuredQueriesCore
 
 /// A cursor of a structured query.

--- a/Sources/SQLiteData/StructuredQueries+GRDB/SQLiteFunctionDecoder.swift
+++ b/Sources/SQLiteData/StructuredQueries+GRDB/SQLiteFunctionDecoder.swift
@@ -1,5 +1,9 @@
 import Foundation
+#if GRDBCIPHER
+import SQLCipher
+#else
 import GRDBSQLite
+#endif
 import StructuredQueriesCore
 
 @usableFromInline

--- a/Sources/SQLiteData/StructuredQueries+GRDB/SQLiteQueryDecoder.swift
+++ b/Sources/SQLiteData/StructuredQueries+GRDB/SQLiteQueryDecoder.swift
@@ -1,5 +1,9 @@
 import Foundation
+#if GRDBCIPHER
+import SQLCipher
+#else
 import GRDBSQLite
+#endif
 import StructuredQueriesCore
 
 @usableFromInline


### PR DESCRIPTION
https://github.com/groue/GRDB.swift/pull/1708

This is a PR to use the same SQLCipher trait that is employed over in GRDB to support Android. 

This is an initial path that seems to allow compiling for Android through skip, but there may be better ways to do it.

It seems that the grdb-sqlcipher needs some updates to match GRDB, so there's a little bit of shim code in here for the time being. I'll work on getting that updated while we discuss