### PR TITLE
Propagate suspension handling to CloudKit metadata

### DIFF
--- a/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
@@ -8,7 +8,8 @@
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   func defaultMetadatabase(
     logger: Logger,
-    url: URL
+    url: URL,
+    observesSuspensionNotifications: Bool
   ) throws -> any DatabaseWriter {
     logger.debug(
       """
@@ -24,7 +25,12 @@
       throw InMemoryDatabase()
     }
 
-    let metadatabase = try DatabasePool(path: url.path(percentEncoded: false))
+    var configuration = Configuration()
+    configuration.observesSuspensionNotifications = observesSuspensionNotifications
+    let metadatabase = try DatabasePool(
+      path: url.path(percentEncoded: false),
+      configuration: configuration
+    )
     try migrate(metadatabase: metadatabase)
     return metadatabase
   }

--- a/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Metadatabase.swift
@@ -9,7 +9,7 @@
   func defaultMetadatabase(
     logger: Logger,
     url: URL,
-    observesSuspensionNotifications: Bool
+    configuration: Configuration
   ) throws -> any DatabaseWriter {
     logger.debug(
       """
@@ -25,11 +25,11 @@
       throw InMemoryDatabase()
     }
 
-    var configuration = Configuration()
-    configuration.observesSuspensionNotifications = observesSuspensionNotifications
+    var metadatabaseConfiguration = Configuration()
+    metadatabaseConfiguration.observesSuspensionNotifications = configuration.observesSuspensionNotifications
     let metadatabase = try DatabasePool(
       path: url.path(percentEncoded: false),
-      configuration: configuration
+      configuration: metadatabaseConfiguration
     )
     try migrate(metadatabase: metadatabase)
     return metadatabase

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -269,7 +269,9 @@
         url: try URL.metadatabase(
           databasePath: userDatabase.path,
           containerIdentifier: container.containerIdentifier
-        )
+        ),
+        observesSuspensionNotifications:
+          userDatabase.configuration.observesSuspensionNotifications
       )
       self.tablesByName = Dictionary(
         uniqueKeysWithValues: self.tables.map { ($0.base.tableName, $0) }

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -270,8 +270,7 @@
           databasePath: userDatabase.path,
           containerIdentifier: container.containerIdentifier
         ),
-        observesSuspensionNotifications:
-          userDatabase.configuration.observesSuspensionNotifications
+        configuration: userDatabase.configuration
       )
       self.tablesByName = Dictionary(
         uniqueKeysWithValues: self.tables.map { ($0.base.tableName, $0) }

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineTests.swift
@@ -43,6 +43,32 @@
       }
 
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test(arguments: [false, true])
+      func metadatabaseInheritsSuspensionNotificationConfiguration(
+        _ observesSuspensionNotifications: Bool
+      ) async throws {
+        var configuration = Configuration()
+        configuration.observesSuspensionNotifications = observesSuspensionNotifications
+        let syncEngine = try await SyncEngine(
+          container: MockCloudContainer(
+            containerIdentifier: "test",
+            privateCloudDatabase: MockCloudDatabase(databaseScope: .private),
+            sharedCloudDatabase: MockCloudDatabase(databaseScope: .shared)
+          ),
+          userDatabase: UserDatabase(
+            database: try DatabaseQueue(configuration: configuration)
+          ),
+          tables: [],
+          startImmediately: false
+        )
+
+        #expect(
+          syncEngine.metadatabase.configuration.observesSuspensionNotifications
+            == observesSuspensionNotifications
+        )
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test(.dependency(\.context, .live))
       func inMemoryUserDatabase_LiveContext() async throws {
         let error = await #expect(throws: (any Error).self) {


### PR DESCRIPTION
## Motivation

`SyncEngine` already includes iOS-specific lifecycle handling: it observes `UIApplication.willResignActiveNotification`, begins a background task, and attempts to send pending private and shared CloudKit changes before the app is suspended.

watchOS does not use this integration and can suspend apps much more aggressively. GRDB supports this environment through the experimental flag `observesSuspensionNotifications`, allowing clients to release database locks when posting `Database.suspendNotification`.

However, while the user database can opt into this behavior, `SyncEngine` maintains a separate CloudKit metadata connection that does not currently participate. This can leave the metadata database holding a SQLite lock during suspension, resulting in a `RUNNINGBOARD 0xdead10cc` termination on watchOS.