### PR TITLE
Fix sync delegate test crash in Xcode 27 beta.

### DIFF
--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -34,7 +34,11 @@
     let foreignKeysByTableName: [String: [ForeignKey]]
     package let syncEngines = LockIsolated<SyncEngines>(SyncEngines())
     package let defaultZone: CKRecordZone
-    weak let delegate: (any SyncEngineDelegate)?
+    #if compiler(<6.2.3)
+      weak var delegate: (any SyncEngineDelegate)?
+    #else
+      weak let delegate: (any SyncEngineDelegate)?
+    #endif
     let defaultSyncEngines:
       @Sendable (any DatabaseReader, SyncEngine)
         -> (private: any SyncEngineProtocol, shared: any SyncEngineProtocol)
@@ -944,6 +948,14 @@
       }
     }
   }
+
+  #if compiler(<6.2.3)
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    extension SyncEngine: @unchecked Sendable {}
+  #else
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    extension SyncEngine: Sendable {}
+  #endif
 
   extension PrimaryKeyedTable {
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -34,7 +34,7 @@
     let foreignKeysByTableName: [String: [ForeignKey]]
     package let syncEngines = LockIsolated<SyncEngines>(SyncEngines())
     package let defaultZone: CKRecordZone
-    let delegate: (any SyncEngineDelegate)?
+    weak let delegate: (any SyncEngineDelegate)?
     let defaultSyncEngines:
       @Sendable (any DatabaseReader, SyncEngine)
         -> (private: any SyncEngineProtocol, shared: any SyncEngineProtocol)

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineDelegateTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineDelegateTests.swift
@@ -15,7 +15,6 @@
     @MainActor
     final class SyncEngineDelegateTests: BaseCloudKitTests, @unchecked Sendable {
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-
       @Test($syncEngineDelegate.set(MyDelegate()))
       func accountChanged() async throws {
         try await userDatabase.userWrite { db in


### PR DESCRIPTION
Fixes #509.

Something different (I think!) in Xcode 27 causes traits to be evaluated on tests that are not actually run. That, coupled with `SyncEngineDelegate`s being kept in memory for too long, caused a crash when running any tests that did not use the sync delegate trait. The fix is just to weakly hold onto the delegate in the `SyncEngine`. 

That does mean that if anyone ever created a sync engine like this:

```swift
SyncEngine(
  …,
  delegate: MyDelegate()
)
```

…will have their delegate immediately deallocated, which would be a bug. Luckily all of our docs and sample apps show off holding on the delegate explicitly, which is standard practice in most Apple APIs.