### PR TITLE
Fix error when creating databases on tvOS devices

### DIFF
--- a/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
@@ -13,10 +13,6 @@
       open "\(url.path(percentEncoded: false))"
       """
     )
-    try FileManager.default.createDirectory(
-      at: .applicationSupportDirectory,
-      withIntermediateDirectories: true
-    )
 
     @Dependency(\.context) var context
     guard !url.isInMemory || context != .live

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -2243,10 +2243,6 @@
         containerIdentifier: containerIdentifier
       )
       let path = url.isInMemory ? url.absoluteString : url.path(percentEncoded: false)
-      try FileManager.default.createDirectory(
-        at: .applicationSupportDirectory,
-        withIntermediateDirectories: true
-      )
       let database: any DatabaseWriter =
         url.isInMemory
         ? try DatabaseQueue(path: path)


### PR DESCRIPTION
Remove redundant `createDirectory` calls that are now handled by `FileManager.default.url(create:true)`.