### PR TITLE
Deliver latest record state in `ModifyRecordsCallback` test helper

### DIFF
--- a/Tests/SQLiteDataTests/CloudKitTests/ModifyRecordsCallbackTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/ModifyRecordsCallbackTests.swift
@@ -1,0 +1,68 @@
+#if canImport(CloudKit)
+  import CloudKit
+  import SQLiteData
+  import Testing
+
+  extension BaseCloudKitTests {
+    @MainActor
+    final class ModifyRecordsCallbackTests: BaseCloudKitTests, @unchecked Sendable {
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func deferredCallbackDeliversLatestRecords() async throws {
+        try await userDatabase.userWrite { db in
+          try db.seed { RemindersList(id: 1, title: "Original") }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        let firstRecord = try syncEngine.private.database.record(
+          for: RemindersList.recordID(for: 1)
+        )
+        firstRecord.setValue("First", forKey: "title", at: 30)
+        let callback = try syncEngine.modifyRecords(scope: .private, saving: [firstRecord])
+
+        let secondRecord = try syncEngine.private.database.record(
+          for: RemindersList.recordID(for: 1)
+        )
+        secondRecord.setValue("Second", forKey: "title", at: 60)
+        _ = try syncEngine.modifyRecords(scope: .private, saving: [secondRecord])
+
+        await callback.notify()
+
+        let title = try await userDatabase.database.read { db in
+          try RemindersList.find(1).select(\.title).fetchOne(db)
+        }
+        #expect(title == "Second")
+      }
+
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func deferredCallbackSkipsDeletionOfReSavedRecord() async throws {
+        try await userDatabase.userWrite { db in
+          try db.seed { RemindersList(id: 1, title: "Original") }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        let recordID = RemindersList.recordID(for: 1)
+
+        let callback = try syncEngine.modifyRecords(
+          scope: .private,
+          deleting: [recordID]
+        )
+
+        let revivedRecord = CKRecord(
+          recordType: RemindersList.tableName,
+          recordID: recordID
+        )
+        revivedRecord.setValue("Revived", forKey: "title", at: 30)
+        _ = try syncEngine.modifyRecords(scope: .private, saving: [revivedRecord])
+
+        await callback.notify()
+
+        let title = try await userDatabase.database.read { db in
+          try RemindersList.find(1).select(\.title).fetchOne(db)
+        }
+        // NB: The deletion is skipped and the revival's callback isn't notified at this point,
+        //     so the local record stays untouched.
+        #expect(title == "Original")
+      }
+    }
+  }
+#endif

--- a/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
@@ -20,10 +20,9 @@ extension PrimaryKeyedTable where PrimaryKey.QueryOutput: IdentifierStringConver
 
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
 extension SyncEngine {
-  struct ModifyRecordsCallback<ReturnValue> {
-    fileprivate let operation: @Sendable () async -> ReturnValue
-    @discardableResult
-    func notify() async -> ReturnValue {
+  struct ModifyRecordsCallback {
+    fileprivate let operation: @Sendable () async -> Void
+    func notify() async {
       await operation()
     }
   }
@@ -32,12 +31,7 @@ extension SyncEngine {
     scope: CKDatabase.Scope,
     saving recordZonesToSave: [CKRecordZone] = [],
     deleting recordZoneIDsToDelete: [CKRecordZone.ID] = []
-  ) throws -> ModifyRecordsCallback<
-    (
-      saveResults: [CKRecordZone.ID: Result<CKRecordZone, any Error>],
-      deleteResults: [CKRecordZone.ID: Result<Void, any Error>]
-    )
-  > {
+  ) throws -> ModifyRecordsCallback {
     let syncEngine = syncEngine(for: scope)
 
     let (saveResults, deleteResults) = try syncEngine.database.modifyRecordZones(
@@ -58,7 +52,6 @@ extension SyncEngine {
           ),
           syncEngine: syncEngine
         )
-      return (saveResults, deleteResults)
     }
   }
 
@@ -67,12 +60,7 @@ extension SyncEngine {
     saving recordsToSave: [CKRecord] = [],
     deleting recordIDsToDelete: [CKRecord.ID] = [],
     atomically: Bool = true
-  ) throws -> ModifyRecordsCallback<
-    (
-      saveResults: [CKRecord.ID: Result<CKRecord, any Error>],
-      deleteResults: [CKRecord.ID: Result<Void, any Error>]
-    )
-  > {
+  ) throws -> ModifyRecordsCallback {
     let syncEngine = syncEngine(for: scope)
     let recordsToDeleteByID = Dictionary(
       grouping: syncEngine.database.state.withValue { state in
@@ -110,7 +98,6 @@ extension SyncEngine {
         ),
         syncEngine: syncEngine
       )
-      return (saveResults, deleteResults)
     }
   }
 }

--- a/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
@@ -79,19 +79,24 @@ extension SyncEngine {
     )
 
     return ModifyRecordsCallback {
+      let savedRecordIDs = saveResults.compactMap { recordID, result in
+        (try? result.get()) != nil ? recordID : nil
+      }
+      let deletedRecordIDs = deleteResults.compactMap { recordID, result in
+        (try? result.get()) != nil ? recordID : nil
+      }
+      let freshRecords =
+        (try? syncEngine.database.records(
+          for: savedRecordIDs + deletedRecordIDs,
+          desiredKeys: nil
+        )) ?? [:]
       await syncEngine.parentSyncEngine.handleEvent(
         .fetchedRecordZoneChanges(
-          modifications: saveResults.compactMap { recordID, result in
-            guard case .success = result else { return nil }
-            // NB: Read the latest version from the database in case the record has been
-            //     modified between the original save and when this callback is invoked.
-            return try? syncEngine.database.record(for: recordID)
+          modifications: savedRecordIDs.compactMap { recordID in
+            try? freshRecords[recordID]?.get()
           },
-          deletions: deleteResults.compactMap { recordID, result in
-            guard case .success = result else { return nil }
-            // NB: Skip if the record has been re-saved between the original delete and
-            //     when this callback is invoked.
-            guard (try? syncEngine.database.record(for: recordID)) == nil else { return nil }
+          deletions: deletedRecordIDs.compactMap { recordID in
+            guard (try? freshRecords[recordID]?.get()) == nil else { return nil }
             guard let record = recordsToDeleteByID[recordID] else { return nil }
             return (recordID, record.recordType)
           }

--- a/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
+++ b/Tests/SQLiteDataTests/Internal/CloudKitTestHelpers.swift
@@ -93,13 +93,19 @@ extension SyncEngine {
     return ModifyRecordsCallback {
       await syncEngine.parentSyncEngine.handleEvent(
         .fetchedRecordZoneChanges(
-          modifications: saveResults.values.compactMap { try? $0.get() },
+          modifications: saveResults.compactMap { recordID, result in
+            guard case .success = result else { return nil }
+            // NB: Read the latest version from the database in case the record has been
+            //     modified between the original save and when this callback is invoked.
+            return try? syncEngine.database.record(for: recordID)
+          },
           deletions: deleteResults.compactMap { recordID, result in
-            (recordsToDeleteByID[recordID]?.recordType).flatMap { recordType in
-              (try? result.get()) != nil
-                ? (recordID, recordType)
-                : nil
-            }
+            guard case .success = result else { return nil }
+            // NB: Skip if the record has been re-saved between the original delete and
+            //     when this callback is invoked.
+            guard (try? syncEngine.database.record(for: recordID)) == nil else { return nil }
+            guard let record = recordsToDeleteByID[recordID] else { return nil }
+            return (recordID, record.recordType)
           }
         ),
         syncEngine: syncEngine


### PR DESCRIPTION
## Motivation

The `modifyRecords(…)` test helper returns a `ModifyRecordsCallback`, which allows tests to notify the sync engine about server-side changes at a later point. This is useful for testing merge conflict scenarios that depend on ordering, such as fetch-before-retry and retry-before-fetch.

However, the callback currently captures the saved records at modification time. If the same record is modified again in the mock database before the callback is invoked, the callback replays stale record versions, so an earlier edit is delivered to the sync engine even though the mock database already holds a newer one. The deletion side has the equivalent problem, as a deferred deletion is still delivered even if the record has been re-created in the meantime. This deviates from CloudKit's behavior, where a fetch always reflects the latest server state. Production code is not involved, but tests relying on deferred callbacks currently exercise scenarios that real CloudKit can never produce.

The issue would become even more relevant with mocked `CKRecord.recordChangeTag` (a follow-up to #411 I have lined up), where stale change tags would break the conflict detection required for supporting customizable conflict resolution in the future.

This was originally discussed in [this comment on #412](https://github.com/pointfreeco/sqlite-data/pull/412#issuecomment-4132703584), where filing it as a separate PR was suggested. I had planned to wait for #507, but the change turned out to be independent of it. It also doesn't reintroduce the shared reference issue addressed there, since `record(for:)` already returns copies of the stored records on `main`.

## Implementation

The callback now reads the latest state from the mock database at invocation time instead of using the captured save results:

- For modifications, each successfully saved record is re-read via `record(for:)`, so the sync engine receives the current server state.
- For deletions, the event is skipped if the record has been re-saved between the original delete and the callback invocation, mirroring how a real fetch would no longer report such a record as deleted.

Both behaviors are covered by regression tests that fail on `main` and pass with this fix.

---

*Disclaimer: AI assistance (Claude Code with Fable model) was used to prepare this PR. All changes and verifications were reviewed by me.*