### PR TITLE
Work around Swift parameter pack bug in `@FetchAll(sectionBy:)`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "706feb7858a7f6c242879d137b8ee30926aa5b26",
-        "version" : "1.12.0"
+        "revision" : "8dc1fbf2f6255a73dec53b4648164884898db4c5",
+        "version" : "1.14.1"
       }
     },
     {

--- a/Sources/SQLiteData/Documentation.docc/Articles/Fetching.md
+++ b/Sources/SQLiteData/Documentation.docc/Articles/Fetching.md
@@ -195,6 +195,39 @@ and its value names each section:
 var reminders
 ```
 
+Sections are not limited to `@FetchAll`. Any query can be fetched into a
+``ResultsSectionCollection`` directly, which is useful when defining a custom
+``FetchKeyRequest``:
+
+```swift
+struct RemindersByCategory: FetchKeyRequest {
+  func fetch(_ db: Database) throws -> ResultsSectionCollection<Reminder, String?> {
+    try Reminder
+      .order(by: \.title)
+      .fetchAll(db, sectionBy: \.category)
+  }
+}
+```
+
+The request can be observed with ``Fetch``, and its sections drive a list just like
+``FetchAll/sections`` does:
+
+```swift
+@Fetch(RemindersByCategory()) var sections = ResultsSectionCollection<Reminder, String?>()
+```
+
+And while `@FetchAll` always names its sections with strings, this form can section by any
+`Hashable` value the database can decode, and supports joins and custom selections:
+
+```swift
+try Reminder
+  .order(by: \.title)
+  .join(RemindersList.all) { $0.listID.eq($1.id) }
+  .select { ReminderRow.Columns(title: $0.title, list: $1.name) }
+  .fetchAll(db, sectionBy: { $1.id })
+// ResultsSectionCollection<ReminderRow, Int?>
+```
+
 [sq-safe-sql-strings]: https://swiftpackageindex.com/pointfreeco/swift-structured-queries/~/documentation/structuredqueriescore/safesqlstrings
 [structured-queries-gh]: https://github.com/pointfreeco/swift-structured-queries
 [structured-queries-docs]: https://swiftpackageindex.com/pointfreeco/swift-structured-queries/main/documentation/structuredqueriescore/

--- a/Sources/SQLiteData/FetchAll+Sections.swift
+++ b/Sources/SQLiteData/FetchAll+Sections.swift
@@ -37,52 +37,6 @@ extension FetchAll {
     return sectionedReader.wrappedValue
   }
 
-  fileprivate init<From: StructuredQueriesCore.Table>(
-    wrappedValue: [Element],
-    statement: Select<(), From, ()>,
-    sectionBy: _Sectioning,
-    database: (any DatabaseReader)?,
-    scheduler: (any ValueObservationScheduler & Hashable)?
-  )
-  where
-    Element == From.QueryOutput,
-    From.QueryOutput: Sendable
-  {
-    self.init(
-      wrappedValue: wrappedValue,
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectionBy),
-      sectionBy: sectionBy,
-      database: database,
-      scheduler: scheduler
-    )
-  }
-
-  fileprivate init<Value: QueryRepresentable>(
-    wrappedValue: [Element],
-    request: FetchAllSectionedStatementValueRequest<Value>,
-    sectionBy: _Sectioning,
-    database: (any DatabaseReader)?,
-    scheduler: (any ValueObservationScheduler & Hashable)?
-  )
-  where
-    Element == Value.QueryOutput,
-    Value.QueryOutput: Sendable
-  {
-    let sectionedReader = SharedReader(
-      wrappedValue: ResultsSectionCollection(elements: wrappedValue, sectionName: nil),
-      FetchKey(
-        request: request,
-        database: database,
-        scheduler: scheduler
-      )
-    )
-    self.sectionedReader = sectionedReader
-    self.sharedReader = sectionedReader.elements
-    self.sectioning.setValue(sectionBy)
-  }
-}
-
-extension FetchAll {
   /// Initializes this property with a query that fetches every row from a table, grouping results
   /// into sections.
   ///
@@ -179,6 +133,373 @@ extension FetchAll {
   ///
   /// - Parameters:
   ///   - wrappedValue: A default collection to associate with this property.
+  ///   - sectionKeyPath: A key path to a string column to group results by.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  public init(
+    wrappedValue: [Element] = [],
+    sectionBy sectionKeyPath: KeyPath<
+      Element.TableColumns, some QueryExpression<some _OptionalPromotable<String?>>
+    >,
+    database: (any DatabaseReader)? = nil
+  )
+  where Element: StructuredQueriesCore.Table, Element.QueryOutput == Element {
+    self.init(
+      wrappedValue: wrappedValue,
+      sectionBy: { $0[keyPath: sectionKeyPath] },
+      database: database
+    )
+  }
+
+  /// Initializes this property with a query associated with the wrapped value, grouping results
+  /// into sections.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default collection to associate with this property.
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectionKeyPath: A key path to a string column to group results by.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  public init<S: SelectStatement>(
+    wrappedValue: [Element] = [],
+    _ statement: S,
+    sectionBy sectionKeyPath: KeyPath<
+      S.From.TableColumns, some QueryExpression<some _OptionalPromotable<String?>>
+    >,
+    database: (any DatabaseReader)? = nil
+  )
+  where
+    Element == S.From.QueryOutput,
+    S.QueryValue == (),
+    S.From.QueryOutput: Sendable,
+    S.Joins == ()
+  {
+    self.init(
+      wrappedValue: wrappedValue,
+      statement,
+      sectionBy: { $0[keyPath: sectionKeyPath] },
+      database: database
+    )
+  }
+
+  public init<
+    V: QueryRepresentable, From: StructuredQueriesCore.Table
+  >(
+    wrappedValue: [Element] = [],
+    _ statement: Select<V, From, ()>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil
+  )
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns) else {
+      self.init(wrappedValue: wrappedValue, statement, database: database)
+      return
+    }
+    self.init(
+      wrappedValue: wrappedValue,
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: nil
+    )
+  }
+
+  public init<
+    V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
+  >(
+    wrappedValue: [Element] = [],
+    _ statement: Select<V, From, J>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil
+  )
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J.columns) else {
+      self.init(wrappedValue: wrappedValue, statement, database: database)
+      return
+    }
+    self.init(
+      wrappedValue: wrappedValue,
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: nil
+    )
+  }
+
+  public init<
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J1: StructuredQueriesCore.Table,
+    each J2: StructuredQueriesCore.Table
+  >(
+    wrappedValue: [Element] = [],
+    _ statement: Select<V, From, (J1, repeat each J2)>,
+    @_SectionBuilder sectionBy sectioning: (
+      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+    ) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil
+  )
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
+      self.init(wrappedValue: wrappedValue, statement, database: database)
+      return
+    }
+    self.init(
+      wrappedValue: wrappedValue,
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: nil
+    )
+  }
+
+  /// Replaces the wrapped value with data from the given query, grouping results into sections.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+  ///     results by, or `nil` for no grouping.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  /// - Returns: A subscription associated with the observation.
+  @discardableResult
+  public func load<S: SelectStatement>(
+    _ statement: S,
+    @_SectionBuilder sectionBy sectioning: (S.From.TableColumns) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil
+  ) async throws -> FetchSubscription
+  where
+    Element == S.From.QueryOutput,
+    S.QueryValue == (),
+    S.From.QueryOutput: Sendable,
+    S.Joins == ()
+  {
+    let statement: Select<(), S.From, ()> = statement.asSelect()
+    return try await loadSections(
+      statement: statement,
+      sectionBy: sectioning(S.From.columns),
+      database: database,
+      scheduler: nil
+    )
+  }
+
+  /// Replaces the wrapped value with data from the given query, grouping results into sections.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectionKeyPath: A key path to a string column to group results by.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  /// - Returns: A subscription associated with the observation.
+  @discardableResult
+  public func load<S: SelectStatement>(
+    _ statement: S,
+    sectionBy sectionKeyPath: KeyPath<
+      S.From.TableColumns, some QueryExpression<some _OptionalPromotable<String?>>
+    >,
+    database: (any DatabaseReader)? = nil
+  ) async throws -> FetchSubscription
+  where
+    Element == S.From.QueryOutput,
+    S.QueryValue == (),
+    S.From.QueryOutput: Sendable,
+    S.Joins == ()
+  {
+    try await load(
+      statement,
+      sectionBy: { $0[keyPath: sectionKeyPath] },
+      database: database
+    )
+  }
+
+  @discardableResult
+  public func load<
+    V: QueryRepresentable, From: StructuredQueriesCore.Table
+  >(
+    _ statement: Select<V, From, ()>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil
+  ) async throws -> FetchSubscription
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns) else {
+      return try await load(statement, database: database)
+    }
+    return try await loadSections(
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: nil
+    )
+  }
+
+  @discardableResult
+  public func load<
+    V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
+  >(
+    _ statement: Select<V, From, J>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil
+  ) async throws -> FetchSubscription
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J.columns) else {
+      return try await load(statement, database: database)
+    }
+    return try await loadSections(
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: nil
+    )
+  }
+
+  @discardableResult
+  public func load<
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J1: StructuredQueriesCore.Table,
+    each J2: StructuredQueriesCore.Table
+  >(
+    _ statement: Select<V, From, (J1, repeat each J2)>,
+    @_SectionBuilder sectionBy sectioning: (
+      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+    ) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil
+  ) async throws -> FetchSubscription
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
+      return try await load(statement, database: database)
+    }
+    return try await loadSections(
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: nil
+    )
+  }
+
+  fileprivate init<From: StructuredQueriesCore.Table>(
+    wrappedValue: [Element],
+    statement: Select<(), From, ()>,
+    sectionBy: _Sectioning,
+    database: (any DatabaseReader)?,
+    scheduler: (any ValueObservationScheduler & Hashable)?
+  )
+  where
+    Element == From.QueryOutput,
+    From.QueryOutput: Sendable
+  {
+    self.init(
+      wrappedValue: wrappedValue,
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectionBy),
+      sectionBy: sectionBy,
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  fileprivate init<Value: QueryRepresentable>(
+    wrappedValue: [Element],
+    request: FetchAllSectionedStatementValueRequest<Value>,
+    sectionBy: _Sectioning,
+    database: (any DatabaseReader)?,
+    scheduler: (any ValueObservationScheduler & Hashable)?
+  )
+  where
+    Element == Value.QueryOutput,
+    Value.QueryOutput: Sendable
+  {
+    let sectionedReader = SharedReader(
+      wrappedValue: ResultsSectionCollection(elements: wrappedValue, sectionName: nil),
+      FetchKey(
+        request: request,
+        database: database,
+        scheduler: scheduler
+      )
+    )
+    self.sectionedReader = sectionedReader
+    self.sharedReader = sectionedReader.elements
+    self.sectioning.setValue(sectionBy)
+  }
+
+  func loadSections<From: StructuredQueriesCore.Table>(
+    statement: Select<(), From, ()>,
+    sectionBy sectioning: _Sectioning?,
+    database: (any DatabaseReader)?,
+    scheduler: (any ValueObservationScheduler & Hashable)?
+  ) async throws -> FetchSubscription
+  where
+    Element == From.QueryOutput,
+    From.QueryOutput: Sendable
+  {
+    guard let sectioning else {
+      removeSections()
+      let statement: Select<From, From, ()> = statement.selectStar()
+      try await sharedReader.load(
+        FetchKey(
+          request: FetchAllStatementValueRequest(statement: statement),
+          database: database,
+          scheduler: scheduler
+        )
+      )
+      return FetchSubscription(sharedReader: sharedReader)
+    }
+    return try await loadSections(
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  private func loadSections<Value: QueryRepresentable>(
+    request: FetchAllSectionedStatementValueRequest<Value>,
+    sectionBy sectioning: _Sectioning,
+    database: (any DatabaseReader)?,
+    scheduler: (any ValueObservationScheduler & Hashable)?
+  ) async throws -> FetchSubscription
+  where
+    Element == Value.QueryOutput,
+    Value.QueryOutput: Sendable
+  {
+    self.sectioning.setValue(sectioning)
+    defer {
+      sharedReader.projectedValue = sectionedReader.elements.projectedValue
+    }
+    try await sectionedReader.load(
+      FetchKey(
+        request: request,
+        database: database,
+        scheduler: scheduler
+      )
+    )
+    return FetchSubscription(sharedReader: sharedReader, sectionedReader: sectionedReader)
+  }
+}
+
+extension FetchAll {
+  /// Initializes this property with a query that fetches every row from a table, grouping results
+  /// into sections.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default collection to associate with this property.
   ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
   ///     results by, or `nil` for no grouping.
   ///   - database: The database to read from. A value of `nil` will use the default database
@@ -239,6 +560,294 @@ extension FetchAll {
     self.init(
       wrappedValue: wrappedValue,
       statement: statement,
+      sectionBy: sectioning,
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  /// Initializes this property with a query that fetches every row from a table, grouping results
+  /// into sections.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default collection to associate with this property.
+  ///   - sectionKeyPath: A key path to a string column to group results by.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
+  ///     asynchronously on the main queue.
+  public init(
+    wrappedValue: [Element] = [],
+    sectionBy sectionKeyPath: KeyPath<
+      Element.TableColumns, some QueryExpression<some _OptionalPromotable<String?>>
+    >,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where Element: StructuredQueriesCore.Table, Element.QueryOutput == Element {
+    self.init(
+      wrappedValue: wrappedValue,
+      sectionBy: { $0[keyPath: sectionKeyPath] },
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  /// Initializes this property with a query associated with the wrapped value, grouping results
+  /// into sections.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default collection to associate with this property.
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectionKeyPath: A key path to a string column to group results by.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
+  ///     asynchronously on the main queue.
+  public init<S: SelectStatement>(
+    wrappedValue: [Element] = [],
+    _ statement: S,
+    sectionBy sectionKeyPath: KeyPath<
+      S.From.TableColumns, some QueryExpression<some _OptionalPromotable<String?>>
+    >,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where
+    Element == S.From.QueryOutput,
+    S.QueryValue == (),
+    S.From.QueryOutput: Sendable,
+    S.Joins == ()
+  {
+    self.init(
+      wrappedValue: wrappedValue,
+      statement,
+      sectionBy: { $0[keyPath: sectionKeyPath] },
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  public init<
+    V: QueryRepresentable, From: StructuredQueriesCore.Table
+  >(
+    wrappedValue: [Element] = [],
+    _ statement: Select<V, From, ()>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns) else {
+      self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
+      return
+    }
+    self.init(
+      wrappedValue: wrappedValue,
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  public init<
+    V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
+  >(
+    wrappedValue: [Element] = [],
+    _ statement: Select<V, From, J>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J.columns) else {
+      self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
+      return
+    }
+    self.init(
+      wrappedValue: wrappedValue,
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  public init<
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J1: StructuredQueriesCore.Table,
+    each J2: StructuredQueriesCore.Table
+  >(
+    wrappedValue: [Element] = [],
+    _ statement: Select<V, From, (J1, repeat each J2)>,
+    @_SectionBuilder sectionBy sectioning: (
+      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+    ) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
+      self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
+      return
+    }
+    self.init(
+      wrappedValue: wrappedValue,
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  /// Replaces the wrapped value with data from the given query, grouping results into sections.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+  ///     results by, or `nil` for no grouping.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
+  ///     asynchronously on the main queue.
+  /// - Returns: A subscription associated with the observation.
+  @discardableResult
+  public func load<S: SelectStatement>(
+    _ statement: S,
+    @_SectionBuilder sectionBy sectioning: (S.From.TableColumns) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  ) async throws -> FetchSubscription
+  where
+    Element == S.From.QueryOutput,
+    S.QueryValue == (),
+    S.From.QueryOutput: Sendable,
+    S.Joins == ()
+  {
+    let statement: Select<(), S.From, ()> = statement.asSelect()
+    return try await loadSections(
+      statement: statement,
+      sectionBy: sectioning(S.From.columns),
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  /// Replaces the wrapped value with data from the given query, grouping results into sections.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectionKeyPath: A key path to a string column to group results by.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
+  ///     asynchronously on the main queue.
+  /// - Returns: A subscription associated with the observation.
+  @discardableResult
+  public func load<S: SelectStatement>(
+    _ statement: S,
+    sectionBy sectionKeyPath: KeyPath<
+      S.From.TableColumns, some QueryExpression<some _OptionalPromotable<String?>>
+    >,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  ) async throws -> FetchSubscription
+  where
+    Element == S.From.QueryOutput,
+    S.QueryValue == (),
+    S.From.QueryOutput: Sendable,
+    S.Joins == ()
+  {
+    try await load(
+      statement,
+      sectionBy: { $0[keyPath: sectionKeyPath] },
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  @discardableResult
+  public func load<
+    V: QueryRepresentable, From: StructuredQueriesCore.Table
+  >(
+    _ statement: Select<V, From, ()>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  ) async throws -> FetchSubscription
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns) else {
+      return try await load(statement, database: database, scheduler: scheduler)
+    }
+    return try await loadSections(
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  @discardableResult
+  public func load<
+    V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
+  >(
+    _ statement: Select<V, From, J>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  ) async throws -> FetchSubscription
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J.columns) else {
+      return try await load(statement, database: database, scheduler: scheduler)
+    }
+    return try await loadSections(
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  @discardableResult
+  public func load<
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J1: StructuredQueriesCore.Table,
+    each J2: StructuredQueriesCore.Table
+  >(
+    _ statement: Select<V, From, (J1, repeat each J2)>,
+    @_SectionBuilder sectionBy sectioning: (
+      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+    ) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  ) async throws -> FetchSubscription
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
+      return try await load(statement, database: database, scheduler: scheduler)
+    }
+    return try await loadSections(
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
       sectionBy: sectioning,
       database: database,
       scheduler: scheduler
@@ -309,347 +918,7 @@ extension FetchAll {
         scheduler: .animation(animation)
       )
     }
-  }
-#endif
 
-extension FetchAll {
-  /// Replaces the wrapped value with data from the given query, grouping results into sections.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
-  ///     results by, or `nil` for no grouping.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  /// - Returns: A subscription associated with the observation.
-  @discardableResult
-  public func load<S: SelectStatement>(
-    _ statement: S,
-    @_SectionBuilder sectionBy sectioning: (S.From.TableColumns) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil
-  ) async throws -> FetchSubscription
-  where
-    Element == S.From.QueryOutput,
-    S.QueryValue == (),
-    S.From.QueryOutput: Sendable,
-    S.Joins == ()
-  {
-    let statement: Select<(), S.From, ()> = statement.asSelect()
-    return try await loadSections(
-      statement: statement,
-      sectionBy: sectioning(S.From.columns),
-      database: database,
-      scheduler: nil
-    )
-  }
-
-  /// Replaces the wrapped value with data from the given query, grouping results into sections.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
-  ///     results by, or `nil` for no grouping.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
-  ///     asynchronously on the main queue.
-  /// - Returns: A subscription associated with the observation.
-  @discardableResult
-  public func load<S: SelectStatement>(
-    _ statement: S,
-    @_SectionBuilder sectionBy sectioning: (S.From.TableColumns) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  ) async throws -> FetchSubscription
-  where
-    Element == S.From.QueryOutput,
-    S.QueryValue == (),
-    S.From.QueryOutput: Sendable,
-    S.Joins == ()
-  {
-    let statement: Select<(), S.From, ()> = statement.asSelect()
-    return try await loadSections(
-      statement: statement,
-      sectionBy: sectioning(S.From.columns),
-      database: database,
-      scheduler: scheduler
-    )
-  }
-
-  func loadSections<From: StructuredQueriesCore.Table>(
-    statement: Select<(), From, ()>,
-    sectionBy sectioning: _Sectioning?,
-    database: (any DatabaseReader)?,
-    scheduler: (any ValueObservationScheduler & Hashable)?
-  ) async throws -> FetchSubscription
-  where
-    Element == From.QueryOutput,
-    From.QueryOutput: Sendable
-  {
-    guard let sectioning else {
-      removeSections()
-      let statement: Select<From, From, ()> = statement.selectStar()
-      try await sharedReader.load(
-        FetchKey(
-          request: FetchAllStatementValueRequest(statement: statement),
-          database: database,
-          scheduler: scheduler
-        )
-      )
-      return FetchSubscription(sharedReader: sharedReader)
-    }
-    return try await loadSections(
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: scheduler
-    )
-  }
-
-  private func loadSections<Value: QueryRepresentable>(
-    request: FetchAllSectionedStatementValueRequest<Value>,
-    sectionBy sectioning: _Sectioning,
-    database: (any DatabaseReader)?,
-    scheduler: (any ValueObservationScheduler & Hashable)?
-  ) async throws -> FetchSubscription
-  where
-    Element == Value.QueryOutput,
-    Value.QueryOutput: Sendable
-  {
-    self.sectioning.setValue(sectioning)
-    defer {
-      sharedReader.projectedValue = sectionedReader.elements.projectedValue
-    }
-    try await sectionedReader.load(
-      FetchKey(
-        request: request,
-        database: database,
-        scheduler: scheduler
-      )
-    )
-    return FetchSubscription(sharedReader: sharedReader, sectionedReader: sectionedReader)
-  }
-}
-
-#if canImport(SwiftUI)
-  extension FetchAll {
-    /// Replaces the wrapped value with data from the given query, grouping results into sections.
-    ///
-    /// - Parameters:
-    ///   - statement: A query associated with the wrapped value.
-    ///   - sectioning: A closure that returns a string expression, or an ordering of one, to
-    ///     group results by, or `nil` for no grouping.
-    ///   - database: The database to read from. A value of `nil` will use the default database
-    ///     (`@Dependency(\.defaultDatabase)`).
-    ///   - animation: The animation to use for user interface changes that result from changes to
-    ///     the fetched results.
-    /// - Returns: A subscription associated with the observation.
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    @discardableResult
-    public func load<S: SelectStatement>(
-      _ statement: S,
-      @_SectionBuilder sectionBy sectioning: (S.From.TableColumns) -> _Sectioning?,
-      database: (any DatabaseReader)? = nil,
-      animation: Animation?
-    ) async throws -> FetchSubscription
-    where
-      Element == S.From.QueryOutput,
-      S.QueryValue == (),
-      S.From.QueryOutput: Sendable,
-      S.Joins == ()
-    {
-      try await load(
-        statement,
-        sectionBy: sectioning,
-        database: database,
-        scheduler: .animation(animation)
-      )
-    }
-  }
-#endif
-
-extension FetchAll {
-  /// Initializes this property with a query that fetches every row from a table, grouping results
-  /// into sections.
-  ///
-  /// - Parameters:
-  ///   - wrappedValue: A default collection to associate with this property.
-  ///   - sectionKeyPath: A key path to a string column to group results by.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  public init(
-    wrappedValue: [Element] = [],
-    sectionBy sectionKeyPath: KeyPath<
-      Element.TableColumns, some QueryExpression<some _OptionalPromotable<String?>>
-    >,
-    database: (any DatabaseReader)? = nil
-  )
-  where Element: StructuredQueriesCore.Table, Element.QueryOutput == Element {
-    self.init(
-      wrappedValue: wrappedValue,
-      sectionBy: { $0[keyPath: sectionKeyPath] },
-      database: database
-    )
-  }
-
-  /// Initializes this property with a query associated with the wrapped value, grouping results
-  /// into sections.
-  ///
-  /// - Parameters:
-  ///   - wrappedValue: A default collection to associate with this property.
-  ///   - statement: A query associated with the wrapped value.
-  ///   - sectionKeyPath: A key path to a string column to group results by.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  public init<S: SelectStatement>(
-    wrappedValue: [Element] = [],
-    _ statement: S,
-    sectionBy sectionKeyPath: KeyPath<
-      S.From.TableColumns, some QueryExpression<some _OptionalPromotable<String?>>
-    >,
-    database: (any DatabaseReader)? = nil
-  )
-  where
-    Element == S.From.QueryOutput,
-    S.QueryValue == (),
-    S.From.QueryOutput: Sendable,
-    S.Joins == ()
-  {
-    self.init(
-      wrappedValue: wrappedValue,
-      statement,
-      sectionBy: { $0[keyPath: sectionKeyPath] },
-      database: database
-    )
-  }
-
-  /// Initializes this property with a query that fetches every row from a table, grouping results
-  /// into sections.
-  ///
-  /// - Parameters:
-  ///   - wrappedValue: A default collection to associate with this property.
-  ///   - sectionKeyPath: A key path to a string column to group results by.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
-  ///     asynchronously on the main queue.
-  public init(
-    wrappedValue: [Element] = [],
-    sectionBy sectionKeyPath: KeyPath<
-      Element.TableColumns, some QueryExpression<some _OptionalPromotable<String?>>
-    >,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  )
-  where Element: StructuredQueriesCore.Table, Element.QueryOutput == Element {
-    self.init(
-      wrappedValue: wrappedValue,
-      sectionBy: { $0[keyPath: sectionKeyPath] },
-      database: database,
-      scheduler: scheduler
-    )
-  }
-
-  /// Initializes this property with a query associated with the wrapped value, grouping results
-  /// into sections.
-  ///
-  /// - Parameters:
-  ///   - wrappedValue: A default collection to associate with this property.
-  ///   - statement: A query associated with the wrapped value.
-  ///   - sectionKeyPath: A key path to a string column to group results by.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
-  ///     asynchronously on the main queue.
-  public init<S: SelectStatement>(
-    wrappedValue: [Element] = [],
-    _ statement: S,
-    sectionBy sectionKeyPath: KeyPath<
-      S.From.TableColumns, some QueryExpression<some _OptionalPromotable<String?>>
-    >,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  )
-  where
-    Element == S.From.QueryOutput,
-    S.QueryValue == (),
-    S.From.QueryOutput: Sendable,
-    S.Joins == ()
-  {
-    self.init(
-      wrappedValue: wrappedValue,
-      statement,
-      sectionBy: { $0[keyPath: sectionKeyPath] },
-      database: database,
-      scheduler: scheduler
-    )
-  }
-
-  /// Replaces the wrapped value with data from the given query, grouping results into sections.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - sectionKeyPath: A key path to a string column to group results by.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  /// - Returns: A subscription associated with the observation.
-  @discardableResult
-  public func load<S: SelectStatement>(
-    _ statement: S,
-    sectionBy sectionKeyPath: KeyPath<
-      S.From.TableColumns, some QueryExpression<some _OptionalPromotable<String?>>
-    >,
-    database: (any DatabaseReader)? = nil
-  ) async throws -> FetchSubscription
-  where
-    Element == S.From.QueryOutput,
-    S.QueryValue == (),
-    S.From.QueryOutput: Sendable,
-    S.Joins == ()
-  {
-    try await load(
-      statement,
-      sectionBy: { $0[keyPath: sectionKeyPath] },
-      database: database
-    )
-  }
-
-  /// Replaces the wrapped value with data from the given query, grouping results into sections.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - sectionKeyPath: A key path to a string column to group results by.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
-  ///     asynchronously on the main queue.
-  /// - Returns: A subscription associated with the observation.
-  @discardableResult
-  public func load<S: SelectStatement>(
-    _ statement: S,
-    sectionBy sectionKeyPath: KeyPath<
-      S.From.TableColumns, some QueryExpression<some _OptionalPromotable<String?>>
-    >,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  ) async throws -> FetchSubscription
-  where
-    Element == S.From.QueryOutput,
-    S.QueryValue == (),
-    S.From.QueryOutput: Sendable,
-    S.Joins == ()
-  {
-    try await load(
-      statement,
-      sectionBy: { $0[keyPath: sectionKeyPath] },
-      database: database,
-      scheduler: scheduler
-    )
-  }
-}
-
-#if canImport(SwiftUI)
-  extension FetchAll {
     /// Initializes this property with a query that fetches every row from a table, grouping
     /// results into sections.
     ///
@@ -714,6 +983,113 @@ extension FetchAll {
       )
     }
 
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    public init<
+      V: QueryRepresentable, From: StructuredQueriesCore.Table
+    >(
+      wrappedValue: [Element] = [],
+      _ statement: Select<V, From, ()>,
+      @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    )
+    where
+      Element == V.QueryOutput,
+      V.QueryOutput: Sendable
+    {
+      self.init(
+        wrappedValue: wrappedValue,
+        statement,
+        sectionBy: sectioning,
+        database: database,
+        scheduler: .animation(animation)
+      )
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    public init<
+      V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
+    >(
+      wrappedValue: [Element] = [],
+      _ statement: Select<V, From, J>,
+      @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    )
+    where
+      Element == V.QueryOutput,
+      V.QueryOutput: Sendable
+    {
+      self.init(
+        wrappedValue: wrappedValue,
+        statement,
+        sectionBy: sectioning,
+        database: database,
+        scheduler: .animation(animation)
+      )
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    public init<
+      V: QueryRepresentable,
+      From: StructuredQueriesCore.Table,
+      J1: StructuredQueriesCore.Table,
+      each J2: StructuredQueriesCore.Table
+    >(
+      wrappedValue: [Element] = [],
+      _ statement: Select<V, From, (J1, repeat each J2)>,
+      @_SectionBuilder sectionBy sectioning: (
+        From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+      ) -> _Sectioning?,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    )
+    where
+      Element == V.QueryOutput,
+      V.QueryOutput: Sendable
+    {
+      self.init(
+        wrappedValue: wrappedValue,
+        statement,
+        sectionBy: sectioning,
+        database: database,
+        scheduler: .animation(animation)
+      )
+    }
+
+    /// Replaces the wrapped value with data from the given query, grouping results into sections.
+    ///
+    /// - Parameters:
+    ///   - statement: A query associated with the wrapped value.
+    ///   - sectioning: A closure that returns a string expression, or an ordering of one, to
+    ///     group results by, or `nil` for no grouping.
+    ///   - database: The database to read from. A value of `nil` will use the default database
+    ///     (`@Dependency(\.defaultDatabase)`).
+    ///   - animation: The animation to use for user interface changes that result from changes to
+    ///     the fetched results.
+    /// - Returns: A subscription associated with the observation.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @discardableResult
+    public func load<S: SelectStatement>(
+      _ statement: S,
+      @_SectionBuilder sectionBy sectioning: (S.From.TableColumns) -> _Sectioning?,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation?
+    ) async throws -> FetchSubscription
+    where
+      Element == S.From.QueryOutput,
+      S.QueryValue == (),
+      S.From.QueryOutput: Sendable,
+      S.Joins == ()
+    {
+      try await load(
+        statement,
+        sectionBy: sectioning,
+        database: database,
+        scheduler: .animation(animation)
+      )
+    }
+
     /// Replaces the wrapped value with data from the given query, grouping results into sections.
     ///
     /// - Parameters:
@@ -747,353 +1123,6 @@ extension FetchAll {
         animation: animation
       )
     }
-  }
-#endif
-
-extension FetchAll {
-  public init<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table
-  >(
-    wrappedValue: [Element] = [],
-    _ statement: Select<V, From, ()>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil
-  )
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns) else {
-      self.init(wrappedValue: wrappedValue, statement, database: database)
-      return
-    }
-    self.init(
-      wrappedValue: wrappedValue,
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: nil
-    )
-  }
-
-  public init<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table
-  >(
-    wrappedValue: [Element] = [],
-    _ statement: Select<V, From, ()>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  )
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns) else {
-      self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
-      return
-    }
-    self.init(
-      wrappedValue: wrappedValue,
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: scheduler
-    )
-  }
-
-  @discardableResult
-  public func load<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table
-  >(
-    _ statement: Select<V, From, ()>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil
-  ) async throws -> FetchSubscription
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns) else {
-      return try await load(statement, database: database)
-    }
-    return try await loadSections(
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: nil
-    )
-  }
-
-  @discardableResult
-  public func load<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table
-  >(
-    _ statement: Select<V, From, ()>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  ) async throws -> FetchSubscription
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns) else {
-      return try await load(statement, database: database, scheduler: scheduler)
-    }
-    return try await loadSections(
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: scheduler
-    )
-  }
-}
-
-extension FetchAll {
-  public init<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
-  >(
-    wrappedValue: [Element] = [],
-    _ statement: Select<V, From, J>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil
-  )
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns, J.columns) else {
-      self.init(wrappedValue: wrappedValue, statement, database: database)
-      return
-    }
-    self.init(
-      wrappedValue: wrappedValue,
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: nil
-    )
-  }
-
-  public init<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
-  >(
-    wrappedValue: [Element] = [],
-    _ statement: Select<V, From, J>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  )
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns, J.columns) else {
-      self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
-      return
-    }
-    self.init(
-      wrappedValue: wrappedValue,
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: scheduler
-    )
-  }
-
-  @discardableResult
-  public func load<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
-  >(
-    _ statement: Select<V, From, J>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil
-  ) async throws -> FetchSubscription
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns, J.columns) else {
-      return try await load(statement, database: database)
-    }
-    return try await loadSections(
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: nil
-    )
-  }
-
-  @discardableResult
-  public func load<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
-  >(
-    _ statement: Select<V, From, J>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  ) async throws -> FetchSubscription
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns, J.columns) else {
-      return try await load(statement, database: database, scheduler: scheduler)
-    }
-    return try await loadSections(
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: scheduler
-    )
-  }
-}
-
-extension FetchAll {
-  public init<
-    V: QueryRepresentable,
-    From: StructuredQueriesCore.Table,
-    J1: StructuredQueriesCore.Table,
-    each J2: StructuredQueriesCore.Table
-  >(
-    wrappedValue: [Element] = [],
-    _ statement: Select<V, From, (J1, repeat each J2)>,
-    @_SectionBuilder sectionBy sectioning: (
-      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-    ) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil
-  )
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
-      self.init(wrappedValue: wrappedValue, statement, database: database)
-      return
-    }
-    self.init(
-      wrappedValue: wrappedValue,
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: nil
-    )
-  }
-
-  public init<
-    V: QueryRepresentable,
-    From: StructuredQueriesCore.Table,
-    J1: StructuredQueriesCore.Table,
-    each J2: StructuredQueriesCore.Table
-  >(
-    wrappedValue: [Element] = [],
-    _ statement: Select<V, From, (J1, repeat each J2)>,
-    @_SectionBuilder sectionBy sectioning: (
-      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-    ) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  )
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
-      self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
-      return
-    }
-    self.init(
-      wrappedValue: wrappedValue,
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: scheduler
-    )
-  }
-
-  @discardableResult
-  public func load<
-    V: QueryRepresentable,
-    From: StructuredQueriesCore.Table,
-    J1: StructuredQueriesCore.Table,
-    each J2: StructuredQueriesCore.Table
-  >(
-    _ statement: Select<V, From, (J1, repeat each J2)>,
-    @_SectionBuilder sectionBy sectioning: (
-      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-    ) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil
-  ) async throws -> FetchSubscription
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
-      return try await load(statement, database: database)
-    }
-    return try await loadSections(
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: nil
-    )
-  }
-
-  @discardableResult
-  public func load<
-    V: QueryRepresentable,
-    From: StructuredQueriesCore.Table,
-    J1: StructuredQueriesCore.Table,
-    each J2: StructuredQueriesCore.Table
-  >(
-    _ statement: Select<V, From, (J1, repeat each J2)>,
-    @_SectionBuilder sectionBy sectioning: (
-      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-    ) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  ) async throws -> FetchSubscription
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
-      return try await load(statement, database: database, scheduler: scheduler)
-    }
-    return try await loadSections(
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: scheduler
-    )
-  }
-}
-
-#if canImport(SwiftUI)
-  extension FetchAll {
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    public init<
-      V: QueryRepresentable, From: StructuredQueriesCore.Table
-    >(
-      wrappedValue: [Element] = [],
-      _ statement: Select<V, From, ()>,
-      @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
-      database: (any DatabaseReader)? = nil,
-      animation: Animation
-    )
-    where
-      Element == V.QueryOutput,
-      V.QueryOutput: Sendable
-    {
-      self.init(
-        wrappedValue: wrappedValue,
-        statement,
-        sectionBy: sectioning,
-        database: database,
-        scheduler: .animation(animation)
-      )
-    }
 
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     @discardableResult
@@ -1118,29 +1147,6 @@ extension FetchAll {
     }
 
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    public init<
-      V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
-    >(
-      wrappedValue: [Element] = [],
-      _ statement: Select<V, From, J>,
-      @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
-      database: (any DatabaseReader)? = nil,
-      animation: Animation
-    )
-    where
-      Element == V.QueryOutput,
-      V.QueryOutput: Sendable
-    {
-      self.init(
-        wrappedValue: wrappedValue,
-        statement,
-        sectionBy: sectioning,
-        database: database,
-        scheduler: .animation(animation)
-      )
-    }
-
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     @discardableResult
     public func load<
       V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
@@ -1155,34 +1161,6 @@ extension FetchAll {
       V.QueryOutput: Sendable
     {
       try await load(
-        statement,
-        sectionBy: sectioning,
-        database: database,
-        scheduler: .animation(animation)
-      )
-    }
-
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    public init<
-      V: QueryRepresentable,
-      From: StructuredQueriesCore.Table,
-      J1: StructuredQueriesCore.Table,
-      each J2: StructuredQueriesCore.Table
-    >(
-      wrappedValue: [Element] = [],
-      _ statement: Select<V, From, (J1, repeat each J2)>,
-      @_SectionBuilder sectionBy sectioning: (
-        From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-      ) -> _Sectioning?,
-      database: (any DatabaseReader)? = nil,
-      animation: Animation
-    )
-    where
-      Element == V.QueryOutput,
-      V.QueryOutput: Sendable
-    {
-      self.init(
-        wrappedValue: wrappedValue,
         statement,
         sectionBy: sectioning,
         database: database,

--- a/Sources/SQLiteData/FetchAll+Sections.swift
+++ b/Sources/SQLiteData/FetchAll+Sections.swift
@@ -183,19 +183,18 @@ extension FetchAll {
   }
 
   public init<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
+    V: QueryRepresentable, From: StructuredQueriesCore.Table
   >(
     wrappedValue: [Element] = [],
-    _ statement: Select<V, From, (repeat each J)>,
-    @_SectionBuilder sectionBy sectioning: ((From.TableColumns, repeat (each J).TableColumns)) ->
-      _Sectioning?,
+    _ statement: Select<V, From, ()>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
     database: (any DatabaseReader)? = nil
   )
   where
     Element == V.QueryOutput,
     V.QueryOutput: Sendable
   {
-    guard let sectioning = sectioning((From.columns, repeat (each J).columns)) else {
+    guard let sectioning = sectioning(From.columns) else {
       self.init(wrappedValue: wrappedValue, statement, database: database)
       return
     }
@@ -221,6 +220,36 @@ extension FetchAll {
     V.QueryOutput: Sendable
   {
     guard let sectioning = sectioning(From.columns, J.columns) else {
+      self.init(wrappedValue: wrappedValue, statement, database: database)
+      return
+    }
+    self.init(
+      wrappedValue: wrappedValue,
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: nil
+    )
+  }
+
+  public init<
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J1: StructuredQueriesCore.Table,
+    each J2: StructuredQueriesCore.Table
+  >(
+    wrappedValue: [Element] = [],
+    _ statement: Select<V, From, (J1, repeat each J2)>,
+    @_SectionBuilder sectionBy sectioning: (
+      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+    ) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil
+  )
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
       self.init(wrappedValue: wrappedValue, statement, database: database)
       return
     }
@@ -294,18 +323,17 @@ extension FetchAll {
 
   @discardableResult
   public func load<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
+    V: QueryRepresentable, From: StructuredQueriesCore.Table
   >(
-    _ statement: Select<V, From, (repeat each J)>,
-    @_SectionBuilder sectionBy sectioning: ((From.TableColumns, repeat (each J).TableColumns)) ->
-      _Sectioning?,
+    _ statement: Select<V, From, ()>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
     database: (any DatabaseReader)? = nil
   ) async throws -> FetchSubscription
   where
     Element == V.QueryOutput,
     V.QueryOutput: Sendable
   {
-    guard let sectioning = sectioning((From.columns, repeat (each J).columns)) else {
+    guard let sectioning = sectioning(From.columns) else {
       return try await load(statement, database: database)
     }
     return try await loadSections(
@@ -329,6 +357,34 @@ extension FetchAll {
     V.QueryOutput: Sendable
   {
     guard let sectioning = sectioning(From.columns, J.columns) else {
+      return try await load(statement, database: database)
+    }
+    return try await loadSections(
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: nil
+    )
+  }
+
+  @discardableResult
+  public func load<
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J1: StructuredQueriesCore.Table,
+    each J2: StructuredQueriesCore.Table
+  >(
+    _ statement: Select<V, From, (J1, repeat each J2)>,
+    @_SectionBuilder sectionBy sectioning: (
+      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+    ) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil
+  ) async throws -> FetchSubscription
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
       return try await load(statement, database: database)
     }
     return try await loadSections(
@@ -573,12 +629,11 @@ extension FetchAll {
   }
 
   public init<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
+    V: QueryRepresentable, From: StructuredQueriesCore.Table
   >(
     wrappedValue: [Element] = [],
-    _ statement: Select<V, From, (repeat each J)>,
-    @_SectionBuilder sectionBy sectioning: ((From.TableColumns, repeat (each J).TableColumns)) ->
-      _Sectioning?,
+    _ statement: Select<V, From, ()>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   )
@@ -586,7 +641,7 @@ extension FetchAll {
     Element == V.QueryOutput,
     V.QueryOutput: Sendable
   {
-    guard let sectioning = sectioning((From.columns, repeat (each J).columns)) else {
+    guard let sectioning = sectioning(From.columns) else {
       self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
       return
     }
@@ -613,6 +668,37 @@ extension FetchAll {
     V.QueryOutput: Sendable
   {
     guard let sectioning = sectioning(From.columns, J.columns) else {
+      self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
+      return
+    }
+    self.init(
+      wrappedValue: wrappedValue,
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  public init<
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J1: StructuredQueriesCore.Table,
+    each J2: StructuredQueriesCore.Table
+  >(
+    wrappedValue: [Element] = [],
+    _ statement: Select<V, From, (J1, repeat each J2)>,
+    @_SectionBuilder sectionBy sectioning: (
+      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+    ) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
       self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
       return
     }
@@ -693,11 +779,10 @@ extension FetchAll {
 
   @discardableResult
   public func load<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
+    V: QueryRepresentable, From: StructuredQueriesCore.Table
   >(
-    _ statement: Select<V, From, (repeat each J)>,
-    @_SectionBuilder sectionBy sectioning: ((From.TableColumns, repeat (each J).TableColumns)) ->
-      _Sectioning?,
+    _ statement: Select<V, From, ()>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   ) async throws -> FetchSubscription
@@ -705,7 +790,7 @@ extension FetchAll {
     Element == V.QueryOutput,
     V.QueryOutput: Sendable
   {
-    guard let sectioning = sectioning((From.columns, repeat (each J).columns)) else {
+    guard let sectioning = sectioning(From.columns) else {
       return try await load(statement, database: database, scheduler: scheduler)
     }
     return try await loadSections(
@@ -730,6 +815,35 @@ extension FetchAll {
     V.QueryOutput: Sendable
   {
     guard let sectioning = sectioning(From.columns, J.columns) else {
+      return try await load(statement, database: database, scheduler: scheduler)
+    }
+    return try await loadSections(
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  @discardableResult
+  public func load<
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J1: StructuredQueriesCore.Table,
+    each J2: StructuredQueriesCore.Table
+  >(
+    _ statement: Select<V, From, (J1, repeat each J2)>,
+    @_SectionBuilder sectionBy sectioning: (
+      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+    ) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  ) async throws -> FetchSubscription
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
       return try await load(statement, database: database, scheduler: scheduler)
     }
     return try await loadSections(
@@ -871,12 +985,11 @@ extension FetchAll {
 
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<
-      V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
+      V: QueryRepresentable, From: StructuredQueriesCore.Table
     >(
       wrappedValue: [Element] = [],
-      _ statement: Select<V, From, (repeat each J)>,
-      @_SectionBuilder sectionBy sectioning: ((From.TableColumns, repeat (each J).TableColumns)) ->
-        _Sectioning?,
+      _ statement: Select<V, From, ()>,
+      @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
       database: (any DatabaseReader)? = nil,
       animation: Animation
     )
@@ -900,6 +1013,34 @@ extension FetchAll {
       wrappedValue: [Element] = [],
       _ statement: Select<V, From, J>,
       @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    )
+    where
+      Element == V.QueryOutput,
+      V.QueryOutput: Sendable
+    {
+      self.init(
+        wrappedValue: wrappedValue,
+        statement,
+        sectionBy: sectioning,
+        database: database,
+        scheduler: .animation(animation)
+      )
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    public init<
+      V: QueryRepresentable,
+      From: StructuredQueriesCore.Table,
+      J1: StructuredQueriesCore.Table,
+      each J2: StructuredQueriesCore.Table
+    >(
+      wrappedValue: [Element] = [],
+      _ statement: Select<V, From, (J1, repeat each J2)>,
+      @_SectionBuilder sectionBy sectioning: (
+        From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+      ) -> _Sectioning?,
       database: (any DatabaseReader)? = nil,
       animation: Animation
     )
@@ -986,11 +1127,10 @@ extension FetchAll {
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     @discardableResult
     public func load<
-      V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
+      V: QueryRepresentable, From: StructuredQueriesCore.Table
     >(
-      _ statement: Select<V, From, (repeat each J)>,
-      @_SectionBuilder sectionBy sectioning: ((From.TableColumns, repeat (each J).TableColumns)) ->
-        _Sectioning?,
+      _ statement: Select<V, From, ()>,
+      @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
       database: (any DatabaseReader)? = nil,
       animation: Animation?
     ) async throws -> FetchSubscription
@@ -1013,6 +1153,33 @@ extension FetchAll {
     >(
       _ statement: Select<V, From, J>,
       @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation?
+    ) async throws -> FetchSubscription
+    where
+      Element == V.QueryOutput,
+      V.QueryOutput: Sendable
+    {
+      try await load(
+        statement,
+        sectionBy: sectioning,
+        database: database,
+        scheduler: .animation(animation)
+      )
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @discardableResult
+    public func load<
+      V: QueryRepresentable,
+      From: StructuredQueriesCore.Table,
+      J1: StructuredQueriesCore.Table,
+      each J2: StructuredQueriesCore.Table
+    >(
+      _ statement: Select<V, From, (J1, repeat each J2)>,
+      @_SectionBuilder sectionBy sectioning: (
+        From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+      ) -> _Sectioning?,
       database: (any DatabaseReader)? = nil,
       animation: Animation?
     ) async throws -> FetchSubscription

--- a/Sources/SQLiteData/FetchAll+Sections.swift
+++ b/Sources/SQLiteData/FetchAll+Sections.swift
@@ -183,18 +183,19 @@ extension FetchAll {
   }
 
   public init<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table
+    V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
   >(
     wrappedValue: [Element] = [],
-    _ statement: Select<V, From, ()>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+    _ statement: Select<V, From, (repeat each J)>,
+    @_SectionBuilder sectionBy sectioning: ((From.TableColumns, repeat (each J).TableColumns)) ->
+      _Sectioning?,
     database: (any DatabaseReader)? = nil
   )
   where
     Element == V.QueryOutput,
     V.QueryOutput: Sendable
   {
-    guard let sectioning = sectioning(From.columns) else {
+    guard let sectioning = sectioning((From.columns, repeat (each J).columns)) else {
       self.init(wrappedValue: wrappedValue, statement, database: database)
       return
     }
@@ -220,36 +221,6 @@ extension FetchAll {
     V.QueryOutput: Sendable
   {
     guard let sectioning = sectioning(From.columns, J.columns) else {
-      self.init(wrappedValue: wrappedValue, statement, database: database)
-      return
-    }
-    self.init(
-      wrappedValue: wrappedValue,
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: nil
-    )
-  }
-
-  public init<
-    V: QueryRepresentable,
-    From: StructuredQueriesCore.Table,
-    J1: StructuredQueriesCore.Table,
-    each J2: StructuredQueriesCore.Table
-  >(
-    wrappedValue: [Element] = [],
-    _ statement: Select<V, From, (J1, repeat each J2)>,
-    @_SectionBuilder sectionBy sectioning: (
-      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-    ) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil
-  )
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
       self.init(wrappedValue: wrappedValue, statement, database: database)
       return
     }
@@ -323,17 +294,18 @@ extension FetchAll {
 
   @discardableResult
   public func load<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table
+    V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
   >(
-    _ statement: Select<V, From, ()>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+    _ statement: Select<V, From, (repeat each J)>,
+    @_SectionBuilder sectionBy sectioning: ((From.TableColumns, repeat (each J).TableColumns)) ->
+      _Sectioning?,
     database: (any DatabaseReader)? = nil
   ) async throws -> FetchSubscription
   where
     Element == V.QueryOutput,
     V.QueryOutput: Sendable
   {
-    guard let sectioning = sectioning(From.columns) else {
+    guard let sectioning = sectioning((From.columns, repeat (each J).columns)) else {
       return try await load(statement, database: database)
     }
     return try await loadSections(
@@ -357,34 +329,6 @@ extension FetchAll {
     V.QueryOutput: Sendable
   {
     guard let sectioning = sectioning(From.columns, J.columns) else {
-      return try await load(statement, database: database)
-    }
-    return try await loadSections(
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: nil
-    )
-  }
-
-  @discardableResult
-  public func load<
-    V: QueryRepresentable,
-    From: StructuredQueriesCore.Table,
-    J1: StructuredQueriesCore.Table,
-    each J2: StructuredQueriesCore.Table
-  >(
-    _ statement: Select<V, From, (J1, repeat each J2)>,
-    @_SectionBuilder sectionBy sectioning: (
-      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-    ) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil
-  ) async throws -> FetchSubscription
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
       return try await load(statement, database: database)
     }
     return try await loadSections(
@@ -629,11 +573,12 @@ extension FetchAll {
   }
 
   public init<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table
+    V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
   >(
     wrappedValue: [Element] = [],
-    _ statement: Select<V, From, ()>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+    _ statement: Select<V, From, (repeat each J)>,
+    @_SectionBuilder sectionBy sectioning: ((From.TableColumns, repeat (each J).TableColumns)) ->
+      _Sectioning?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   )
@@ -641,7 +586,7 @@ extension FetchAll {
     Element == V.QueryOutput,
     V.QueryOutput: Sendable
   {
-    guard let sectioning = sectioning(From.columns) else {
+    guard let sectioning = sectioning((From.columns, repeat (each J).columns)) else {
       self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
       return
     }
@@ -668,37 +613,6 @@ extension FetchAll {
     V.QueryOutput: Sendable
   {
     guard let sectioning = sectioning(From.columns, J.columns) else {
-      self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
-      return
-    }
-    self.init(
-      wrappedValue: wrappedValue,
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: scheduler
-    )
-  }
-
-  public init<
-    V: QueryRepresentable,
-    From: StructuredQueriesCore.Table,
-    J1: StructuredQueriesCore.Table,
-    each J2: StructuredQueriesCore.Table
-  >(
-    wrappedValue: [Element] = [],
-    _ statement: Select<V, From, (J1, repeat each J2)>,
-    @_SectionBuilder sectionBy sectioning: (
-      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-    ) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  )
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
       self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
       return
     }
@@ -779,10 +693,11 @@ extension FetchAll {
 
   @discardableResult
   public func load<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table
+    V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
   >(
-    _ statement: Select<V, From, ()>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+    _ statement: Select<V, From, (repeat each J)>,
+    @_SectionBuilder sectionBy sectioning: ((From.TableColumns, repeat (each J).TableColumns)) ->
+      _Sectioning?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   ) async throws -> FetchSubscription
@@ -790,7 +705,7 @@ extension FetchAll {
     Element == V.QueryOutput,
     V.QueryOutput: Sendable
   {
-    guard let sectioning = sectioning(From.columns) else {
+    guard let sectioning = sectioning((From.columns, repeat (each J).columns)) else {
       return try await load(statement, database: database, scheduler: scheduler)
     }
     return try await loadSections(
@@ -815,35 +730,6 @@ extension FetchAll {
     V.QueryOutput: Sendable
   {
     guard let sectioning = sectioning(From.columns, J.columns) else {
-      return try await load(statement, database: database, scheduler: scheduler)
-    }
-    return try await loadSections(
-      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
-      sectionBy: sectioning,
-      database: database,
-      scheduler: scheduler
-    )
-  }
-
-  @discardableResult
-  public func load<
-    V: QueryRepresentable,
-    From: StructuredQueriesCore.Table,
-    J1: StructuredQueriesCore.Table,
-    each J2: StructuredQueriesCore.Table
-  >(
-    _ statement: Select<V, From, (J1, repeat each J2)>,
-    @_SectionBuilder sectionBy sectioning: (
-      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-    ) -> _Sectioning?,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  ) async throws -> FetchSubscription
-  where
-    Element == V.QueryOutput,
-    V.QueryOutput: Sendable
-  {
-    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
       return try await load(statement, database: database, scheduler: scheduler)
     }
     return try await loadSections(
@@ -985,11 +871,12 @@ extension FetchAll {
 
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<
-      V: QueryRepresentable, From: StructuredQueriesCore.Table
+      V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
     >(
       wrappedValue: [Element] = [],
-      _ statement: Select<V, From, ()>,
-      @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+      _ statement: Select<V, From, (repeat each J)>,
+      @_SectionBuilder sectionBy sectioning: ((From.TableColumns, repeat (each J).TableColumns)) ->
+        _Sectioning?,
       database: (any DatabaseReader)? = nil,
       animation: Animation
     )
@@ -1013,34 +900,6 @@ extension FetchAll {
       wrappedValue: [Element] = [],
       _ statement: Select<V, From, J>,
       @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
-      database: (any DatabaseReader)? = nil,
-      animation: Animation
-    )
-    where
-      Element == V.QueryOutput,
-      V.QueryOutput: Sendable
-    {
-      self.init(
-        wrappedValue: wrappedValue,
-        statement,
-        sectionBy: sectioning,
-        database: database,
-        scheduler: .animation(animation)
-      )
-    }
-
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    public init<
-      V: QueryRepresentable,
-      From: StructuredQueriesCore.Table,
-      J1: StructuredQueriesCore.Table,
-      each J2: StructuredQueriesCore.Table
-    >(
-      wrappedValue: [Element] = [],
-      _ statement: Select<V, From, (J1, repeat each J2)>,
-      @_SectionBuilder sectionBy sectioning: (
-        From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-      ) -> _Sectioning?,
       database: (any DatabaseReader)? = nil,
       animation: Animation
     )
@@ -1127,10 +986,11 @@ extension FetchAll {
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     @discardableResult
     public func load<
-      V: QueryRepresentable, From: StructuredQueriesCore.Table
+      V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
     >(
-      _ statement: Select<V, From, ()>,
-      @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+      _ statement: Select<V, From, (repeat each J)>,
+      @_SectionBuilder sectionBy sectioning: ((From.TableColumns, repeat (each J).TableColumns)) ->
+        _Sectioning?,
       database: (any DatabaseReader)? = nil,
       animation: Animation?
     ) async throws -> FetchSubscription
@@ -1153,33 +1013,6 @@ extension FetchAll {
     >(
       _ statement: Select<V, From, J>,
       @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
-      database: (any DatabaseReader)? = nil,
-      animation: Animation?
-    ) async throws -> FetchSubscription
-    where
-      Element == V.QueryOutput,
-      V.QueryOutput: Sendable
-    {
-      try await load(
-        statement,
-        sectionBy: sectioning,
-        database: database,
-        scheduler: .animation(animation)
-      )
-    }
-
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    @discardableResult
-    public func load<
-      V: QueryRepresentable,
-      From: StructuredQueriesCore.Table,
-      J1: StructuredQueriesCore.Table,
-      each J2: StructuredQueriesCore.Table
-    >(
-      _ statement: Select<V, From, (J1, repeat each J2)>,
-      @_SectionBuilder sectionBy sectioning: (
-        From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-      ) -> _Sectioning?,
       database: (any DatabaseReader)? = nil,
       animation: Animation?
     ) async throws -> FetchSubscription

--- a/Sources/SQLiteData/FetchAll+Sections.swift
+++ b/Sources/SQLiteData/FetchAll+Sections.swift
@@ -53,7 +53,7 @@ extension FetchAll {
   ///     (`@Dependency(\.defaultDatabase)`).
   public init(
     wrappedValue: [Element] = [],
-    @_SectionBuilder sectionBy sectioning: (Element.TableColumns) -> _Sectioning?,
+    @_SectionBuilder<String?> sectionBy sectioning: (Element.TableColumns) -> _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil
   )
   where Element: StructuredQueriesCore.Table, Element.QueryOutput == Element {
@@ -105,7 +105,7 @@ extension FetchAll {
   public init<S: SelectStatement>(
     wrappedValue: [Element] = [],
     _ statement: S,
-    @_SectionBuilder sectionBy sectioning: (S.From.TableColumns) -> _Sectioning?,
+    @_SectionBuilder<String?> sectionBy sectioning: (S.From.TableColumns) -> _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil
   )
   where
@@ -182,12 +182,25 @@ extension FetchAll {
     )
   }
 
+  /// Initializes this property with a query associated with the wrapped value, grouping results
+  /// into sections.
+  ///
+  /// The query can select custom values and join other tables. The sectioning closure is handed
+  /// the columns of every table in the query.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default collection to associate with this property.
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+  ///     results by, or `nil` for no grouping.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
   public init<
     V: QueryRepresentable, From: StructuredQueriesCore.Table
   >(
     wrappedValue: [Element] = [],
     _ statement: Select<V, From, ()>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+    @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns) -> _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil
   )
   where
@@ -207,12 +220,24 @@ extension FetchAll {
     )
   }
 
+  /// Initializes this property with a query associated with the wrapped value, grouping results
+  /// into sections.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default collection to associate with this property.
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+  ///     results by, or `nil` for no grouping.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  @_documentation(visibility: private)
   public init<
     V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
   >(
     wrappedValue: [Element] = [],
     _ statement: Select<V, From, J>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
+    @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns, J.TableColumns) ->
+      _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil
   )
   where
@@ -232,6 +257,17 @@ extension FetchAll {
     )
   }
 
+  /// Initializes this property with a query associated with the wrapped value, grouping results
+  /// into sections.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default collection to associate with this property.
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+  ///     results by, or `nil` for no grouping.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  @_documentation(visibility: private)
   public init<
     V: QueryRepresentable,
     From: StructuredQueriesCore.Table,
@@ -240,9 +276,9 @@ extension FetchAll {
   >(
     wrappedValue: [Element] = [],
     _ statement: Select<V, From, (J1, repeat each J2)>,
-    @_SectionBuilder sectionBy sectioning: (
+    @_SectionBuilder<String?> sectionBy sectioning: (
       From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-    ) -> _Sectioning?,
+    ) -> _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil
   )
   where
@@ -274,7 +310,7 @@ extension FetchAll {
   @discardableResult
   public func load<S: SelectStatement>(
     _ statement: S,
-    @_SectionBuilder sectionBy sectioning: (S.From.TableColumns) -> _Sectioning?,
+    @_SectionBuilder<String?> sectionBy sectioning: (S.From.TableColumns) -> _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil
   ) async throws -> FetchSubscription
   where
@@ -321,12 +357,24 @@ extension FetchAll {
     )
   }
 
+  /// Replaces the wrapped value with data from the given query, grouping results into sections.
+  ///
+  /// The query can select custom values and join other tables. The sectioning closure is handed
+  /// the columns of every table in the query.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+  ///     results by, or `nil` for no grouping.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  /// - Returns: A subscription associated with the observation.
   @discardableResult
   public func load<
     V: QueryRepresentable, From: StructuredQueriesCore.Table
   >(
     _ statement: Select<V, From, ()>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+    @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns) -> _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil
   ) async throws -> FetchSubscription
   where
@@ -344,12 +392,23 @@ extension FetchAll {
     )
   }
 
+  /// Replaces the wrapped value with data from the given query, grouping results into sections.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+  ///     results by, or `nil` for no grouping.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  /// - Returns: A subscription associated with the observation.
+  @_documentation(visibility: private)
   @discardableResult
   public func load<
     V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
   >(
     _ statement: Select<V, From, J>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
+    @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns, J.TableColumns) ->
+      _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil
   ) async throws -> FetchSubscription
   where
@@ -367,6 +426,16 @@ extension FetchAll {
     )
   }
 
+  /// Replaces the wrapped value with data from the given query, grouping results into sections.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+  ///     results by, or `nil` for no grouping.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  /// - Returns: A subscription associated with the observation.
+  @_documentation(visibility: private)
   @discardableResult
   public func load<
     V: QueryRepresentable,
@@ -375,9 +444,9 @@ extension FetchAll {
     each J2: StructuredQueriesCore.Table
   >(
     _ statement: Select<V, From, (J1, repeat each J2)>,
-    @_SectionBuilder sectionBy sectioning: (
+    @_SectionBuilder<String?> sectionBy sectioning: (
       From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-    ) -> _Sectioning?,
+    ) -> _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil
   ) async throws -> FetchSubscription
   where
@@ -398,7 +467,7 @@ extension FetchAll {
   fileprivate init<From: StructuredQueriesCore.Table>(
     wrappedValue: [Element],
     statement: Select<(), From, ()>,
-    sectionBy: _Sectioning,
+    sectionBy: _Sectioning<String?>,
     database: (any DatabaseReader)?,
     scheduler: (any ValueObservationScheduler & Hashable)?
   )
@@ -417,8 +486,8 @@ extension FetchAll {
 
   fileprivate init<Value: QueryRepresentable>(
     wrappedValue: [Element],
-    request: FetchAllSectionedStatementValueRequest<Value>,
-    sectionBy: _Sectioning,
+    request: FetchAllSectionedStatementValueRequest<Value, String?>,
+    sectionBy: _Sectioning<String?>,
     database: (any DatabaseReader)?,
     scheduler: (any ValueObservationScheduler & Hashable)?
   )
@@ -441,7 +510,7 @@ extension FetchAll {
 
   func loadSections<From: StructuredQueriesCore.Table>(
     statement: Select<(), From, ()>,
-    sectionBy sectioning: _Sectioning?,
+    sectionBy sectioning: _Sectioning<String?>?,
     database: (any DatabaseReader)?,
     scheduler: (any ValueObservationScheduler & Hashable)?
   ) async throws -> FetchSubscription
@@ -470,8 +539,8 @@ extension FetchAll {
   }
 
   private func loadSections<Value: QueryRepresentable>(
-    request: FetchAllSectionedStatementValueRequest<Value>,
-    sectionBy sectioning: _Sectioning,
+    request: FetchAllSectionedStatementValueRequest<Value, String?>,
+    sectionBy sectioning: _Sectioning<String?>,
     database: (any DatabaseReader)?,
     scheduler: (any ValueObservationScheduler & Hashable)?
   ) async throws -> FetchSubscription
@@ -508,7 +577,7 @@ extension FetchAll {
   ///     asynchronously on the main queue.
   public init(
     wrappedValue: [Element] = [],
-    @_SectionBuilder sectionBy sectioning: (Element.TableColumns) -> _Sectioning?,
+    @_SectionBuilder<String?> sectionBy sectioning: (Element.TableColumns) -> _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   )
@@ -542,7 +611,7 @@ extension FetchAll {
   public init<S: SelectStatement>(
     wrappedValue: [Element] = [],
     _ statement: S,
-    @_SectionBuilder sectionBy sectioning: (S.From.TableColumns) -> _Sectioning?,
+    @_SectionBuilder<String?> sectionBy sectioning: (S.From.TableColumns) -> _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   )
@@ -628,12 +697,27 @@ extension FetchAll {
     )
   }
 
+  /// Initializes this property with a query associated with the wrapped value, grouping results
+  /// into sections.
+  ///
+  /// The query can select custom values and join other tables. The sectioning closure is handed
+  /// the columns of every table in the query.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default collection to associate with this property.
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+  ///     results by, or `nil` for no grouping.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
+  ///     asynchronously on the main queue.
   public init<
     V: QueryRepresentable, From: StructuredQueriesCore.Table
   >(
     wrappedValue: [Element] = [],
     _ statement: Select<V, From, ()>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+    @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns) -> _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   )
@@ -654,12 +738,26 @@ extension FetchAll {
     )
   }
 
+  /// Initializes this property with a query associated with the wrapped value, grouping results
+  /// into sections.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default collection to associate with this property.
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+  ///     results by, or `nil` for no grouping.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
+  ///     asynchronously on the main queue.
+  @_documentation(visibility: private)
   public init<
     V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
   >(
     wrappedValue: [Element] = [],
     _ statement: Select<V, From, J>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
+    @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns, J.TableColumns) ->
+      _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   )
@@ -680,6 +778,19 @@ extension FetchAll {
     )
   }
 
+  /// Initializes this property with a query associated with the wrapped value, grouping results
+  /// into sections.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default collection to associate with this property.
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+  ///     results by, or `nil` for no grouping.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
+  ///     asynchronously on the main queue.
+  @_documentation(visibility: private)
   public init<
     V: QueryRepresentable,
     From: StructuredQueriesCore.Table,
@@ -688,9 +799,9 @@ extension FetchAll {
   >(
     wrappedValue: [Element] = [],
     _ statement: Select<V, From, (J1, repeat each J2)>,
-    @_SectionBuilder sectionBy sectioning: (
+    @_SectionBuilder<String?> sectionBy sectioning: (
       From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-    ) -> _Sectioning?,
+    ) -> _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   )
@@ -725,7 +836,7 @@ extension FetchAll {
   @discardableResult
   public func load<S: SelectStatement>(
     _ statement: S,
-    @_SectionBuilder sectionBy sectioning: (S.From.TableColumns) -> _Sectioning?,
+    @_SectionBuilder<String?> sectionBy sectioning: (S.From.TableColumns) -> _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   ) async throws -> FetchSubscription
@@ -777,12 +888,26 @@ extension FetchAll {
     )
   }
 
+  /// Replaces the wrapped value with data from the given query, grouping results into sections.
+  ///
+  /// The query can select custom values and join other tables. The sectioning closure is handed
+  /// the columns of every table in the query.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+  ///     results by, or `nil` for no grouping.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
+  ///     asynchronously on the main queue.
+  /// - Returns: A subscription associated with the observation.
   @discardableResult
   public func load<
     V: QueryRepresentable, From: StructuredQueriesCore.Table
   >(
     _ statement: Select<V, From, ()>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+    @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns) -> _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   ) async throws -> FetchSubscription
@@ -801,12 +926,25 @@ extension FetchAll {
     )
   }
 
+  /// Replaces the wrapped value with data from the given query, grouping results into sections.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+  ///     results by, or `nil` for no grouping.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
+  ///     asynchronously on the main queue.
+  /// - Returns: A subscription associated with the observation.
+  @_documentation(visibility: private)
   @discardableResult
   public func load<
     V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
   >(
     _ statement: Select<V, From, J>,
-    @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
+    @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns, J.TableColumns) ->
+      _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   ) async throws -> FetchSubscription
@@ -825,6 +963,18 @@ extension FetchAll {
     )
   }
 
+  /// Replaces the wrapped value with data from the given query, grouping results into sections.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+  ///     results by, or `nil` for no grouping.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
+  ///     asynchronously on the main queue.
+  /// - Returns: A subscription associated with the observation.
+  @_documentation(visibility: private)
   @discardableResult
   public func load<
     V: QueryRepresentable,
@@ -833,9 +983,9 @@ extension FetchAll {
     each J2: StructuredQueriesCore.Table
   >(
     _ statement: Select<V, From, (J1, repeat each J2)>,
-    @_SectionBuilder sectionBy sectioning: (
+    @_SectionBuilder<String?> sectionBy sectioning: (
       From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-    ) -> _Sectioning?,
+    ) -> _Sectioning<String?>?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   ) async throws -> FetchSubscription
@@ -871,7 +1021,9 @@ extension FetchAll {
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init(
       wrappedValue: [Element] = [],
-      @_SectionBuilder sectionBy sectioning: (Element.TableColumns) -> _Sectioning?,
+      @_SectionBuilder<String?> sectionBy sectioning: (Element.TableColumns) -> _Sectioning<
+        String?
+      >?,
       database: (any DatabaseReader)? = nil,
       animation: Animation
     )
@@ -900,7 +1052,9 @@ extension FetchAll {
     public init<S: SelectStatement>(
       wrappedValue: [Element] = [],
       _ statement: S,
-      @_SectionBuilder sectionBy sectioning: (S.From.TableColumns) -> _Sectioning?,
+      @_SectionBuilder<String?> sectionBy sectioning: (S.From.TableColumns) -> _Sectioning<
+        String?
+      >?,
       database: (any DatabaseReader)? = nil,
       animation: Animation
     )
@@ -983,13 +1137,28 @@ extension FetchAll {
       )
     }
 
+    /// Initializes this property with a query associated with the wrapped value, grouping results
+    /// into sections.
+    ///
+    /// The query can select custom values and join other tables. The sectioning closure is handed
+    /// the columns of every table in the query.
+    ///
+    /// - Parameters:
+    ///   - wrappedValue: A default collection to associate with this property.
+    ///   - statement: A query associated with the wrapped value.
+    ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+    ///     results by, or `nil` for no grouping.
+    ///   - database: The database to read from. A value of `nil` will use the default database
+    ///     (`@Dependency(\.defaultDatabase)`).
+    ///   - animation: The animation to use for user interface changes that result from changes to
+    ///     the fetched results.
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<
       V: QueryRepresentable, From: StructuredQueriesCore.Table
     >(
       wrappedValue: [Element] = [],
       _ statement: Select<V, From, ()>,
-      @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+      @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns) -> _Sectioning<String?>?,
       database: (any DatabaseReader)? = nil,
       animation: Animation
     )
@@ -1006,13 +1175,27 @@ extension FetchAll {
       )
     }
 
+    /// Initializes this property with a query associated with the wrapped value, grouping results
+    /// into sections.
+    ///
+    /// - Parameters:
+    ///   - wrappedValue: A default collection to associate with this property.
+    ///   - statement: A query associated with the wrapped value.
+    ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+    ///     results by, or `nil` for no grouping.
+    ///   - database: The database to read from. A value of `nil` will use the default database
+    ///     (`@Dependency(\.defaultDatabase)`).
+    ///   - animation: The animation to use for user interface changes that result from changes to
+    ///     the fetched results.
+    @_documentation(visibility: private)
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<
       V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
     >(
       wrappedValue: [Element] = [],
       _ statement: Select<V, From, J>,
-      @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
+      @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns, J.TableColumns) ->
+        _Sectioning<String?>?,
       database: (any DatabaseReader)? = nil,
       animation: Animation
     )
@@ -1029,6 +1212,19 @@ extension FetchAll {
       )
     }
 
+    /// Initializes this property with a query associated with the wrapped value, grouping results
+    /// into sections.
+    ///
+    /// - Parameters:
+    ///   - wrappedValue: A default collection to associate with this property.
+    ///   - statement: A query associated with the wrapped value.
+    ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+    ///     results by, or `nil` for no grouping.
+    ///   - database: The database to read from. A value of `nil` will use the default database
+    ///     (`@Dependency(\.defaultDatabase)`).
+    ///   - animation: The animation to use for user interface changes that result from changes to
+    ///     the fetched results.
+    @_documentation(visibility: private)
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<
       V: QueryRepresentable,
@@ -1038,9 +1234,9 @@ extension FetchAll {
     >(
       wrappedValue: [Element] = [],
       _ statement: Select<V, From, (J1, repeat each J2)>,
-      @_SectionBuilder sectionBy sectioning: (
+      @_SectionBuilder<String?> sectionBy sectioning: (
         From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-      ) -> _Sectioning?,
+      ) -> _Sectioning<String?>?,
       database: (any DatabaseReader)? = nil,
       animation: Animation
     )
@@ -1072,7 +1268,9 @@ extension FetchAll {
     @discardableResult
     public func load<S: SelectStatement>(
       _ statement: S,
-      @_SectionBuilder sectionBy sectioning: (S.From.TableColumns) -> _Sectioning?,
+      @_SectionBuilder<String?> sectionBy sectioning: (S.From.TableColumns) -> _Sectioning<
+        String?
+      >?,
       database: (any DatabaseReader)? = nil,
       animation: Animation?
     ) async throws -> FetchSubscription
@@ -1124,13 +1322,27 @@ extension FetchAll {
       )
     }
 
+    /// Replaces the wrapped value with data from the given query, grouping results into sections.
+    ///
+    /// The query can select custom values and join other tables. The sectioning closure is handed
+    /// the columns of every table in the query.
+    ///
+    /// - Parameters:
+    ///   - statement: A query associated with the wrapped value.
+    ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+    ///     results by, or `nil` for no grouping.
+    ///   - database: The database to read from. A value of `nil` will use the default database
+    ///     (`@Dependency(\.defaultDatabase)`).
+    ///   - animation: The animation to use for user interface changes that result from changes to
+    ///     the fetched results.
+    /// - Returns: A subscription associated with the observation.
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     @discardableResult
     public func load<
       V: QueryRepresentable, From: StructuredQueriesCore.Table
     >(
       _ statement: Select<V, From, ()>,
-      @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
+      @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns) -> _Sectioning<String?>?,
       database: (any DatabaseReader)? = nil,
       animation: Animation?
     ) async throws -> FetchSubscription
@@ -1146,13 +1358,26 @@ extension FetchAll {
       )
     }
 
+    /// Replaces the wrapped value with data from the given query, grouping results into sections.
+    ///
+    /// - Parameters:
+    ///   - statement: A query associated with the wrapped value.
+    ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+    ///     results by, or `nil` for no grouping.
+    ///   - database: The database to read from. A value of `nil` will use the default database
+    ///     (`@Dependency(\.defaultDatabase)`).
+    ///   - animation: The animation to use for user interface changes that result from changes to
+    ///     the fetched results.
+    /// - Returns: A subscription associated with the observation.
+    @_documentation(visibility: private)
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     @discardableResult
     public func load<
       V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
     >(
       _ statement: Select<V, From, J>,
-      @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
+      @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns, J.TableColumns) ->
+        _Sectioning<String?>?,
       database: (any DatabaseReader)? = nil,
       animation: Animation?
     ) async throws -> FetchSubscription
@@ -1168,6 +1393,18 @@ extension FetchAll {
       )
     }
 
+    /// Replaces the wrapped value with data from the given query, grouping results into sections.
+    ///
+    /// - Parameters:
+    ///   - statement: A query associated with the wrapped value.
+    ///   - sectioning: A closure that returns a string expression, or an ordering of one, to group
+    ///     results by, or `nil` for no grouping.
+    ///   - database: The database to read from. A value of `nil` will use the default database
+    ///     (`@Dependency(\.defaultDatabase)`).
+    ///   - animation: The animation to use for user interface changes that result from changes to
+    ///     the fetched results.
+    /// - Returns: A subscription associated with the observation.
+    @_documentation(visibility: private)
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     @discardableResult
     public func load<
@@ -1177,9 +1414,9 @@ extension FetchAll {
       each J2: StructuredQueriesCore.Table
     >(
       _ statement: Select<V, From, (J1, repeat each J2)>,
-      @_SectionBuilder sectionBy sectioning: (
+      @_SectionBuilder<String?> sectionBy sectioning: (
         From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
-      ) -> _Sectioning?,
+      ) -> _Sectioning<String?>?,
       database: (any DatabaseReader)? = nil,
       animation: Animation?
     ) async throws -> FetchSubscription
@@ -1197,115 +1434,120 @@ extension FetchAll {
   }
 #endif
 
-private func sectionedColumns<From: StructuredQueriesCore.Table>(
+func sectionedColumns<From: StructuredQueriesCore.Table, Key: QueryRepresentable>(
   of _: From.Type,
-  _ sectionBy: _Sectioning
-) -> Select<(From, String?), From, ()> {
+  _ sectionBy: _Sectioning<Key>
+) -> Select<(From, Key), From, ()> {
   From.unscoped
-    .select { ($0, SQLQueryExpression(sectionBy.select, as: String?.self)) }
+    .select { ($0, SQLQueryExpression(sectionBy.select, as: Key.self)) }
     .order { _ in SQLQueryExpression(sectionBy.order) }
 }
 
-private func sectionedColumn<From: StructuredQueriesCore.Table>(
+func sectionedColumn<From: StructuredQueriesCore.Table, Key: QueryRepresentable>(
   of _: From.Type,
-  _ sectionBy: _Sectioning
-) -> Select<String?, From, ()> {
+  _ sectionBy: _Sectioning<Key>
+) -> Select<Key, From, ()> {
   From.unscoped.asSelect()
-    .select { _ in SQLQueryExpression(sectionBy.select, as: String?.self) }
+    .select { _ in SQLQueryExpression(sectionBy.select, as: Key.self) }
 }
 
-private func sectionedOrder<From: StructuredQueriesCore.Table>(
+func sectionedOrder<From: StructuredQueriesCore.Table, Key>(
   of _: From.Type,
-  _ sectionBy: _Sectioning
+  _ sectionBy: _Sectioning<Key>
 ) -> Select<(), From, ()> {
   From.unscoped.asSelect()
     .order { _ in SQLQueryExpression(sectionBy.order) }
 }
 
-public struct _Sectioning: Hashable, Sendable {
+public struct _Sectioning<Key>: Hashable, Sendable {
   let select: QueryFragment
   let order: QueryFragment
 
-  package init(_ expression: some QueryExpression<some _OptionalPromotable<String?>>) {
+  package init(_ expression: some QueryExpression<some _OptionalPromotable<Key>>) {
     self.select = expression.queryFragment
     self.order = expression.queryFragment
   }
 
-  package init(_ orderingTerm: _OrderingTerm<some _OptionalPromotable<String?>>) {
+  package init(_ orderingTerm: _OrderingTerm<some _OptionalPromotable<Key>>) {
     self.select = orderingTerm.baseQueryFragment
     self.order = orderingTerm.queryFragment
   }
 }
 
 @resultBuilder
-public enum _SectionBuilder {
+public enum _SectionBuilder<Key> {
   public static func buildExpression(
     _ expression: Never?
-  ) -> _Sectioning? {
+  ) -> _Sectioning<Key>? {
     nil
   }
 
+  @_disfavoredOverload
   public static func buildExpression(
-    _ expression: some QueryExpression<some _OptionalPromotable<String?>>
-  ) -> _Sectioning {
+    _ expression: some QueryExpression<some _OptionalPromotable<Key>>
+  ) -> _Sectioning<Key> {
     _Sectioning(expression)
   }
 
   public static func buildExpression(
-    _ orderingTerm: _OrderingTerm<some _OptionalPromotable<String?>>
-  ) -> _Sectioning {
+    _ orderingTerm: _OrderingTerm<some _OptionalPromotable<Key>>
+  ) -> _Sectioning<Key> {
     _Sectioning(orderingTerm)
   }
 
-  public static func buildBlock(_ component: _Sectioning) -> _Sectioning {
+  public static func buildBlock(_ component: _Sectioning<Key>) -> _Sectioning<Key> {
     component
   }
 
   @_disfavoredOverload
-  public static func buildBlock(_ component: _Sectioning?) -> _Sectioning? {
+  public static func buildBlock(_ component: _Sectioning<Key>?) -> _Sectioning<Key>? {
     component
   }
 
-  public static func buildOptional(_ component: _Sectioning?) -> _Sectioning? {
+  public static func buildOptional(_ component: _Sectioning<Key>?) -> _Sectioning<Key>? {
     component
   }
 
-  public static func buildEither(first component: _Sectioning) -> _Sectioning {
+  public static func buildEither(first component: _Sectioning<Key>) -> _Sectioning<Key> {
     component
   }
 
-  public static func buildEither(second component: _Sectioning) -> _Sectioning {
+  public static func buildEither(second component: _Sectioning<Key>) -> _Sectioning<Key> {
     component
   }
 }
 
-struct FetchAllSectionedStatementValueRequest<Value: QueryRepresentable>: FetchKeyRequest
-where Value.QueryOutput: Sendable {
-  let statement: SQLQueryExpression<(Value, String?)>
+struct FetchAllSectionedStatementValueRequest<
+  Value: QueryRepresentable,
+  Key: QueryRepresentable
+>: FetchKeyRequest
+where Value.QueryOutput: Sendable, Key.QueryOutput: Hashable & Sendable {
+  let statement: SQLQueryExpression<(Value, Key)>
 
   init(
     statement: Select<(), Value, ()>,
-    sectionBy: _Sectioning
+    sectionBy: _Sectioning<Key>
   ) where Value: StructuredQueriesCore.Table {
-    let prefix: Select<(Value, String?), Value, ()> = sectionedColumns(of: Value.self, sectionBy)
-    let sectioned: Select<(Value, String?), Value, ()> = prefix + statement
+    let prefix: Select<(Value, Key), Value, ()> = sectionedColumns(of: Value.self, sectionBy)
+    let sectioned: Select<(Value, Key), Value, ()> = prefix + statement
     self.statement = SQLQueryExpression(sectioned)
   }
 
   init<From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table>(
     statement: Select<Value, From, (repeat each J)>,
-    sectionBy: _Sectioning
+    sectionBy: _Sectioning<Key>
   ) {
     let ordered: Select<Value, From, (repeat each J)> =
       sectionedOrder(of: From.self, sectionBy) + statement
-    let sectioned: Select<(Value, String?), From, (repeat each J)> =
+    let sectioned: Select<(Value, Key), From, (repeat each J)> =
       ordered + sectionedColumn(of: From.self, sectionBy)
     self.statement = SQLQueryExpression(sectioned)
   }
 
-  func fetch(_ db: Database) throws -> ResultsSectionCollection<Value.QueryOutput, String?> {
+  func fetch(_ db: Database) throws -> ResultsSectionCollection<Value.QueryOutput, Key.QueryOutput>
+  {
     try ResultsSectionCollection(
-      cursor: QuerySectionedValueCursor<Value>(db: db, query: statement.queryFragment)
+      cursor: QuerySectionedCursor<Value, Key>(db: db, query: statement.queryFragment)
     )
   }
 

--- a/Sources/SQLiteData/FetchAll+Sections.swift
+++ b/Sources/SQLiteData/FetchAll+Sections.swift
@@ -752,21 +752,18 @@ extension FetchAll {
 
 extension FetchAll {
   public init<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
+    V: QueryRepresentable, From: StructuredQueriesCore.Table
   >(
     wrappedValue: [Element] = [],
-    _ statement: some SelectStatement<V, From, (repeat each J)>,
-    @_SectionBuilder sectionBy sectioning: (
-      From.TableColumns, repeat (each J).TableColumns
-    ) -> _Sectioning?,
+    _ statement: Select<V, From, ()>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
     database: (any DatabaseReader)? = nil
   )
   where
     Element == V.QueryOutput,
     V.QueryOutput: Sendable
   {
-    let statement: Select<V, From, (repeat each J)> = statement.asSelect()
-    guard let sectioning = sectioning(From.columns, repeat (each J).columns) else {
+    guard let sectioning = sectioning(From.columns) else {
       self.init(wrappedValue: wrappedValue, statement, database: database)
       return
     }
@@ -780,13 +777,11 @@ extension FetchAll {
   }
 
   public init<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
+    V: QueryRepresentable, From: StructuredQueriesCore.Table
   >(
     wrappedValue: [Element] = [],
-    _ statement: some SelectStatement<V, From, (repeat each J)>,
-    @_SectionBuilder sectionBy sectioning: (
-      From.TableColumns, repeat (each J).TableColumns
-    ) -> _Sectioning?,
+    _ statement: Select<V, From, ()>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   )
@@ -794,8 +789,7 @@ extension FetchAll {
     Element == V.QueryOutput,
     V.QueryOutput: Sendable
   {
-    let statement: Select<V, From, (repeat each J)> = statement.asSelect()
-    guard let sectioning = sectioning(From.columns, repeat (each J).columns) else {
+    guard let sectioning = sectioning(From.columns) else {
       self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
       return
     }
@@ -810,20 +804,17 @@ extension FetchAll {
 
   @discardableResult
   public func load<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
+    V: QueryRepresentable, From: StructuredQueriesCore.Table
   >(
-    _ statement: some SelectStatement<V, From, (repeat each J)>,
-    @_SectionBuilder sectionBy sectioning: (
-      From.TableColumns, repeat (each J).TableColumns
-    ) -> _Sectioning?,
+    _ statement: Select<V, From, ()>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
     database: (any DatabaseReader)? = nil
   ) async throws -> FetchSubscription
   where
     Element == V.QueryOutput,
     V.QueryOutput: Sendable
   {
-    let statement: Select<V, From, (repeat each J)> = statement.asSelect()
-    guard let sectioning = sectioning(From.columns, repeat (each J).columns) else {
+    guard let sectioning = sectioning(From.columns) else {
       return try await load(statement, database: database)
     }
     return try await loadSections(
@@ -836,12 +827,10 @@ extension FetchAll {
 
   @discardableResult
   public func load<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, each J: StructuredQueriesCore.Table
+    V: QueryRepresentable, From: StructuredQueriesCore.Table
   >(
-    _ statement: some SelectStatement<V, From, (repeat each J)>,
-    @_SectionBuilder sectionBy sectioning: (
-      From.TableColumns, repeat (each J).TableColumns
-    ) -> _Sectioning?,
+    _ statement: Select<V, From, ()>,
+    @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   ) async throws -> FetchSubscription
@@ -849,8 +838,7 @@ extension FetchAll {
     Element == V.QueryOutput,
     V.QueryOutput: Sendable
   {
-    let statement: Select<V, From, (repeat each J)> = statement.asSelect()
-    guard let sectioning = sectioning(From.columns, repeat (each J).columns) else {
+    guard let sectioning = sectioning(From.columns) else {
       return try await load(statement, database: database, scheduler: scheduler)
     }
     return try await loadSections(
@@ -962,18 +950,135 @@ extension FetchAll {
   }
 }
 
+extension FetchAll {
+  public init<
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J1: StructuredQueriesCore.Table,
+    each J2: StructuredQueriesCore.Table
+  >(
+    wrappedValue: [Element] = [],
+    _ statement: Select<V, From, (J1, repeat each J2)>,
+    @_SectionBuilder sectionBy sectioning: (
+      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+    ) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil
+  )
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
+      self.init(wrappedValue: wrappedValue, statement, database: database)
+      return
+    }
+    self.init(
+      wrappedValue: wrappedValue,
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: nil
+    )
+  }
+
+  public init<
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J1: StructuredQueriesCore.Table,
+    each J2: StructuredQueriesCore.Table
+  >(
+    wrappedValue: [Element] = [],
+    _ statement: Select<V, From, (J1, repeat each J2)>,
+    @_SectionBuilder sectionBy sectioning: (
+      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+    ) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
+      self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
+      return
+    }
+    self.init(
+      wrappedValue: wrappedValue,
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  @discardableResult
+  public func load<
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J1: StructuredQueriesCore.Table,
+    each J2: StructuredQueriesCore.Table
+  >(
+    _ statement: Select<V, From, (J1, repeat each J2)>,
+    @_SectionBuilder sectionBy sectioning: (
+      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+    ) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil
+  ) async throws -> FetchSubscription
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
+      return try await load(statement, database: database)
+    }
+    return try await loadSections(
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: nil
+    )
+  }
+
+  @discardableResult
+  public func load<
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J1: StructuredQueriesCore.Table,
+    each J2: StructuredQueriesCore.Table
+  >(
+    _ statement: Select<V, From, (J1, repeat each J2)>,
+    @_SectionBuilder sectionBy sectioning: (
+      From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+    ) -> _Sectioning?,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  ) async throws -> FetchSubscription
+  where
+    Element == V.QueryOutput,
+    V.QueryOutput: Sendable
+  {
+    guard let sectioning = sectioning(From.columns, J1.columns, repeat (each J2).columns) else {
+      return try await load(statement, database: database, scheduler: scheduler)
+    }
+    return try await loadSections(
+      request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
+      sectionBy: sectioning,
+      database: database,
+      scheduler: scheduler
+    )
+  }
+}
+
 #if canImport(SwiftUI)
   extension FetchAll {
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<
-      V: QueryRepresentable, From: StructuredQueriesCore.Table,
-      each J: StructuredQueriesCore.Table
+      V: QueryRepresentable, From: StructuredQueriesCore.Table
     >(
       wrappedValue: [Element] = [],
-      _ statement: some SelectStatement<V, From, (repeat each J)>,
-      @_SectionBuilder sectionBy sectioning: (
-        From.TableColumns, repeat (each J).TableColumns
-      ) -> _Sectioning?,
+      _ statement: Select<V, From, ()>,
+      @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
       database: (any DatabaseReader)? = nil,
       animation: Animation
     )
@@ -993,13 +1098,10 @@ extension FetchAll {
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     @discardableResult
     public func load<
-      V: QueryRepresentable, From: StructuredQueriesCore.Table,
-      each J: StructuredQueriesCore.Table
+      V: QueryRepresentable, From: StructuredQueriesCore.Table
     >(
-      _ statement: some SelectStatement<V, From, (repeat each J)>,
-      @_SectionBuilder sectionBy sectioning: (
-        From.TableColumns, repeat (each J).TableColumns
-      ) -> _Sectioning?,
+      _ statement: Select<V, From, ()>,
+      @_SectionBuilder sectionBy sectioning: (From.TableColumns) -> _Sectioning?,
       database: (any DatabaseReader)? = nil,
       animation: Animation?
     ) async throws -> FetchSubscription
@@ -1045,6 +1147,61 @@ extension FetchAll {
     >(
       _ statement: Select<V, From, J>,
       @_SectionBuilder sectionBy sectioning: (From.TableColumns, J.TableColumns) -> _Sectioning?,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation?
+    ) async throws -> FetchSubscription
+    where
+      Element == V.QueryOutput,
+      V.QueryOutput: Sendable
+    {
+      try await load(
+        statement,
+        sectionBy: sectioning,
+        database: database,
+        scheduler: .animation(animation)
+      )
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    public init<
+      V: QueryRepresentable,
+      From: StructuredQueriesCore.Table,
+      J1: StructuredQueriesCore.Table,
+      each J2: StructuredQueriesCore.Table
+    >(
+      wrappedValue: [Element] = [],
+      _ statement: Select<V, From, (J1, repeat each J2)>,
+      @_SectionBuilder sectionBy sectioning: (
+        From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+      ) -> _Sectioning?,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    )
+    where
+      Element == V.QueryOutput,
+      V.QueryOutput: Sendable
+    {
+      self.init(
+        wrappedValue: wrappedValue,
+        statement,
+        sectionBy: sectioning,
+        database: database,
+        scheduler: .animation(animation)
+      )
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @discardableResult
+    public func load<
+      V: QueryRepresentable,
+      From: StructuredQueriesCore.Table,
+      J1: StructuredQueriesCore.Table,
+      each J2: StructuredQueriesCore.Table
+    >(
+      _ statement: Select<V, From, (J1, repeat each J2)>,
+      @_SectionBuilder sectionBy sectioning: (
+        From.TableColumns, J1.TableColumns, repeat (each J2).TableColumns
+      ) -> _Sectioning?,
       database: (any DatabaseReader)? = nil,
       animation: Animation?
     ) async throws -> FetchSubscription
@@ -1097,9 +1254,7 @@ public struct _Sectioning: Hashable, Sendable {
   }
 
   package init(_ orderingTerm: _OrderingTerm<some _OptionalPromotable<String?>>) {
-    var orderingTerm = orderingTerm
     self.select = orderingTerm.baseQueryFragment
-    orderingTerm.baseQueryFragment = orderingTerm.base.queryFragment
     self.order = orderingTerm.queryFragment
   }
 }

--- a/Sources/SQLiteData/FetchAll.swift
+++ b/Sources/SQLiteData/FetchAll.swift
@@ -31,7 +31,7 @@ public struct FetchAll<Element: Sendable>: Sendable {
   var sectionedReader: SharedReader<ResultsSectionCollection<Element, String?>> =
     SharedReader(value: ResultsSectionCollection())
 
-  let sectioning = LockIsolated<_Sectioning?>(nil)
+  let sectioning = LockIsolated<_Sectioning<String?>?>(nil)
 
   /// A collection of data associated with the underlying query.
   public var wrappedValue: [Element] {

--- a/Sources/SQLiteData/ResultsSectionCollection.swift
+++ b/Sources/SQLiteData/ResultsSectionCollection.swift
@@ -31,7 +31,8 @@ public struct ResultsSectionCollection<Element, SectionName: Hashable> {
   let elements: [Element]
   private let elementIndicesBySectionName: OrderedDictionary<SectionName, ElementIndices>
 
-  init() {
+  /// Creates an empty collection of sections.
+  public init() {
     elements = []
     elementIndicesBySectionName = [:]
   }
@@ -71,10 +72,10 @@ public struct ResultsSectionCollection<Element, SectionName: Hashable> {
   }
 }
 
-extension ResultsSectionCollection where SectionName == String? {
-  init(cursor: QueryCursor<(Element, String?)>) throws {
+extension ResultsSectionCollection {
+  init(cursor: QueryCursor<(Element, SectionName)>) throws {
     var elements: [Element] = []
-    var elementIndicesBySectionName: OrderedDictionary<String?, ElementIndices> = [:]
+    var elementIndicesBySectionName: OrderedDictionary<SectionName, ElementIndices> = [:]
     while let (element, sectionName) = try cursor.next() {
       let index = elements.count
       elementIndicesBySectionName[sectionName, default: ElementIndices(range: index..<index)]

--- a/Sources/SQLiteData/StructuredQueries+GRDB/QueryCursor.swift
+++ b/Sources/SQLiteData/StructuredQueries+GRDB/QueryCursor.swift
@@ -79,11 +79,10 @@ final class QueryValueCursor<QueryValue: QueryRepresentable>: QueryCursor<QueryV
 }
 
 @usableFromInline
-final class QuerySectionedValueCursor<QueryValue: QueryRepresentable>: QueryCursor<
-  (QueryValue.QueryOutput, String?)
-> {
-  public typealias Element = (QueryValue.QueryOutput, String?)
-
+final class QuerySectionedCursor<
+  Element: QueryRepresentable,
+  SectionName: QueryRepresentable
+>: QueryCursor<(Element.QueryOutput, SectionName.QueryOutput)> {
   // NB: Required to workaround a "Legacy previews execution" bug
   //     https://github.com/pointfreeco/sqlite-data/pull/60
   @usableFromInline
@@ -92,10 +91,12 @@ final class QuerySectionedValueCursor<QueryValue: QueryRepresentable>: QueryCurs
   }
 
   @inlinable
-  public override func _element(sqliteStatement _: SQLiteStatement) throws -> Element {
+  public override func _element(
+    sqliteStatement _: SQLiteStatement
+  ) throws -> (Element.QueryOutput, SectionName.QueryOutput) {
     do {
-      let element = try QueryValue(decoder: &decoder).queryOutput
-      let sectionName = try String?(decoder: &decoder)
+      let element = try Element(decoder: &decoder).queryOutput
+      let sectionName = try SectionName(decoder: &decoder).queryOutput
       decoder.next()
       return (element, sectionName)
     } catch QueryDecodingError.missingRequiredColumn {

--- a/Sources/SQLiteData/StructuredQueries+GRDB/Statement+Sections.swift
+++ b/Sources/SQLiteData/StructuredQueries+GRDB/Statement+Sections.swift
@@ -1,0 +1,145 @@
+public import GRDB
+public import StructuredQueriesCore
+
+extension SelectStatement where QueryValue == (), Joins == () {
+  /// Returns all values fetched from the database, grouped into sections.
+  ///
+  /// Results are ordered by the given expression and grouped into a section for each of its
+  /// distinct values:
+  ///
+  /// ```swift
+  /// try Reminder
+  ///   .order(by: \.title)
+  ///   .fetchAll(db, sectionBy: \.priority)
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - db: A database connection.
+  ///   - sectioning: A closure that returns an expression, or an ordering of one, to group results
+  ///     by.
+  /// - Returns: A collection of all values decoded from the database, grouped into sections.
+  public func fetchAll<Key: QueryRepresentable>(
+    _ db: Database,
+    @_SectionBuilder<Key> sectionBy sectioning: (From.TableColumns) -> _Sectioning<Key>
+  ) throws -> ResultsSectionCollection<From.QueryOutput, Key.QueryOutput>
+  where Key.QueryOutput: Hashable {
+    let sectionBy = sectioning(From.columns)
+    let statement: Select<(), From, ()> = asSelect()
+    let prefix: Select<(From, Key), From, ()> = sectionedColumns(of: From.self, sectionBy)
+    let sectioned: Select<(From, Key), From, ()> = prefix + statement
+    return try sectionedResults(From.self, Key.self, db: db, query: sectioned.query)
+  }
+
+  /// Returns all values fetched from the database, grouped into sections.
+  ///
+  /// See ``StructuredQueriesCore/SelectStatement/fetchAll(_:sectionBy:)`` for more information.
+  ///
+  /// - Parameters:
+  ///   - db: A database connection.
+  ///   - sectionKeyPath: A key path to a column to group results by.
+  /// - Returns: A collection of all values decoded from the database, grouped into sections.
+  public func fetchAll<Key: QueryRepresentable>(
+    _ db: Database,
+    sectionBy sectionKeyPath: KeyPath<
+      From.TableColumns, some QueryExpression<some _OptionalPromotable<Key>>
+    >
+  ) throws -> ResultsSectionCollection<From.QueryOutput, Key.QueryOutput>
+  where Key.QueryOutput: Hashable {
+    try fetchAll(db, sectionBy: { $0[keyPath: sectionKeyPath] })
+  }
+}
+
+extension Select {
+  /// Returns all values fetched from the database, grouped into sections.
+  ///
+  /// See ``StructuredQueriesCore/SelectStatement/fetchAll(_:sectionBy:)`` for more information.
+  ///
+  /// - Parameters:
+  ///   - db: A database connection.
+  ///   - sectioning: A closure that returns an expression, or an ordering of one, to group results
+  ///     by.
+  /// - Returns: A collection of all values decoded from the database, grouped into sections.
+  @_documentation(visibility: private)
+  @_disfavoredOverload
+  public func fetchAll<Key: QueryRepresentable, each J: StructuredQueriesCore.Table>(
+    _ db: Database,
+    @_SectionBuilder<Key> sectionBy sectioning: (
+      From.TableColumns, repeat (each J).TableColumns
+    ) -> _Sectioning<Key>
+  ) throws -> ResultsSectionCollection<QueryValue.QueryOutput, Key.QueryOutput>
+  where QueryValue: QueryRepresentable, Joins == (repeat each J), Key.QueryOutput: Hashable {
+    let sectionBy = sectioning(From.columns, repeat (each J).columns)
+    return try sectionedResults(db, statement: self, sectionBy: sectionBy)
+  }
+
+  /// Returns all values fetched from the database, grouped into sections.
+  ///
+  /// See ``StructuredQueriesCore/SelectStatement/fetchAll(_:sectionBy:)`` for more information.
+  ///
+  /// - Parameters:
+  ///   - db: A database connection.
+  ///   - sectioning: A closure that returns an expression, or an ordering of one, to group results
+  ///     by.
+  /// - Returns: A collection of all values decoded from the database, grouped into sections.
+  @_documentation(visibility: private)
+  public func fetchAll<Key: QueryRepresentable>(
+    _ db: Database,
+    @_SectionBuilder<Key> sectionBy sectioning: (
+      From.TableColumns, Joins.TableColumns
+    ) -> _Sectioning<Key>
+  ) throws -> ResultsSectionCollection<QueryValue.QueryOutput, Key.QueryOutput>
+  where
+    QueryValue: QueryRepresentable,
+    Joins: StructuredQueriesCore.Table,
+    Key.QueryOutput: Hashable
+  {
+    let sectionBy = sectioning(From.columns, Joins.columns)
+    return try sectionedResults(db, statement: self, sectionBy: sectionBy)
+  }
+
+  /// Returns all values fetched from the database, grouped into sections.
+  ///
+  /// See ``StructuredQueriesCore/SelectStatement/fetchAll(_:sectionBy:)`` for more information.
+  ///
+  /// - Parameters:
+  ///   - db: A database connection.
+  ///   - sectionKeyPath: A key path to a column to group results by.
+  /// - Returns: A collection of all values decoded from the database, grouped into sections.
+  public func fetchAll<Key: QueryRepresentable>(
+    _ db: Database,
+    sectionBy sectionKeyPath: KeyPath<
+      From.TableColumns, some QueryExpression<some _OptionalPromotable<Key>>
+    >
+  ) throws -> ResultsSectionCollection<QueryValue.QueryOutput, Key.QueryOutput>
+  where QueryValue: QueryRepresentable, Joins == (), Key.QueryOutput: Hashable {
+    try fetchAll(db, sectionBy: { $0[keyPath: sectionKeyPath] })
+  }
+}
+
+private func sectionedResults<
+  Value: QueryRepresentable,
+  From: StructuredQueriesCore.Table,
+  each J: StructuredQueriesCore.Table,
+  Key: QueryRepresentable
+>(
+  _ db: Database,
+  statement: Select<Value, From, (repeat each J)>,
+  sectionBy: _Sectioning<Key>
+) throws -> ResultsSectionCollection<Value.QueryOutput, Key.QueryOutput>
+where Key.QueryOutput: Hashable {
+  let ordered: Select<Value, From, (repeat each J)> =
+    sectionedOrder(of: From.self, sectionBy) + statement
+  let sectioned: Select<(Value, Key), From, (repeat each J)> =
+    ordered + sectionedColumn(of: From.self, sectionBy)
+  return try sectionedResults(Value.self, Key.self, db: db, query: sectioned.query)
+}
+
+private func sectionedResults<Value: QueryRepresentable, Key: QueryRepresentable>(
+  _: Value.Type,
+  _: Key.Type,
+  db: Database,
+  query: QueryFragment
+) throws -> ResultsSectionCollection<Value.QueryOutput, Key.QueryOutput>
+where Key.QueryOutput: Hashable {
+  try ResultsSectionCollection(cursor: QuerySectionedCursor<Value, Key>(db: db, query: query))
+}

