### PR TITLE
Work around `@_exported`-`public import` bug

### DIFF
--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "c56e7b70de4fe8bcc798354797a8405c0eeb2e9bc68bc0f202c14a8b11a0a97f",
+  "originHash" : "c133bf7d10c8ce1e5d6506c3d2f080eac8b4c8c2827044d53a9b925e903564fd",
   "pins" : [
     {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "fd16d76fd8b9a976d88bfb6cacc05ca8d19c91b6",
-        "version" : "1.1.0"
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift",
       "state" : {
-        "revision" : "aa0079aeb82a4bf00324561a40bffe68c6fe1c26",
-        "version" : "7.9.0"
+        "revision" : "9ed8c8457e00ff9c7aedb3bf213f20a2cfdf509e",
+        "version" : "7.11.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "6989976265be3f8d2b5802c722f9ba168e227c71",
-        "version" : "1.7.2"
+        "revision" : "206cbce3882b4de9aee19ce62ac5b7306cadd45b",
+        "version" : "1.7.3"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
-        "version" : "1.3.3"
+        "revision" : "b9b59eb58c946236d6f16305c576ad194c36444e",
+        "version" : "1.6.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "a10f9feeb214bc72b5337b6ef6d5a029360db4cc",
-        "version" : "1.10.0"
+        "revision" : "f80552807ec92f72fe3fe4543d71879182b0bfd5",
+        "version" : "1.13.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "bf498690e1f6b4af790260f542e8428a4ba10d78",
-        "version" : "2.6.0"
+        "revision" : "32f35241b8be0719c4c7f00eb27713b1cadb6248",
+        "version" : "2.8.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "4f47ebafed5f0b0172cf5c661454fa8e28fb2ac4",
-        "version" : "2.0.9"
+        "revision" : "25ac73741c3436605d61eceb5207e896973918e7",
+        "version" : "2.0.10"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "3bfc408cc2d0bee2287c174da6b1c76768377818",
-        "version" : "2.7.4"
+        "revision" : "c525e53936c878c102421eee241d82711eb38104",
+        "version" : "2.8.1"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "a8b7c5e0ed33d8ab8887d1654d9b59f2cbad529b",
-        "version" : "1.18.7"
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
-        "version" : "602.0.0"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "4c27acf5394b645b70d8ba19dc249c0472d5f618",
-        "version" : "1.7.0"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],

--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
-        "version" : "1.0.6"
+        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
+        "version" : "1.1.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
+        "revision" : "cb281f343fd953280336dcbd3822cdf47c182f5b",
+        "version" : "1.10.0"
       }
     }
   ],

