### PR TITLE
Add `LazyInitializableByDefault` trait

### DIFF
--- a/Examples/CaseStudies/DynamicQuery.swift
+++ b/Examples/CaseStudies/DynamicQuery.swift
@@ -89,7 +89,7 @@ struct DynamicQueryDemo: SwiftUICaseStudy {
     func fetch(_ db: Database) throws -> Value {
       let search =
         Fact
-        .where { $0.body.contains(query) }
+        .where { $0.body.like("%\(query)%") }
         .order { $0.id.desc() }
       return try Value(
         facts: search.fetchAll(db),

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 100;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 100;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1100,6 +1100,8 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ..;
 			traits = (
+				LazyInitializableByDefault,
+				StrictDecoding,
 			);
 		};
 /* End XCLocalSwiftPackageReference section */

--- a/Examples/Reminders/Schema.swift
+++ b/Examples/Reminders/Schema.swift
@@ -36,6 +36,7 @@ nonisolated struct Reminder: Hashable, Identifiable {
   var notes = ""
   var position = 0
   var priority: Priority?
+  @Column(lazyInitializable: false)
   var remindersListID: RemindersList.ID
   var status: Status = .incomplete
   var title = ""

--- a/Examples/SyncUps/Dependencies/SpeechClient.swift
+++ b/Examples/SyncUps/Dependencies/SpeechClient.swift
@@ -37,7 +37,7 @@ nonisolated struct SpeechClient: DependencyKey {
       requestAuthorization: { .authorized },
       startTask: {
         AsyncThrowingStream { continuation in
-          Task { @MainActor in
+          _ = Task { @MainActor in
             isRecording.setValue(true)
             var finalText = """
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor \

--- a/Examples/SyncUps/SyncUpDetail.swift
+++ b/Examples/SyncUps/SyncUpDetail.swift
@@ -44,7 +44,7 @@ final class SyncUpDetailModel: HashableObject {
     withErrorReporting {
       try database.write { db in
         let ids = indices.map { meetings[$0].id }
-        try Meeting.where { ids.contains($0.id) }.delete().execute(db)
+        try Meeting.where { $0.id.in(ids) }.delete().execute(db)
       }
     }
   }

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,10 @@ let package = Package(
   ],
   traits: [
     .trait(
+      name: "LazyInitializableByDefault",
+      description: "Optionalize draft properties that have no default."
+    ),
+    .trait(
       name: "StrictDecoding",
       description: """
         Throw an error, rather than coerce, when decoding a column whose storage type does not \
@@ -57,6 +61,10 @@ let package = Package(
       branch: "strict-decoding",
 //      from: "0.32.0",
       traits: [
+        .trait(
+          name: "LazyInitializableByDefault",
+          condition: .when(traits: ["LazyInitializableByDefault"])
+        ),
         .trait(name: "CasePaths", condition: .when(traits: ["CasePaths"])),
         .trait(name: "Tagged", condition: .when(traits: ["Tagged"])),
       ]


### PR DESCRIPTION
Makes it easier to turn on the StructuredQueries trait without an explicit dependency.