### PR TITLE
Fix compile error by making Tagged import public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build ${{ matrix.config }} without exports
         run: swift build -c ${{ matrix.config }} -Xswiftc -D -Xswiftc EXCLUDE_EXPORTS
       - name: Run ${{ matrix.config }} tests
-        run: swift test -c ${{ matrix.config }}
+        run: swift test -c ${{ matrix.config }} --traits SQLiteDataTagged
 
   examples:
     name: Examples

--- a/Sources/SQLiteData/Traits/Tagged.swift
+++ b/Sources/SQLiteData/Traits/Tagged.swift
@@ -1,5 +1,5 @@
 #if SQLiteDataTagged
-  import Tagged
+  public import Tagged
 
   extension Tagged: IdentifierStringConvertible where RawValue: IdentifierStringConvertible {
     public init?(rawIdentifier: String) {


### PR DESCRIPTION
This pull request makes a small change to the import visibility of the `Tagged` module in `Sources/SQLiteData/Traits/Tagged.swift`. The import is now marked as `public`, allowing the `Tagged` module to be re-exported for downstream consumers.

Fixes #472 