--- a/Tests/SQLiteDataTests/FetchAllSectionsTests.swift
+++ b/Tests/SQLiteDataTests/FetchAllSectionsTests.swift
@@ -488,6 +488,143 @@ struct FetchAllSectionsTests {
     #expect(reminders.isEmpty)
     #expect($reminders.sections.isEmpty)
   }
+
+  @Suite
+  struct StatementSectionsTests {
+    @Dependency(\.defaultDatabase) var database
+
+    @Test func wholeTable() async throws {
+      let sections = try await database.read { db in
+        try SectionedReminder.order(by: \.id).fetchAll(db, sectionBy: { $0.category })
+      }
+
+      #expect(sections.sectionNames == ["Errands", "Home", "Work"])
+      #expect(sections[sectionName: "Home"]?.map(\.title) == ["Dishes", "Laundry"])
+      #expect(sections[sectionName: "Work"]?.map(\.title) == ["Standup", "Review"])
+      #expect(sections[sectionName: "Errands"]?.map(\.title) == ["Groceries"])
+    }
+
+    @Test func sectionOrderingWinsOverQueryOrdering() async throws {
+      let sections = try await database.read { db in
+        try SectionedReminder.order { $0.title.desc() }.fetchAll(db, sectionBy: { $0.category })
+      }
+
+      #expect(sections.sectionNames == ["Errands", "Home", "Work"])
+      #expect(sections[sectionName: "Home"]?.map(\.title) == ["Laundry", "Dishes"])
+    }
+
+    @Test func descendingSections() async throws {
+      let sections = try await database.read { db in
+        try SectionedReminder.order(by: \.id).fetchAll(db, sectionBy: { $0.category.desc() })
+      }
+
+      #expect(sections.sectionNames == ["Work", "Home", "Errands"])
+    }
+
+    @Test func nullSections() async throws {
+      let sections = try await database.read { db in
+        try SectionedReminder.order(by: \.id).fetchAll(db, sectionBy: { $0.priority })
+      }
+
+      #expect(sections.sectionNames == [nil, "high", "low"])
+      #expect(sections[sectionName: nil]?.map(\.title) == ["Laundry", "Review"])
+      #expect(sections[sectionName: "high"]?.map(\.title) == ["Dishes", "Standup"])
+    }
+
+    @Test func integerSections() async throws {
+      let sections = try await database.read { db in
+        try SectionedReminder
+          .order(by: \.id)
+          .join(SectionedCategory.all) { $0.category.eq($1.name) }
+          .select { SectionedRow.Columns(title: $0.title, label: $1.label) }
+          .fetchAll(db, sectionBy: { $1.id })
+      }
+
+      #expect(sections.sectionNames == [1, 2, 3])
+      #expect(sections[sectionName: 1]?.map(\.title) == ["Dishes", "Laundry"])
+      #expect(sections[sectionName: 2]?.map(\.title) == ["Standup", "Review"])
+      #expect(sections[sectionName: 3]?.map(\.title) == ["Groceries"])
+    }
+
+    @Test func selectionKeyPath() async throws {
+      let sections = try await database.read { db in
+        try SectionedReminder
+          .order(by: \.id)
+          .select { SectionedRow.Columns(title: $0.title, label: $0.category) }
+          .fetchAll(db, sectionBy: \.category)
+      }
+
+      #expect(sections.sectionNames == ["Errands", "Home", "Work"])
+      #expect(sections[sectionName: "Home"]?.map(\.title) == ["Dishes", "Laundry"])
+    }
+
+    @Test func nullableKeyPath() async throws {
+      let sections = try await database.read { db in
+        try SectionedReminder.order(by: \.id).fetchAll(db, sectionBy: \.priority)
+      }
+
+      #expect(sections.sectionNames == [nil, "high", "low"])
+      #expect(sections[sectionName: nil]?.map(\.title) == ["Laundry", "Review"])
+    }
+
+    @Test func joinedSections() async throws {
+      let sections = try await database.read { db in
+        try SectionedReminder
+          .order(by: \.id)
+          .join(SectionedCategory.all) { $0.category.eq($1.name) }
+          .select { SectionedRow.Columns(title: $0.title, label: $1.label) }
+          .fetchAll(db, sectionBy: { $1.label })
+      }
+
+      #expect(sections.sectionNames == ["At Home", "At Work", "Out & About"])
+      #expect(sections[sectionName: "At Home"]?.map(\.title) == ["Dishes", "Laundry"])
+    }
+
+    @Test func multipleJoins() async throws {
+      let sections = try await database.read { db in
+        try SectionedReminder
+          .order(by: \.id)
+          .join(SectionedCategory.all) { $0.category.eq($1.name) }
+          .join(SectionedPriority.all) { reminder, _, priority in
+            reminder.priority.eq(priority.name)
+          }
+          .select { reminder, category, _ in
+            SectionedRow.Columns(title: reminder.title, label: category.label)
+          }
+          .fetchAll(db, sectionBy: { _, _, priority in priority.label })
+      }
+
+      #expect(sections.sectionNames == ["High!", "Low!"])
+      #expect(sections[sectionName: "High!"]?.map(\.title) == ["Dishes", "Standup"])
+      #expect(sections[sectionName: "Low!"]?.map(\.title) == ["Groceries"])
+    }
+
+    @Test func selectionWithoutJoins() async throws {
+      let sections = try await database.read { db in
+        try SectionedReminder
+          .order(by: \.id)
+          .select { SectionedRow.Columns(title: $0.title, label: $0.category) }
+          .fetchAll(db, sectionBy: { $0.category })
+      }
+
+      #expect(sections.sectionNames == ["Errands", "Home", "Work"])
+      #expect(sections[sectionName: "Home"]?.map(\.label) == ["Home", "Home"])
+    }
+
+    @Test func fetchKeyRequest() async throws {
+      struct Request: FetchKeyRequest {
+        func fetch(_ db: Database) throws -> ResultsSectionCollection<SectionedReminder, String?> {
+          try SectionedReminder.order(by: \.id).fetchAll(db, sectionBy: { $0.category })
+        }
+      }
+
+      @Fetch(Request()) var sections = ResultsSectionCollection<SectionedReminder, String?>()
+      try await $sections.load()
+
+      #expect(sections.sectionNames == ["Errands", "Home", "Work"])
+      #expect(sections[sectionName: "Home"]?.map(\.title) == ["Dishes", "Laundry"])
+    }
+  }
 }
 
 @Table

