### PR TITLE
use typed throws in SQLite query/function decoder

### DIFF
--- a/Sources/SQLiteData/StructuredQueries+GRDB/SQLiteFunctionDecoder.swift
+++ b/Sources/SQLiteData/StructuredQueries+GRDB/SQLiteFunctionDecoder.swift
@@ -34,7 +34,7 @@ struct SQLiteFunctionDecoder: QueryDecoder {
   }
 
   @inlinable
-  mutating func decode(_ columnType: [UInt8].Type) throws -> [UInt8]? {
+  mutating func decode(_ columnType: [UInt8].Type) throws(QueryDecodingError) -> [UInt8]? {
     precondition(argumentCount > currentIndex)
     let value = arguments?[Int(currentIndex)]
     switch sqlite3_value_type(value) {
@@ -57,18 +57,22 @@ struct SQLiteFunctionDecoder: QueryDecoder {
   }
 
   @inlinable
-  mutating func decode(_ columnType: Bool.Type) throws -> Bool? {
+  mutating func decode(_ columnType: Bool.Type) throws(QueryDecodingError) -> Bool? {
     try decode(Int64.self).map { $0 != 0 }
   }
 
   @usableFromInline
-  mutating func decode(_ columnType: Date.Type) throws -> Date? {
-    guard let iso8601String = try decode(String.self) else { return nil }
-    return try Date(iso8601String: iso8601String)
+  mutating func decode(_ columnType: Date.Type) throws(QueryDecodingError) -> Date? {
+    do {
+      guard let iso8601String = try decode(String.self) else { return nil }
+      return try Date(iso8601String: iso8601String)
+    } catch {
+      throw .other(error)
+    }
   }
 
   @inlinable
-  mutating func decode(_ columnType: Double.Type) throws -> Double? {
+  mutating func decode(_ columnType: Double.Type) throws(QueryDecodingError) -> Double? {
     precondition(argumentCount > currentIndex)
     let value = arguments?[Int(currentIndex)]
     switch sqlite3_value_type(value) {
@@ -85,12 +89,12 @@ struct SQLiteFunctionDecoder: QueryDecoder {
   }
 
   @inlinable
-  mutating func decode(_ columnType: Int.Type) throws -> Int? {
+  mutating func decode(_ columnType: Int.Type) throws(QueryDecodingError) -> Int? {
     try decode(Int64.self).map(Int.init)
   }
 
   @inlinable
-  mutating func decode(_ columnType: Int64.Type) throws -> Int64? {
+  mutating func decode(_ columnType: Int64.Type) throws(QueryDecodingError) -> Int64? {
     precondition(argumentCount > currentIndex)
     let value = arguments?[Int(currentIndex)]
     switch sqlite3_value_type(value) {
@@ -107,7 +111,7 @@ struct SQLiteFunctionDecoder: QueryDecoder {
   }
 
   @inlinable
-  mutating func decode(_ columnType: String.Type) throws -> String? {
+  mutating func decode(_ columnType: String.Type) throws(QueryDecodingError) -> String? {
     precondition(argumentCount > currentIndex)
     let value = arguments?[Int(currentIndex)]
     switch sqlite3_value_type(value) {
@@ -124,20 +128,20 @@ struct SQLiteFunctionDecoder: QueryDecoder {
   }
 
   @inlinable
-  mutating func decode(_ columnType: UInt64.Type) throws -> UInt64? {
+  mutating func decode(_ columnType: UInt64.Type) throws(QueryDecodingError) -> UInt64? {
     guard let n = try decode(Int64.self) else { return nil }
-    guard n >= 0 else { throw UInt64OverflowError(signedInteger: n) }
+    guard n >= 0 else { throw .other(UInt64OverflowError(signedInteger: n)) }
     return UInt64(n)
   }
 
   @usableFromInline
-  mutating func decode(_ columnType: UUID.Type) throws -> UUID? {
+  mutating func decode(_ columnType: UUID.Type) throws(QueryDecodingError) -> UUID? {
     guard let uuidString = try decode(String.self) else { return nil }
     return UUID(uuidString: uuidString)
   }
 
   @usableFromInline
-  func reportTypeMismatch(_ columnType: Any.Type) throws {
+  func reportTypeMismatch(_ columnType: Any.Type) throws(QueryDecodingError) {
     #if StrictDecoding
       throw QueryDecodingError.typeMismatch(columnType)
     #else

--- a/Sources/SQLiteData/StructuredQueries+GRDB/SQLiteFunctionDecoder.swift
+++ b/Sources/SQLiteData/StructuredQueries+GRDB/SQLiteFunctionDecoder.swift
@@ -63,8 +63,8 @@ struct SQLiteFunctionDecoder: QueryDecoder {
 
   @usableFromInline
   mutating func decode(_ columnType: Date.Type) throws(QueryDecodingError) -> Date? {
+    guard let iso8601String = try decode(String.self) else { return nil }
     do {
-      guard let iso8601String = try decode(String.self) else { return nil }
       return try Date(iso8601String: iso8601String)
     } catch {
       throw .other(error)

--- a/Sources/SQLiteData/StructuredQueries+GRDB/SQLiteQueryDecoder.swift
+++ b/Sources/SQLiteData/StructuredQueries+GRDB/SQLiteQueryDecoder.swift
@@ -52,8 +52,9 @@ struct SQLiteQueryDecoder: QueryDecoder {
 
   @inlinable
   mutating func decode(_ columnType: Date.Type) throws(QueryDecodingError) -> Date? {
+    guard let iso8601String = try decode(String.self) else { return nil }
     do {
-      return try decode(String.self).map { try Date(iso8601String: $0) }
+      return try Date(iso8601String: iso8601String) }
     } catch {
       throw .other(error)
     }

--- a/Sources/SQLiteData/StructuredQueries+GRDB/SQLiteQueryDecoder.swift
+++ b/Sources/SQLiteData/StructuredQueries+GRDB/SQLiteQueryDecoder.swift
@@ -26,7 +26,7 @@ struct SQLiteQueryDecoder: QueryDecoder {
   }
 
   @inlinable
-  mutating func decode(_ columnType: [UInt8].Type) throws -> [UInt8]? {
+  mutating func decode(_ columnType: [UInt8].Type) throws(QueryDecodingError) -> [UInt8]? {
     switch sqlite3_column_type(statement, currentIndex) {
     case SQLITE_NULL:
       currentIndex += 1
@@ -46,17 +46,21 @@ struct SQLiteQueryDecoder: QueryDecoder {
   }
 
   @inlinable
-  mutating func decode(_ columnType: Bool.Type) throws -> Bool? {
+  mutating func decode(_ columnType: Bool.Type) throws(QueryDecodingError) -> Bool? {
     try decode(Int64.self).map { $0 != 0 }
   }
 
   @inlinable
-  mutating func decode(_ columnType: Date.Type) throws -> Date? {
-    try decode(String.self).map { try Date(iso8601String: $0) }
+  mutating func decode(_ columnType: Date.Type) throws(QueryDecodingError) -> Date? {
+    do {
+      return try decode(String.self).map { try Date(iso8601String: $0) }
+    } catch {
+      throw .other(error)
+    }
   }
 
   @inlinable
-  mutating func decode(_ columnType: Double.Type) throws -> Double? {
+  mutating func decode(_ columnType: Double.Type) throws(QueryDecodingError) -> Double? {
     switch sqlite3_column_type(statement, currentIndex) {
     case SQLITE_NULL:
       currentIndex += 1
@@ -71,12 +75,12 @@ struct SQLiteQueryDecoder: QueryDecoder {
   }
 
   @inlinable
-  mutating func decode(_ columnType: Int.Type) throws -> Int? {
+  mutating func decode(_ columnType: Int.Type) throws(QueryDecodingError) -> Int? {
     try decode(Int64.self).map(Int.init)
   }
 
   @inlinable
-  mutating func decode(_ columnType: Int64.Type) throws -> Int64? {
+  mutating func decode(_ columnType: Int64.Type) throws(QueryDecodingError) -> Int64? {
     switch sqlite3_column_type(statement, currentIndex) {
     case SQLITE_NULL:
       currentIndex += 1
@@ -91,7 +95,7 @@ struct SQLiteQueryDecoder: QueryDecoder {
   }
 
   @inlinable
-  mutating func decode(_ columnType: String.Type) throws -> String? {
+  mutating func decode(_ columnType: String.Type) throws(QueryDecodingError) -> String? {
     switch sqlite3_column_type(statement, currentIndex) {
     case SQLITE_NULL:
       currentIndex += 1
@@ -106,21 +110,21 @@ struct SQLiteQueryDecoder: QueryDecoder {
   }
 
   @inlinable
-  mutating func decode(_ columnType: UInt64.Type) throws -> UInt64? {
+  mutating func decode(_ columnType: UInt64.Type) throws(QueryDecodingError) -> UInt64? {
     guard let n = try decode(Int64.self) else { return nil }
-    guard n >= 0 else { throw UInt64OverflowError(signedInteger: n) }
+    guard n >= 0 else { throw .other(UInt64OverflowError(signedInteger: n)) }
     return UInt64(n)
   }
 
   @inlinable
-  mutating func decode(_ columnType: UUID.Type) throws -> UUID? {
+  mutating func decode(_ columnType: UUID.Type) throws(QueryDecodingError) -> UUID? {
     guard let uuidString = try decode(String.self) else { return nil }
-    guard let uuid = UUID(uuidString: uuidString) else { throw InvalidUUID() }
+    guard let uuid = UUID(uuidString: uuidString) else { throw .other(InvalidUUID()) }
     return uuid
   }
 
   @usableFromInline
-  func reportTypeMismatch(_ columnType: Any.Type) throws {
+  func reportTypeMismatch(_ columnType: Any.Type) throws(QueryDecodingError) {
     #if StrictDecoding
       throw QueryDecodingError.typeMismatch(columnType)
     #else


### PR DESCRIPTION
This prevents an allocation, particularly on type mismatch, improving performance for columns containing multiple data types.

See https://github.com/pointfreeco/sqlite-data/discussions/488#discussioncomment-17601879 for details on performance benchmarks.

This depends on https://github.com/pointfreeco/swift-structured-queries/pull/339 for the new error case.