### PR TITLE
Fix Database not resolving via import SQLiteData under whole-module builds

### DIFF
--- a/Sources/SQLiteData/CloudKit/PrimaryKeyMigration.swift
+++ b/Sources/SQLiteData/CloudKit/PrimaryKeyMigration.swift
@@ -1,7 +1,7 @@
 #if canImport(CloudKit) && canImport(CryptoKit)
   import CryptoKit
   public import Foundation
-  public import class GRDB.Database
+  @_exported import class GRDB.Database
   public import StructuredQueriesCore
   public import StructuredQueriesSQLite
 

--- a/Sources/SQLiteData/StructuredQueries+GRDB/CustomFunctions.swift
+++ b/Sources/SQLiteData/StructuredQueries+GRDB/CustomFunctions.swift
@@ -1,5 +1,5 @@
 import Foundation
-public import class GRDB.Database
+@_exported import class GRDB.Database
 import GRDBSQLite
 public import StructuredQueriesSQLiteCore
 


### PR DESCRIPTION
## What

Two scoped imports of `GRDB.Database` are written as `public import` instead of `@_exported import`. Under whole-module compilation this causes `Database` to stop resolving via `import SQLiteData` in downstream modules:

```
error: cannot find type 'Database' in scope
```

## Why it broke

`Internal/Exports.swift` intentionally re-exports selected GRDB types via scoped imports, e.g.:

```swift
@_exported import class GRDB.Database
```

#467 ("Modernize package.", first released in 1.6.3) adopted `InternalImportsByDefault` and added explicit access-level imports across the package, including two **non-exported** scoped imports of the same declaration:

- `Sources/SQLiteData/CloudKit/PrimaryKeyMigration.swift`
- `Sources/SQLiteData/StructuredQueries+GRDB/CustomFunctions.swift`

Both files sort before `Internal/Exports.swift` in compilation order.

Under whole-module compilation, swiftc dedupes scoped imports of the same `(module, access-path)` pair, keeping the **first occurrence in file order**. The non-exported import wins, so the `@_exported` flag is silently dropped from the serialized module. Sibling re-exports that are only scoped-imported once (`Configuration`, `DatabasePool`, `DatabaseQueue`, …) keep working.

This only reproduces under WMO — `swift build -c release`, or any build system that compiles library targets with `-wmo`. Debug builds compile incrementally (non-WMO), which is presumably why it wasn't caught.

## The fix

Mark the two colliding scoped imports `@_exported` as well, so dedup keeps an exported entry regardless of file order. This is a no-op for consumers: `GRDB.Database` is already intentionally re-exported by `Internal/Exports.swift`.

A whole-module `public import GRDB` is **not** an option in `CustomFunctions.swift`: GRDB's `DatabaseFunction` class then collides with StructuredQueries' `DatabaseFunction` protocol used in that file (`value of type 'some DatabaseFunction' has no member 'name'`).

## Notes

The underlying swiftc behavior (WMO scoped-import dedup dropping `@_exported` based on file order) looks like a compiler bug worth a separate issue against swiftlang/swift; this PR works around it at the source level.
