### PR TITLE
Add `CasePaths` and `Tagged` traits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Build ${{ matrix.config }} without exports
-        run: swift build -c ${{ matrix.config }} -Xswiftc -D -Xswiftc EXCLUDE_EXPORTS
+        env:
+          EXCLUDE_EXPORTS: true
+        run: swift build -c ${{ matrix.config }}
       - name: Run ${{ matrix.config }} tests
         run: swift test -c ${{ matrix.config }} --traits SQLiteDataTagged
 

--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "8da8818fccd9959bd683934ddc62cf45bb65b3c8",
-        "version" : "0.31.1"
+        "revision" : "859958c7cf76918abf5aa5d6ce8b068e00a77eb2",
+        "version" : "0.32.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0ab18ed31f19c7e2b527b6bcc8ba2fc8708fcc9962e7bd79c8d049cb9595154d",
+  "originHash" : "e2cc6c054d5cb45b58ddae48858b3338ce4fc9283457edb40b284849c3914ed5",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "16f7dd14ee28d04617090f2a73198b8b316ffa12",
-        "version" : "1.13.1"
+        "revision" : "f80552807ec92f72fe3fe4543d71879182b0bfd5",
+        "version" : "1.13.0"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "8da8818fccd9959bd683934ddc62cf45bb65b3c8",
-        "version" : "0.31.1"
+        "revision" : "859958c7cf76918abf5aa5d6ce8b068e00a77eb2",
+        "version" : "0.32.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,9 +22,18 @@ let package = Package(
   ],
   traits: [
     .trait(
-      name: "SQLiteDataTagged",
+      name: "CasePaths",
+      description: "Introduce support for enum tables."
+    ),
+    .trait(
+      name: "Tagged",
       description: "Introduce SQLiteData conformances to the swift-tagged package."
-    )
+    ),
+    .trait(
+      name: "SQLiteDataTagged",
+      description: "A deprecated alias for the 'Tagged' trait.",
+      enabledTraits: ["Tagged"]
+    ),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
@@ -37,9 +46,10 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.4"),
     .package(
       url: "https://github.com/pointfreeco/swift-structured-queries",
-      from: "0.31.0",
+      from: "0.32.0",
       traits: [
-        .trait(name: "StructuredQueriesTagged", condition: .when(traits: ["SQLiteDataTagged"]))
+        .trait(name: "CasePaths", condition: .when(traits: ["CasePaths"])),
+        .trait(name: "Tagged", condition: .when(traits: ["Tagged"])),
       ]
     ),
     .package(url: "https://github.com/pointfreeco/swift-tagged", from: "0.10.0"),
@@ -60,7 +70,7 @@ let package = Package(
         .product(
           name: "Tagged",
           package: "swift-tagged",
-          condition: .when(traits: ["SQLiteDataTagged"])
+          condition: .when(traits: ["Tagged"])
         ),
       ]
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version: 6.1
 
+import Foundation
 import PackageDescription
 
 let package = Package(
@@ -118,6 +119,9 @@ for target in package.targets {
       .enableUpcomingFeature("InternalImportsByDefault"),
       .enableUpcomingFeature("MemberImportVisibility"),
     ])
+    if ProcessInfo.processInfo.environment.keys.contains("EXCLUDE_EXPORTS") {
+      target.swiftSettings?.append(.define("EXCLUDE_EXPORTS"))
+    }
   }
 }
 

--- a/Sources/SQLiteData/Traits/Tagged.swift
+++ b/Sources/SQLiteData/Traits/Tagged.swift
@@ -1,4 +1,4 @@
-#if SQLiteDataTagged
+#if Tagged
   public import Tagged
 
   extension Tagged: IdentifierStringConvertible where RawValue: IdentifierStringConvertible {


### PR DESCRIPTION
The existing `SQLiteDataTagged` trait will serve as a deprecated alias to `Tagged`, while `CasePaths` will allow SQLiteData users to enable enum tables without an explicit dependency on
`swift-structured-queries`.