### PR TITLE
Non-optional sectioning

### DIFF
--- a/Sources/SQLiteData/FetchAll+Sections.swift
+++ b/Sources/SQLiteData/FetchAll+Sections.swift
@@ -1463,12 +1463,12 @@ public struct _Sectioning<Key>: Hashable, Sendable {
   let select: QueryFragment
   let order: QueryFragment
 
-  package init(_ expression: some QueryExpression<some _OptionalPromotable<Key>>) {
+  package init(_ expression: some QueryExpression) {
     self.select = expression.queryFragment
     self.order = expression.queryFragment
   }
 
-  package init(_ orderingTerm: _OrderingTerm<some _OptionalPromotable<Key>>) {
+  package init<Value>(_ orderingTerm: _OrderingTerm<Value>) {
     self.select = orderingTerm.baseQueryFragment
     self.order = orderingTerm.queryFragment
   }
@@ -1476,6 +1476,41 @@ public struct _Sectioning<Key>: Hashable, Sendable {
 
 @resultBuilder
 public enum _SectionBuilder<Key> {
+  public static func buildExpression(
+    _ expression: some QueryExpression<Key>
+  ) -> _Sectioning<Key> {
+    _Sectioning(expression)
+  }
+
+  public static func buildExpression(
+    _ orderingTerm: _OrderingTerm<Key>
+  ) -> _Sectioning<Key> {
+    _Sectioning(orderingTerm)
+  }
+
+  public static func buildBlock(_ component: _Sectioning<Key>) -> _Sectioning<Key> {
+    component
+  }
+
+  @available(
+    *,
+    unavailable,
+    message: "Sectioning is required here. Add an 'else' branch, or section by an optional key."
+  )
+  public static func buildOptional(_ component: _Sectioning<Key>?) -> _Sectioning<Key> {
+    fatalError()
+  }
+
+  public static func buildEither(first component: _Sectioning<Key>) -> _Sectioning<Key> {
+    component
+  }
+
+  public static func buildEither(second component: _Sectioning<Key>) -> _Sectioning<Key> {
+    component
+  }
+}
+
+extension _SectionBuilder where Key: _OptionalProtocol {
   public static func buildExpression(
     _ expression: Never?
   ) -> _Sectioning<Key>? {
@@ -1485,18 +1520,15 @@ public enum _SectionBuilder<Key> {
   @_disfavoredOverload
   public static func buildExpression(
     _ expression: some QueryExpression<some _OptionalPromotable<Key>>
-  ) -> _Sectioning<Key> {
+  ) -> _Sectioning<Key>? {
     _Sectioning(expression)
   }
 
+  @_disfavoredOverload
   public static func buildExpression(
     _ orderingTerm: _OrderingTerm<some _OptionalPromotable<Key>>
-  ) -> _Sectioning<Key> {
+  ) -> _Sectioning<Key>? {
     _Sectioning(orderingTerm)
-  }
-
-  public static func buildBlock(_ component: _Sectioning<Key>) -> _Sectioning<Key> {
-    component
   }
 
   @_disfavoredOverload
@@ -1504,15 +1536,17 @@ public enum _SectionBuilder<Key> {
     component
   }
 
-  public static func buildOptional(_ component: _Sectioning<Key>?) -> _Sectioning<Key>? {
+  public static func buildOptional(_ component: _Sectioning<Key>??) -> _Sectioning<Key>? {
+    component ?? nil
+  }
+
+  @_disfavoredOverload
+  public static func buildEither(first component: _Sectioning<Key>?) -> _Sectioning<Key>? {
     component
   }
 
-  public static func buildEither(first component: _Sectioning<Key>) -> _Sectioning<Key> {
-    component
-  }
-
-  public static func buildEither(second component: _Sectioning<Key>) -> _Sectioning<Key> {
+  @_disfavoredOverload
+  public static func buildEither(second component: _Sectioning<Key>?) -> _Sectioning<Key>? {
     component
   }
 }

--- a/Sources/SQLiteData/StructuredQueries+GRDB/Statement+Sections.swift
+++ b/Sources/SQLiteData/StructuredQueries+GRDB/Statement+Sections.swift
@@ -41,7 +41,7 @@ extension SelectStatement where QueryValue == (), Joins == () {
   public func fetchAll<Key: QueryRepresentable>(
     _ db: Database,
     sectionBy sectionKeyPath: KeyPath<
-      From.TableColumns, some QueryExpression<some _OptionalPromotable<Key>>
+      From.TableColumns, some QueryExpression<Key>
     >
   ) throws -> ResultsSectionCollection<From.QueryOutput, Key.QueryOutput>
   where Key.QueryOutput: Hashable {
@@ -108,7 +108,7 @@ extension Select {
   public func fetchAll<Key: QueryRepresentable>(
     _ db: Database,
     sectionBy sectionKeyPath: KeyPath<
-      From.TableColumns, some QueryExpression<some _OptionalPromotable<Key>>
+      From.TableColumns, some QueryExpression<Key>
     >
   ) throws -> ResultsSectionCollection<QueryValue.QueryOutput, Key.QueryOutput>
   where QueryValue: QueryRepresentable, Joins == (), Key.QueryOutput: Hashable {

--- a/Tests/SQLiteDataTests/FetchAllSectionsTests.swift
+++ b/Tests/SQLiteDataTests/FetchAllSectionsTests.swift
@@ -125,6 +125,77 @@ struct FetchAllSectionsTests {
     )
   }
 
+  @Test(arguments: [true, false]) func ifElseNilSectionBy(byCategory: Bool) async throws {
+    @FetchAll(
+      SectionedReminder.order(by: \.id),
+      sectionBy: {
+        if byCategory {
+          $0.category
+        } else {
+          nil
+        }
+      }
+    )
+    var reminders
+    try await $reminders.load()
+
+    #expect(
+      $reminders.sections.sectionNames == (byCategory ? ["Errands", "Home", "Work"] : [nil])
+    )
+  }
+
+  @Test(arguments: [true, false]) func nestedOptionalSectionBy(isSectioned: Bool) async throws {
+    let byCategory = true
+    @FetchAll(
+      SectionedReminder.order(by: \.id),
+      sectionBy: { columns in
+        if isSectioned {
+          if byCategory {
+            columns.category
+          }
+        }
+      }
+    )
+    var reminders
+    try await $reminders.load()
+
+    #expect(
+      $reminders.sections.sectionNames == (isSectioned ? ["Errands", "Home", "Work"] : [nil])
+    )
+  }
+
+  @Test(arguments: [SectionedReminderSectioning.unsectioned, .category, .priority])
+  func switchNestedOptionalSectionBy(sectioning: SectionedReminderSectioning) async throws {
+    let byCategory = true
+    @FetchAll(
+      SectionedReminder.order(by: \.id),
+      sectionBy: { columns in
+        switch sectioning {
+        case .unsectioned:
+          nil
+        case .category:
+          if byCategory {
+            columns.category
+          } else {
+            nil
+          }
+        case .priority:
+          columns.priority.desc(nulls: .last)
+        }
+      }
+    )
+    var reminders
+    try await $reminders.load()
+
+    let expected: [String?] =
+      switch sectioning {
+      case .unsectioned: [nil]
+      case .category: ["Errands", "Home", "Work"]
+      case .priority: ["low", "high", nil]
+      }
+    #expect($reminders.sections.sectionNames == expected)
+  }
+
   @Test func keyPathSectionBy() async throws {
     @FetchAll(SectionedReminder.order(by: \.id), sectionBy: \.category) var reminders
     try await $reminders.load()
@@ -140,14 +211,6 @@ struct FetchAllSectionsTests {
     try await $reminders.load()
 
     #expect(reminders.count == 5)
-    #expect($reminders.sections.sectionNames == ["Errands", "Home", "Work"])
-  }
-
-  @Test func storedSectioning() async throws {
-    let sectioning: (SectionedReminder.TableColumns) -> _Sectioning? = { _Sectioning($0.category) }
-    @FetchAll(SectionedReminder.order(by: \.id), sectionBy: sectioning) var reminders
-    try await $reminders.load()
-
     #expect($reminders.sections.sectionNames == ["Errands", "Home", "Work"])
   }
 
@@ -531,6 +594,34 @@ struct FetchAllSectionsTests {
       #expect(sections[sectionName: "high"]?.map(\.title) == ["Dishes", "Standup"])
     }
 
+    @Test func nonNullSectionsAreNotOptional() async throws {
+      let sections = try await database.read { db in
+        try SectionedReminder.order(by: \.id).fetchAll(db, sectionBy: { $0.category })
+      }
+
+      let sectionNames: [String] = sections.sectionNames
+      #expect(sectionNames == ["Errands", "Home", "Work"])
+      #expect(sections[sectionName: "Home"]?.name == "Home")
+    }
+
+    @Test func nonNullSectionsAreNotOptionalWithOrdering() async throws {
+      let sections = try await database.read { db in
+        try SectionedReminder.order(by: \.id).fetchAll(db, sectionBy: { $0.category.desc() })
+      }
+
+      let sectionNames: [String] = sections.sectionNames
+      #expect(sectionNames == ["Work", "Home", "Errands"])
+    }
+
+    @Test func nullableSectionsStayOptional() async throws {
+      let sections = try await database.read { db in
+        try SectionedReminder.order(by: \.id).fetchAll(db, sectionBy: { $0.priority })
+      }
+
+      let sectionNames: [String?] = sections.sectionNames
+      #expect(sectionNames == [nil, "high", "low"])
+    }
+
     @Test func integerSections() async throws {
       let sections = try await database.read { db in
         try SectionedReminder
@@ -613,12 +704,12 @@ struct FetchAllSectionsTests {
 
     @Test func fetchKeyRequest() async throws {
       struct Request: FetchKeyRequest {
-        func fetch(_ db: Database) throws -> ResultsSectionCollection<SectionedReminder, String?> {
+        func fetch(_ db: Database) throws -> ResultsSectionCollection<SectionedReminder, String> {
           try SectionedReminder.order(by: \.id).fetchAll(db, sectionBy: { $0.category })
         }
       }
 
-      @Fetch(Request()) var sections = ResultsSectionCollection<SectionedReminder, String?>()
+      @Fetch(Request()) var sections = ResultsSectionCollection<SectionedReminder, String>()
       try await $sections.load()
 
       #expect(sections.sectionNames == ["Errands", "Home", "Work"])
@@ -639,6 +730,12 @@ private struct SectionedReminder: Equatable, Identifiable {
 private struct SectionedRow: Equatable {
   var title = ""
   var label = ""
+}
+
+enum SectionedReminderSectioning: Sendable {
+  case unsectioned
+  case category
+  case priority
 }
 
 @Table


### PR DESCRIPTION
Our section builder was generalized beyond optional strings late in its design, leaving it in an incomplete state. Non-optional string sections produced by `Statement.fetchAll(sectionBy:)` were still optional when they didn't need to be.

This PR closes the gap and improves a few edge cases around section builders and optionality, where nested branches with optionality could fail to compile.