--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "f80552807ec92f72fe3fe4543d71879182b0bfd5",
-        "version" : "1.13.0"
+        "revision" : "16f7dd14ee28d04617090f2a73198b8b316ffa12",
+        "version" : "1.13.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "c525e53936c878c102421eee241d82711eb38104",
-        "version" : "2.8.1"
+        "revision" : "e47a2f545bafa3c0c702600f3e6ce02b3d566b6f",
+        "version" : "2.8.2"
       }
     },
     {

--- a/Examples/Reminders/RemindersApp.swift
+++ b/Examples/Reminders/RemindersApp.swift
@@ -34,7 +34,7 @@ struct RemindersApp: App {
           isPresented: $syncEngineDelegate.isDeleteLocalDataAlertPresented
         ) {
           Button("Reset", role: .destructive) {
-            Task {
+            _ = Task {
               try await syncEngine.deleteLocalData()
             }
           }
@@ -100,7 +100,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     _ windowScene: UIWindowScene,
     userDidAcceptCloudKitShareWith cloudKitShareMetadata: CKShare.Metadata
   ) {
-    Task {
+    _ = Task {
       try await syncEngine.acceptShare(metadata: cloudKitShareMetadata)
     }
   }
@@ -114,7 +114,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     else {
       return
     }
-    Task {
+    _ = Task {
       try await syncEngine.acceptShare(metadata: cloudKitShareMetadata)
     }
   }

--- a/Examples/Reminders/RemindersDetail.swift
+++ b/Examples/Reminders/RemindersDetail.swift
@@ -88,7 +88,7 @@ class RemindersDetailModel: HashableObject {
     }
   }
 
-  private var remindersQuery: some StructuredQueriesCore.Statement<Row> {
+  private var remindersQuery: some Statement<Row> & Sendable {
     Reminder
       .where {
         if !showCompleted {

--- a/Examples/Reminders/Schema.swift
+++ b/Examples/Reminders/Schema.swift
@@ -390,7 +390,7 @@ nonisolated func handleReminderStatusUpdate() {
 
 @DatabaseFunction
 nonisolated func createDefaultRemindersList() {
-  Task {
+  _ = Task {
     @Dependency(\.defaultDatabase) var database
     try await database.write { db in
       try RemindersList.insert {

--- a/Examples/Reminders/SearchReminders.swift
+++ b/Examples/Reminders/SearchReminders.swift
@@ -1,4 +1,3 @@
-import GRDB
 import IssueReporting
 import SQLiteData
 import SwiftUI
@@ -227,7 +226,7 @@ struct SearchRemindersView: View {
         }
         Spacer()
         Button(model.showCompletedInSearchResults ? "Hide" : "Show") {
-          Task { try await model.showCompletedButtonTapped() }
+          _ = Task { try await model.showCompletedButtonTapped() }
         }
       }
     }

--- a/Examples/Reminders/TagsForm.swift
+++ b/Examples/Reminders/TagsForm.swift
@@ -1,4 +1,3 @@
-import GRDB
 import SQLiteData
 import SwiftUI
 import SwiftUINavigation

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
-        "version" : "1.0.6"
+        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
+        "version" : "1.1.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "f80552807ec92f72fe3fe4543d71879182b0bfd5",
-        "version" : "1.13.0"
+        "revision" : "16f7dd14ee28d04617090f2a73198b8b316ffa12",
+        "version" : "1.13.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "c525e53936c878c102421eee241d82711eb38104",
-        "version" : "2.8.1"
+        "revision" : "e47a2f545bafa3c0c702600f3e6ce02b3d566b6f",
+        "version" : "2.8.2"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
+        "revision" : "cb281f343fd953280336dcbd3822cdf47c182f5b",
+        "version" : "1.10.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "725d8f778c84290ef81225fe8c548ff0a0169261b1f4fb6567dc64db04374bbd",
+  "originHash" : "0ab18ed31f19c7e2b527b6bcc8ba2fc8708fcc9962e7bd79c8d049cb9595154d",
   "pins" : [
     {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "fd16d76fd8b9a976d88bfb6cacc05ca8d19c91b6",
-        "version" : "1.1.0"
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift",
       "state" : {
-        "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
-        "version" : "7.10.0"
+        "revision" : "9ed8c8457e00ff9c7aedb3bf213f20a2cfdf509e",
+        "version" : "7.11.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "2a2a938798236b8fa0bc57c453ee9de9f9ec3ab0",
-        "version" : "1.4.1"
+        "revision" : "b9b59eb58c946236d6f16305c576ad194c36444e",
+        "version" : "1.6.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "c79f72b3e67a1eb64f66f76704c22ed6a5c1ed84",
-        "version" : "1.11.0"
+        "revision" : "f80552807ec92f72fe3fe4543d71879182b0bfd5",
+        "version" : "1.13.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
-        "version" : "1.4.6"
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "4f47ebafed5f0b0172cf5c661454fa8e28fb2ac4",
-        "version" : "2.0.9"
+        "revision" : "25ac73741c3436605d61eceb5207e896973918e7",
+        "version" : "2.0.10"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "3bfc408cc2d0bee2287c174da6b1c76768377818",
-        "version" : "2.7.4"
+        "revision" : "c525e53936c878c102421eee241d82711eb38104",
+        "version" : "2.8.1"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "bf8d8c27f0f0c6d5e77bff0db76ab68f2050d15d",
-        "version" : "1.18.9"
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "20db4a2a446f51e67e1207d54a23ad0a03471a7b",
-        "version" : "0.31.0"
+        "revision" : "8da8818fccd9959bd683934ddc62cf45bb65b3c8",
+        "version" : "0.31.1"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
-        "version" : "602.0.0"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {

--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -1,8 +1,8 @@
 #if canImport(CloudKit)
   public import CloudKit
-  public import Dependencies
+  import Dependencies
   import GRDB
-  public import SwiftUI
+  import SwiftUI
   public import StructuredQueries
 
   #if canImport(UIKit)

--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -1,11 +1,13 @@
 #if canImport(CloudKit)
   public import CloudKit
-  import Dependencies
+  import ConcurrencyExtras
   import GRDB
-  import SwiftUI
+  import IssueReporting
   public import StructuredQueries
 
-  #if canImport(UIKit)
+  #if canImport(SwiftUI) && canImport(UIKit) && !os(tvOS) && !os(watchOS)
+    public import Dependencies
+    public import SwiftUI
     public import UIKit
   #endif
 
@@ -255,7 +257,7 @@
     }
   }
 
-  #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
+  #if canImport(SwiftUI) && canImport(UIKit) && !os(tvOS) && !os(watchOS)
     /// A view that presents standard screens for adding and removing people from a CloudKit share \
     /// record.
     ///

--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -348,7 +348,7 @@
               }
 
               Button("Stop Sharing", role: .destructive) {
-                Task {
+                _ = Task {
                   try await syncEngine.unshare(share: sharedRecord.share)
                   try await syncEngine.fetchChanges()
                   dismiss()

--- a/Sources/SQLiteData/CloudKit/Internal/ForeignKey.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/ForeignKey.swift
@@ -1,7 +1,11 @@
 #if canImport(CloudKit)
   import Foundation
   import StructuredQueries
-  import StructuredQueriesCore
+  #if EXCLUDE_EXPORTS
+    public import StructuredQueriesCore
+  #else
+    import StructuredQueriesCore
+  #endif
 
   @Table
   package struct ForeignKey {

--- a/Sources/SQLiteData/CloudKit/Internal/ForeignKey.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/ForeignKey.swift
@@ -1,7 +1,7 @@
 #if canImport(CloudKit)
   import Foundation
   import StructuredQueries
-  public import StructuredQueriesCore
+  import StructuredQueriesCore
 
   @Table
   package struct ForeignKey {

--- a/Sources/SQLiteData/CloudKit/Internal/PendingRecordZoneChange.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/PendingRecordZoneChange.swift
@@ -1,7 +1,7 @@
 #if canImport(CloudKit)
   package import CloudKit
   import StructuredQueries
-  public import StructuredQueriesCore
+  import StructuredQueriesCore
 
   @Table("sqlitedata_icloud_pendingRecordZoneChanges")
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)

--- a/Sources/SQLiteData/CloudKit/Internal/PendingRecordZoneChange.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/PendingRecordZoneChange.swift
@@ -1,7 +1,9 @@
 #if canImport(CloudKit)
   package import CloudKit
   import StructuredQueries
-  import StructuredQueriesCore
+  #if EXCLUDE_EXPORTS
+    public import StructuredQueriesCore
+  #endif
 
   @Table("sqlitedata_icloud_pendingRecordZoneChanges")
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)

--- a/Sources/SQLiteData/CloudKit/Internal/Pragmas.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Pragmas.swift
@@ -1,6 +1,6 @@
 #if canImport(CloudKit)
   import StructuredQueries
-  public import StructuredQueriesCore
+  import StructuredQueriesCore
 
   @Table
   struct PragmaDatabaseList {

--- a/Sources/SQLiteData/CloudKit/Internal/Pragmas.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Pragmas.swift
@@ -1,6 +1,8 @@
 #if canImport(CloudKit)
   import StructuredQueries
-  import StructuredQueriesCore
+  #if EXCLUDE_EXPORTS
+    public import StructuredQueriesCore
+  #endif
 
   @Table
   struct PragmaDatabaseList {

--- a/Sources/SQLiteData/CloudKit/Internal/RecordType.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/RecordType.swift
@@ -1,6 +1,6 @@
 #if canImport(CloudKit)
   import StructuredQueries
-  package import StructuredQueriesCore
+  import StructuredQueriesCore
 
   @Table("sqlitedata_icloud_recordTypes")
   package struct RecordType: Hashable {

--- a/Sources/SQLiteData/CloudKit/Internal/RecordType.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/RecordType.swift
@@ -1,6 +1,8 @@
 #if canImport(CloudKit)
   import StructuredQueries
-  import StructuredQueriesCore
+  #if EXCLUDE_EXPORTS
+    package import StructuredQueriesCore
+  #endif
 
   @Table("sqlitedata_icloud_recordTypes")
   package struct RecordType: Hashable {

--- a/Sources/SQLiteData/CloudKit/Internal/SQLiteSchema.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/SQLiteSchema.swift
@@ -1,6 +1,8 @@
 #if canImport(CloudKit)
   import StructuredQueries
-  import StructuredQueriesCore
+  #if EXCLUDE_EXPORTS
+    package import StructuredQueriesCore
+  #endif
 
   @Table("sqlite_schema")
   package struct SQLiteSchema {

--- a/Sources/SQLiteData/CloudKit/Internal/SQLiteSchema.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/SQLiteSchema.swift
@@ -1,6 +1,6 @@
 #if canImport(CloudKit)
   import StructuredQueries
-  package import StructuredQueriesCore
+  import StructuredQueriesCore
 
   @Table("sqlite_schema")
   package struct SQLiteSchema {

--- a/Sources/SQLiteData/CloudKit/Internal/StateSerialization.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/StateSerialization.swift
@@ -1,6 +1,8 @@
 #if canImport(CloudKit)
   package import CloudKit
-  import StructuredQueries
+#if EXCLUDE_EXPORTS
+  package import StructuredQueries
+#endif
 
   @Table("sqlitedata_icloud_stateSerialization")
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)

--- a/Sources/SQLiteData/CloudKit/Internal/StateSerialization.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/StateSerialization.swift
@@ -1,6 +1,6 @@
 #if canImport(CloudKit)
   package import CloudKit
-  package import StructuredQueries
+  import StructuredQueries
 
   @Table("sqlitedata_icloud_stateSerialization")
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)

--- a/Sources/SQLiteData/CloudKit/Internal/TableInfo.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/TableInfo.swift
@@ -1,6 +1,6 @@
 #if canImport(CloudKit)
   import StructuredQueries
-  package import StructuredQueriesCore
+  import StructuredQueriesCore
 
   @Table
   package struct TableInfo: Codable, Hashable {

--- a/Sources/SQLiteData/CloudKit/Internal/TableInfo.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/TableInfo.swift
@@ -1,6 +1,8 @@
 #if canImport(CloudKit)
   import StructuredQueries
-  import StructuredQueriesCore
+  #if EXCLUDE_EXPORTS
+    package import StructuredQueriesCore
+  #endif
 
   @Table
   package struct TableInfo: Codable, Hashable {

--- a/Sources/SQLiteData/CloudKit/PrimaryKeyMigration.swift
+++ b/Sources/SQLiteData/CloudKit/PrimaryKeyMigration.swift
@@ -1,9 +1,13 @@
 #if canImport(CloudKit) && canImport(CryptoKit)
   import CryptoKit
   public import Foundation
-  public import class GRDB.Database
   public import StructuredQueriesCore
   public import StructuredQueriesSQLite
+
+  #if EXCLUDE_EXPORTS
+    // NB: This 'public import' breaks the '@_exported import'.
+    public import class GRDB.Database
+  #endif
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension SyncEngine {

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -286,7 +286,7 @@
             object: nil,
             queue: nil
           ) { [syncEngines] _ in
-            Task { @MainActor in
+            _ = Task { @MainActor in
               let taskIdentifier = UIApplication.shared.beginBackgroundTask()
               defer { UIApplication.shared.endBackgroundTask(taskIdentifier) }
               let (privateSyncEngine, sharedSyncEngine) = syncEngines.withValue {

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -9,7 +9,7 @@
   import Observation
   public import StructuredQueries
   import StructuredQueriesSQLite
-  public import StructuredQueriesSQLiteCore
+  import StructuredQueriesSQLiteCore
   import SwiftData
   import TabularData
 

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -9,7 +9,9 @@
   import Observation
   public import StructuredQueries
   import StructuredQueriesSQLite
-  import StructuredQueriesSQLiteCore
+  #if EXCLUDE_EXPORTS
+    public import StructuredQueriesSQLiteCore
+  #endif
   import SwiftData
   import TabularData
 

--- a/Sources/SQLiteData/Internal/Exports.swift
+++ b/Sources/SQLiteData/Internal/Exports.swift
@@ -1,15 +1,14 @@
 #if !EXCLUDE_EXPORTS
   @_exported import Dependencies
   @_exported import StructuredQueriesSQLite
-#endif
 
-public import GRDB
-public typealias Configuration = GRDB.Configuration
-public typealias Database = GRDB.Database
-public typealias DatabaseError = GRDB.DatabaseError
-public typealias DatabaseMigrator = GRDB.DatabaseMigrator
-public typealias DatabasePool = GRDB.DatabasePool
-public typealias DatabaseQueue = GRDB.DatabaseQueue
-public typealias DatabaseReader = GRDB.DatabaseReader
-public typealias DatabaseWriter = GRDB.DatabaseWriter
-public typealias ValueObservationScheduler = GRDB.ValueObservationScheduler
+  @_exported import struct GRDB.Configuration
+  @_exported import class GRDB.Database
+  @_exported import struct GRDB.DatabaseError
+  @_exported import struct GRDB.DatabaseMigrator
+  @_exported import class GRDB.DatabasePool
+  @_exported import class GRDB.DatabaseQueue
+  @_exported import protocol GRDB.DatabaseReader
+  @_exported import protocol GRDB.DatabaseWriter
+  @_exported import protocol GRDB.ValueObservationScheduler
+#endif

--- a/Sources/SQLiteData/Internal/Exports.swift
+++ b/Sources/SQLiteData/Internal/Exports.swift
@@ -1,15 +1,15 @@
 #if !EXCLUDE_EXPORTS
   @_exported import Dependencies
   @_exported import StructuredQueriesSQLite
-
-  public import GRDB
-  public typealias Configuration = GRDB.Configuration
-  public typealias Database = GRDB.Database
-  public typealias DatabaseError = GRDB.DatabaseError
-  public typealias DatabaseMigrator = GRDB.DatabaseMigrator
-  public typealias DatabasePool = GRDB.DatabasePool
-  public typealias DatabaseQueue = GRDB.DatabaseQueue
-  public typealias DatabaseReader = GRDB.DatabaseReader
-  public typealias DatabaseWriter = GRDB.DatabaseWriter
-  public typealias ValueObservationScheduler = GRDB.ValueObservationScheduler
 #endif
+
+public import GRDB
+public typealias Configuration = GRDB.Configuration
+public typealias Database = GRDB.Database
+public typealias DatabaseError = GRDB.DatabaseError
+public typealias DatabaseMigrator = GRDB.DatabaseMigrator
+public typealias DatabasePool = GRDB.DatabasePool
+public typealias DatabaseQueue = GRDB.DatabaseQueue
+public typealias DatabaseReader = GRDB.DatabaseReader
+public typealias DatabaseWriter = GRDB.DatabaseWriter
+public typealias ValueObservationScheduler = GRDB.ValueObservationScheduler

--- a/Sources/SQLiteData/Internal/Exports.swift
+++ b/Sources/SQLiteData/Internal/Exports.swift
@@ -2,13 +2,14 @@
   @_exported import Dependencies
   @_exported import StructuredQueriesSQLite
 
-  @_exported import struct GRDB.Configuration
-  @_exported import class GRDB.Database
-  @_exported import struct GRDB.DatabaseError
-  @_exported import struct GRDB.DatabaseMigrator
-  @_exported import class GRDB.DatabasePool
-  @_exported import class GRDB.DatabaseQueue
-  @_exported import protocol GRDB.DatabaseReader
-  @_exported import protocol GRDB.DatabaseWriter
-  @_exported import protocol GRDB.ValueObservationScheduler
+  public import GRDB
+  public typealias Configuration = GRDB.Configuration
+  public typealias Database = GRDB.Database
+  public typealias DatabaseError = GRDB.DatabaseError
+  public typealias DatabaseMigrator = GRDB.DatabaseMigrator
+  public typealias DatabasePool = GRDB.DatabasePool
+  public typealias DatabaseQueue = GRDB.DatabaseQueue
+  public typealias DatabaseReader = GRDB.DatabaseReader
+  public typealias DatabaseWriter = GRDB.DatabaseWriter
+  public typealias ValueObservationScheduler = GRDB.ValueObservationScheduler
 #endif

--- a/Sources/SQLiteData/Internal/FetchKey.swift
+++ b/Sources/SQLiteData/Internal/FetchKey.swift
@@ -1,3 +1,4 @@
+import ConcurrencyExtras
 import Dependencies
 import Dispatch
 import Foundation

--- a/Sources/SQLiteData/StructuredQueries+GRDB/CustomFunctions.swift
+++ b/Sources/SQLiteData/StructuredQueries+GRDB/CustomFunctions.swift
@@ -1,7 +1,11 @@
 import Foundation
-public import class GRDB.Database
 import GRDBSQLite
 public import StructuredQueriesSQLiteCore
+
+#if EXCLUDE_EXPORTS
+  // NB: This 'public import' breaks the '@_exported import'.
+  public import class GRDB.Database
+#endif
 
 extension Database {
   /// Adds a user-defined scalar `@DatabaseFunction` to a connection.

--- a/Sources/SQLiteData/StructuredQueries+GRDB/DefaultDatabase.swift
+++ b/Sources/SQLiteData/StructuredQueries+GRDB/DefaultDatabase.swift
@@ -1,6 +1,7 @@
 public import Dependencies
-public import GRDB
 import Foundation
+public import GRDB
+import IssueReporting
 
 /// Prepares a context-sensitive database writer.
 ///


### PR DESCRIPTION
We've relied on fine-grained GRDB exports via, e.g.:

```swift
@_exported import class GRDB.Database
```

But it turns out this breaks as soon as you have an explicit `public import` in the same module:

```swift
public import class GRDB.Database
```

To work around this bug, we can use `#if` blocks to make each mutually exclusive.