--- a/Tests/SQLiteDataTests/FetchAllSectionsTests.swift
+++ b/Tests/SQLiteDataTests/FetchAllSectionsTests.swift
@@ -341,11 +341,13 @@ struct FetchAllSectionsTests {
   }
 
   @Test func selectionSectionBy() async throws {
-    let statement =
+    @FetchAll(
       SectionedReminder
-      .order(by: \.id)
-      .select { SectionedRow.Columns(title: $0.title, label: $0.category) }
-    @FetchAll(statement, sectionBy: { $0.category }) var rows
+        .order(by: \.id)
+        .select { SectionedRow.Columns(title: $0.title, label: $0.category) },
+      sectionBy: { $0.category }
+    )
+    var rows
     try await $rows.load()
 
     #expect(rows.map(\.title) == ["Groceries", "Dishes", "Laundry", "Standup", "Review"])
@@ -354,12 +356,14 @@ struct FetchAllSectionsTests {
   }
 
   @Test func joinedSectionBy() async throws {
-    let statement =
+    @FetchAll(
       SectionedReminder
-      .order(by: \.id)
-      .join(SectionedCategory.all) { $0.category.eq($1.name) }
-      .select { SectionedRow.Columns(title: $0.title, label: $1.label) }
-    @FetchAll(statement, sectionBy: { $1.label }) var rows
+        .order(by: \.id)
+        .join(SectionedCategory.all) { $0.category.eq($1.name) }
+        .select { SectionedRow.Columns(title: $0.title, label: $1.label) },
+      sectionBy: { $1.label }
+    )
+    var rows
     try await $rows.load()
 
     #expect(rows.map(\.title) == ["Dishes", "Laundry", "Standup", "Review", "Groceries"])
@@ -369,40 +373,47 @@ struct FetchAllSectionsTests {
   }
 
   @Test func joinedDescendingSectionBy() async throws {
-    let statement =
+    @FetchAll(
       SectionedReminder
-      .order(by: \.id)
-      .join(SectionedCategory.all) { $0.category.eq($1.name) }
-      .select { SectionedRow.Columns(title: $0.title, label: $1.label) }
-    @FetchAll(statement, sectionBy: { $1.label.desc() }) var rows
+        .order(by: \.id)
+        .join(SectionedCategory.all) { $0.category.eq($1.name) }
+        .select { SectionedRow.Columns(title: $0.title, label: $1.label) },
+      sectionBy: { $1.label.desc() }
+    )
+    var rows
     try await $rows.load()
 
     #expect($rows.sections.sectionNames == ["Out & About", "At Work", "At Home"])
   }
 
   @Test func loadJoinedSectionBy() async throws {
-    let statement =
+    @FetchAll(
       SectionedReminder
-      .order(by: \.id)
-      .join(SectionedCategory.all) { $0.category.eq($1.name) }
-      .select { SectionedRow.Columns(title: $0.title, label: $1.label) }
-    @FetchAll(statement) var rows
+        .order(by: \.id)
+        .join(SectionedCategory.all) { $0.category.eq($1.name) }
+        .select { SectionedRow.Columns(title: $0.title, label: $1.label) }
+    )
+    var rows
     try await $rows.load()
     #expect($rows.sections.sectionNames == [nil])
 
-    try await $rows.load(statement, sectionBy: { $1.label })
+    try await $rows.load(
+      SectionedReminder
+        .order(by: \.id)
+        .join(SectionedCategory.all) { $0.category.eq($1.name) }
+        .select { SectionedRow.Columns(title: $0.title, label: $1.label) },
+      sectionBy: { $1.label }
+    )
     #expect(rows.map(\.title) == ["Dishes", "Laundry", "Standup", "Review", "Groceries"])
     #expect($rows.sections.sectionNames == ["At Home", "At Work", "Out & About"])
   }
 
   @Test(arguments: [true, false]) func dynamicJoinedSectionBy(isSectioned: Bool) async throws {
-    let statement =
-      SectionedReminder
-      .order(by: \.id)
-      .join(SectionedCategory.all) { $0.category.eq($1.name) }
-      .select { SectionedRow.Columns(title: $0.title, label: $1.label) }
     @FetchAll(
-      statement,
+      SectionedReminder
+        .order(by: \.id)
+        .join(SectionedCategory.all) { $0.category.eq($1.name) }
+        .select { SectionedRow.Columns(title: $0.title, label: $1.label) },
       sectionBy: {
         if isSectioned {
           $1.label
@@ -420,13 +431,16 @@ struct FetchAllSectionsTests {
   }
 
   @Test func twoJoinsSectionBy() async throws {
-    let statement =
+    @FetchAll(
       SectionedReminder
-      .order(by: \.id)
-      .join(SectionedCategory.all) { $0.category.eq($1.name) }
-      .join(SectionedPriority.all) { reminder, _, priority in reminder.priority.eq(priority.name) }
-      .select { SectionedRow.Columns(title: $0.title, label: $2.label) }
-    @FetchAll(statement, sectionBy: { $2.label }) var rows
+        .order(by: \.id)
+        .join(SectionedCategory.all) { $0.category.eq($1.name) }
+        .join(SectionedPriority.all) { reminder, _, priority in reminder.priority.eq(priority.name)
+        }
+        .select { SectionedRow.Columns(title: $0.title, label: $2.label) },
+      sectionBy: { $2.label }
+    )
+    var rows
     try await $rows.load()
 
     #expect(rows.map(\.title) == ["Dishes", "Standup", "Groceries"])
@@ -436,16 +450,19 @@ struct FetchAllSectionsTests {
   }
 
   @Test func threeJoinsSectionBy() async throws {
-    let statement =
+    @FetchAll(
       SectionedReminder
-      .order(by: \.id)
-      .join(SectionedCategory.all) { $0.category.eq($1.name) }
-      .join(SectionedPriority.all) { reminder, _, priority in reminder.priority.eq(priority.name) }
-      .join(SectionedUrgency.all) { reminder, _, _, urgency in
-        reminder.priority.eq(urgency.name)
-      }
-      .select { SectionedRow.Columns(title: $0.title, label: $3.label) }
-    @FetchAll(statement, sectionBy: { $3.label }) var rows
+        .order(by: \.id)
+        .join(SectionedCategory.all) { $0.category.eq($1.name) }
+        .join(SectionedPriority.all) { reminder, _, priority in reminder.priority.eq(priority.name)
+        }
+        .join(SectionedUrgency.all) { reminder, _, _, urgency in
+          reminder.priority.eq(urgency.name)
+        }
+        .select { SectionedRow.Columns(title: $0.title, label: $3.label) },
+      sectionBy: { $3.label }
+    )
+    var rows
     try await $rows.load()
 
     #expect(rows.map(\.title) == ["Groceries", "Dishes", "Standup"])


### PR DESCRIPTION
Inline sectioned fetches don't currently work if the query includes a join due to a parameter pack bug. We can work around it in a way similar to workarounds present in StructuredQueries: overloads.

- `Joins == ()`
- `Joins: Table`
- `Joins == (repeat each J)`