### PR TITLE
Fix permanent sync divergence when userModificationTime stamps tie

### DIFF
--- a/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
@@ -156,10 +156,13 @@
     package func setValue(
       _ newValue: some CKRecordValueProtocol & Equatable,
       forKey key: CKRecord.FieldKey,
-      at userModificationTime: Int64
+      at userModificationTime: Int64,
+      requireStrictlyNewer: Bool = false
     ) -> Bool {
       guard
-        encryptedValues[at: key] <= userModificationTime,
+        requireStrictlyNewer
+          ? encryptedValues[at: key] < userModificationTime
+          : encryptedValues[at: key] <= userModificationTime,
         encryptedValues[key] != newValue
       else { return false }
       encryptedValues[key] = newValue
@@ -172,7 +175,8 @@
     package func setAsset(
       _ newValue: CKAsset,
       forKey key: CKRecord.FieldKey,
-      at userModificationTime: Int64
+      at userModificationTime: Int64,
+      requireStrictlyNewer: Bool = false
     ) -> Bool {
       @Dependency(\.dataManager) var dataManager
       guard
@@ -180,7 +184,9 @@
         let hash = dataManager.sha256(of: fileURL)
       else { return false }
       guard
-        encryptedValues[at: key] <= userModificationTime,
+        requireStrictlyNewer
+          ? encryptedValues[at: key] < userModificationTime
+          : encryptedValues[at: key] <= userModificationTime,
         encryptedValues[hash: key] != hash
       else { return false }
 
@@ -223,9 +229,13 @@
     @discardableResult
     package func removeValue(
       forKey key: CKRecord.FieldKey,
-      at userModificationTime: Int64
+      at userModificationTime: Int64,
+      requireStrictlyNewer: Bool = false
     ) -> Bool {
-      guard encryptedValues[at: key] <= userModificationTime
+      guard
+        requireStrictlyNewer
+          ? encryptedValues[at: key] < userModificationTime
+          : encryptedValues[at: key] <= userModificationTime
       else {
         return false
       }
@@ -283,26 +293,42 @@
       }
     }
 
+    @discardableResult
     func update<T: PrimaryKeyedTable>(
       with other: CKRecord,
       row: T,
       columnNames: inout [String],
       parentForeignKey: ForeignKey?
-    ) {
+    ) -> Bool {
       typealias EquatableCKRecordValueProtocol = CKRecordValueProtocol & Equatable
 
       self.userModificationTime = other.userModificationTime
+      var didPreserveLocalValues = false
       for column in T.TableColumns.writableColumns {
         func open<Root, Value>(_ column: some WritableTableColumnExpression<Root, Value>) {
           let key = column.name
           let keyPath = column.keyPath as! KeyPath<T, Value.QueryOutput>
           let didSet: Bool
           if let value = other[key] as? CKAsset {
-            didSet = setAsset(value, forKey: key, at: other.encryptedValues[at: key])
+            didSet = setAsset(
+              value,
+              forKey: key,
+              at: other.encryptedValues[at: key],
+              requireStrictlyNewer: true
+            )
           } else if let value = other.encryptedValues[key] as? any EquatableCKRecordValueProtocol {
-            didSet = setValue(value, forKey: key, at: other.encryptedValues[at: key])
+            didSet = setValue(
+              value,
+              forKey: key,
+              at: other.encryptedValues[at: key],
+              requireStrictlyNewer: true
+            )
           } else if other.encryptedValues[key] == nil {
-            didSet = removeValue(forKey: key, at: other.encryptedValues[at: key])
+            didSet = removeValue(
+              forKey: key,
+              at: other.encryptedValues[at: key],
+              requireStrictlyNewer: true
+            )
           } else {
             didSet = false
           }
@@ -334,13 +360,17 @@
           }
           if didSet || isRowValueModified {
             columnNames.removeAll(where: { $0 == key })
-            if didSet, let parentForeignKey, key == parentForeignKey.from {
-              self.parent = other.parent
+            if didSet {
+              didPreserveLocalValues = true
+              if let parentForeignKey, key == parentForeignKey.from {
+                self.parent = other.parent
+              }
             }
           }
         }
         open(column)
       }
+      return didPreserveLocalValues
     }
 
     package var userModificationTime: Int64 {

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -1591,24 +1591,33 @@
         case share(CKShare)
         case reference(CKShare.Reference)
       }
-      let shares: [ShareOrReference] =
+      let (shares, preservedRecordIDs): ([ShareOrReference], [CKRecord.ID]) =
         await withErrorReporting(.sqliteDataCloudKitFailure) {
           try await userDatabase.write { db in
             var shares: [ShareOrReference] = []
+            var preservedRecordIDs: [CKRecord.ID] = []
             for record in modifications {
               if let share = record as? CKShare {
                 shares.append(.share(share))
               } else {
-                upsertFromServerRecord(record, db: db)
+                if upsertFromServerRecord(record, db: db) {
+                  preservedRecordIDs.append(record.recordID)
+                }
                 if let shareReference = record.share {
                   shares.append(.reference(shareReference))
                 }
               }
             }
-            return shares
+            return (shares, preservedRecordIDs)
           }
         }
-        ?? []
+        ?? ([], [])
+
+      if !preservedRecordIDs.isEmpty {
+        syncEngine.state.add(
+          pendingRecordZoneChanges: preservedRecordIDs.map { .saveRecord($0) }
+        )
+      }
 
       await withTaskGroup(of: Void.self) { group in
         for share in shares {
@@ -1897,28 +1906,31 @@
       }
     }
 
+    @discardableResult
     private func upsertFromServerRecord(
       _ serverRecord: CKRecord,
       force: Bool = false
-    ) async {
+    ) async -> Bool {
       await withErrorReporting(.sqliteDataCloudKitFailure) {
         try await userDatabase.write { db in
           upsertFromServerRecord(serverRecord, force: force, db: db)
         }
       }
+        ?? false
     }
 
+    @discardableResult
     private func upsertFromServerRecord(
       _ serverRecord: CKRecord,
       force: Bool = false,
       db: Database
-    ) {
+    ) -> Bool {
       withErrorReporting(.sqliteDataCloudKitFailure) {
         guard
           let recordPrimaryKey = serverRecord.recordID.recordPrimaryKey,
           serverRecord.encryptedValues[CKRecord.userModificationTimeKey] != nil
         else {
-          return
+          return false
         }
 
         try SyncMetadata.insert {
@@ -1950,18 +1962,19 @@
           let metadata = try SyncMetadata.find(serverRecord.recordID).fetchOne(db),
           let table = tablesByName[serverRecord.recordType]
         else {
-          return
+          return false
         }
 
         serverRecord.userModificationTime = metadata.userModificationTime
 
-        func open<T>(_ table: some SynchronizableTable<T>) throws {
+        func open<T>(_ table: some SynchronizableTable<T>) throws -> Bool {
           var columnNames: [String] = T.TableColumns.writableColumns.map(\.name)
+          var didPreserveLocalValues = false
           if !force,
             let allFields = metadata._lastKnownServerRecordAllFields,
             let row = try T.unscoped.find(#sql("\(bind: metadata.recordPrimaryKey)")).fetchOne(db)
           {
-            serverRecord.update(
+            didPreserveLocalValues = serverRecord.update(
               with: allFields,
               row: T(queryOutput: row),
               columnNames: &columnNames,
@@ -1994,9 +2007,25 @@
             }
             .execute(db)
           }
+          if didPreserveLocalValues, let lastKnownServerRecord = metadata.lastKnownServerRecord {
+            if let lastKnownDate = lastKnownServerRecord.modificationDate,
+              let serverDate = serverRecord.modificationDate
+            {
+              if serverDate < lastKnownDate {
+                didPreserveLocalValues = false
+              }
+            } else if let lastKnownTag = lastKnownServerRecord._recordChangeTag,
+              let serverTag = serverRecord._recordChangeTag,
+              serverTag < lastKnownTag
+            {
+              didPreserveLocalValues = false
+            }
+          }
+          return didPreserveLocalValues
         }
-        try open(table)
+        return try open(table)
       }
+        ?? false
     }
 
     private func refreshLastKnownServerRecord(_ record: CKRecord) async {

--- a/Tests/SQLiteDataTests/CloudKitTests/MergeConflictTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MergeConflictTests.swift
@@ -638,6 +638,170 @@
       }
 
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func equalTimestampConflictConvergesToServerValue() async throws {
+        try await userDatabase.userWrite { db in
+          try db.seed {
+            RemindersList(id: 1, title: "")
+            Reminder(id: 1, title: "", remindersListID: 1)
+          }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        try await withDependencies {
+          $0.currentTime.now += 30
+        } operation: {
+          try await userDatabase.userWrite { db in
+            try Reminder.find(1).update { $0.title = "Mine" }.execute(db)
+          }
+          try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+          let record = try syncEngine.private.database.record(for: Reminder.recordID(for: 1))
+          record.setValue("Theirs", forKey: "title", at: now)
+          let modificationCallback = try {
+            try syncEngine.modifyRecords(scope: .private, saving: [record])
+          }()
+          await modificationCallback.notify()
+        }
+
+        assertQuery(Reminder.select(\.title), database: userDatabase.database) {
+          """
+          ┌──────────┐
+          │ "Theirs" │
+          └──────────┘
+          """
+        }
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                  recordType: "reminders",
+                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                  share: nil,
+                  dueDate🗓️: 0,
+                  id: 1,
+                  id🗓️: 0,
+                  isCompleted: 0,
+                  isCompleted🗓️: 0,
+                  priority🗓️: 0,
+                  remindersListID: 1,
+                  remindersListID🗓️: 0,
+                  title: "Theirs",
+                  title🗓️: 30,
+                  🗓️: 30
+                ),
+                [1]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  id🗓️: 0,
+                  title: "",
+                  title🗓️: 0,
+                  🗓️: 0
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func olderTimestampFetchReassertsLocalWinToServer() async throws {
+        try await userDatabase.userWrite { db in
+          try db.seed {
+            RemindersList(id: 1, title: "")
+            Reminder(id: 1, title: "", remindersListID: 1)
+          }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        try await withDependencies {
+          $0.currentTime.now += 100
+        } operation: {
+          try await userDatabase.userWrite { db in
+            try Reminder.find(1).update { $0.title = "Fast" }.execute(db)
+          }
+          try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+          let record = try syncEngine.private.database.record(for: Reminder.recordID(for: 1))
+          record.encryptedValues["title"] = "Slow"
+          record.encryptedValues["\(CKRecord.userModificationTimeKey)_title"] = Int64(50)
+          let modificationCallback = try {
+            try syncEngine.modifyRecords(scope: .private, saving: [record])
+          }()
+          await modificationCallback.notify()
+          syncEngine.private.state.assertPendingRecordZoneChanges([
+            .saveRecord(Reminder.recordID(for: 1))
+          ])
+          syncEngine.private.state.add(
+            pendingRecordZoneChanges: [.saveRecord(Reminder.recordID(for: 1))]
+          )
+          try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+        }
+
+        assertQuery(Reminder.select(\.title), database: userDatabase.database) {
+          """
+          ┌────────┐
+          │ "Fast" │
+          └────────┘
+          """
+        }
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: [
+                [0]: CKRecord(
+                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                  recordType: "reminders",
+                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                  share: nil,
+                  dueDate🗓️: 0,
+                  id: 1,
+                  id🗓️: 0,
+                  isCompleted: 0,
+                  isCompleted🗓️: 0,
+                  priority🗓️: 0,
+                  remindersListID: 1,
+                  remindersListID🗓️: 0,
+                  title: "Fast",
+                  title🗓️: 100,
+                  🗓️: 100
+                ),
+                [1]: CKRecord(
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                  recordType: "remindersLists",
+                  parent: nil,
+                  share: nil,
+                  id: 1,
+                  id🗓️: 0,
+                  title: "",
+                  title🗓️: 0,
+                  🗓️: 0
+                )
+              ]
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func mergeWithNullableFields() async throws {
         try await userDatabase.userWrite { db in
           try db.seed {


### PR DESCRIPTION
## Summary

Two devices writing the same field with identical microsecond `userModificationTime` stamps can diverge **permanently and silently**: one device keeps its own value forever while the server and all other devices converge on a different value, and the stuck device reports fully synced. We hit this reproducibly (8/9 scripted trials) with near-simultaneous same-primary-key inserts from two processes — concurrent writers land nanosecond-identical stamps often, since the clock has microsecond resolution and timers coalesce.

## Mechanism

Two behaviors compound:

1. **Self-preferring tie-break.** The merge guards in `CloudKit+StructuredQueries.swift` (`setValue`/`setAsset`/`removeValue`) use `<=`, so on a per-field stamp tie the local/base value overwrites the incoming committed server value. Self-preference is not a total order: both replicas of a tie each conclude "mine wins" and resolve the same tie oppositely.
2. **Override without enqueue on the fetch path.** When `handleFetchedRecordZoneChanges` → `upsertFromServerRecord` preserves local values over an incoming committed record, no upload is enqueued — the `.serverRecordChanged` conflict path re-enqueues (`SyncEngine.swift`), but the fetch path does not.

End to end: A and B insert the same key with stamp *t*. A commits first. B's save conflicts; the tie keeps B's value; the conflict path re-enqueues; B's retry commits — B and the server agree. A then *fetches* B's commit: the tie keeps A's value, the merge-mutated record (server change tag around A's values) is stored as A's base, and nothing is enqueued. A's row now differs from its base on every future delivery, so the `isRowValueModified` branch discards every subsequent server value while advancing the base — a silent absorbing state.

## The fix

1. **Strict `<` for inbound merges.** The three setters gain a `requireStrictlyNewer` parameter (default `false`, so outgoing record construction — where an equal-stamp local edit must still apply — is unchanged). The inbound merge passes `true`: a base field overrules an incoming committed value only when strictly newer. On a tie the committed value wins. CloudKit's CAS chain already totally orders each record's history and replays it identically to every replica, so commit order serves as a deterministic tie-breaker shared by all replicas — no schema change, and safe in a mixed fleet of patched and unpatched clients (a patched device defers on ties; an unpatched peer's conflict path pushes its value; everyone converges on it).
2. **Enqueue on override.** When an inbound merge on the fetch path actively overrules incoming committed field values (base field strictly newer — e.g. clock skew between writers), a `.saveRecord` is enqueued for that record, mirroring the conflict path, so the surviving value is re-asserted to the server and replicas that never saw it converge. Two deliberate scope limits, both shaped by the existing test suite: stale replays (incoming older than the stored base) are suppressed, since a replay legitimately loses and must not cause churn; and row-level preservation of pending local edits (`isRowValueModified`) does not enqueue, since those uploads are already owned by the change triggers.

## Tests

Two regression tests in `MergeConflictTests` using the existing mocks:

- `equalTimestampConflictConvergesToServerValue`: a fetched record carrying a different value at an equal field stamp must be adopted, leaving row, server, and base converged.
- `olderTimestampFetchReassertsLocalWinToServer`: a later commit carrying an older field stamp loses the merge, and the surviving local value is enqueued and pushed so the server converges on the LWW winner.

Full suite passes (241 tests). With `Sources/` reverted to `main` and the tests kept, both fail with the expected signatures (device keeps `"Mine"` over committed `"Theirs"`; the `.saveRecord` never enqueued).

One observation for maintainers, made while validating the red case: `MockCloudDatabase.modifyRecords` stores and returns the same `CKRecord` instance (`MockCloudDatabase.swift:204-205`), so a merge that mutates a fetched record in place also mutates mock server storage — under the buggy code the mock "server" appears to adopt the stale device's value when real CloudKit would not. Happy to file that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)