### PR TITLE
Add GRDBDynamic trait.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,10 @@ let package = Package(
       description: "Introduce support for enum tables."
     ),
     .trait(
+      name: "GRDBDynamic",
+      description: "Link the GRDB-dynamic library instead of the static GRDB library."
+    ),
+    .trait(
       name: "SuppressPlatformSQLiteAvailability",
       description: """
         Suppress '@available' checks on APIs that depend on a newer version of SQLite than the one \
@@ -82,6 +86,11 @@ let package = Package(
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "Dependencies", package: "swift-dependencies"),
         .product(name: "GRDB", package: "GRDB.swift"),
+        .product(
+          name: "GRDB-dynamic",
+          package: "GRDB.swift",
+          condition: .when(traits: ["GRDBDynamic"])
+        ),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         .product(name: "OrderedCollections", package: "swift-collections"),
         .product(name: "Perception", package: "swift-perception"),


### PR DESCRIPTION
## Context

`SQLiteData` currently links the static `GRDB` library from GRDB.swift, which offers two products: `GRDB` (static) and `GRDB-dynamic`. [GRDB's documentation](https://github.com/groue/GRDB.swift#swift-package-manager) recommends `GRDB-dynamic` when a package is linked into multiple targets within a single app, so all targets share one dynamic framework instead of each embedding a copy of the GRDB code.

When `SQLiteData` is consumed by several frameworks in the same app (e.g. a multi-framework project), the statically embedded GRDB code causes conflicts.

## Changes

- Adds a `GRDBDynamic` trait to the package.
- When the trait is enabled, `SQLiteData` links the `GRDB-dynamic` product of GRDB.swift instead of the static `GRDB` product.
- The default behavior is unchanged: without the trait, the static `GRDB` library is linked as before.

## Usage

Enable the trait when declaring the dependency (requires SwiftPM 6.1+):

```swift
.package(url: "https://github.com/pointfreeco/sqlite-data", from: "…", traits: ["GRDBDynamic"])
```

## Verification

- `swift build` (default) and `swift build --traits GRDBDynamic` both pass; the trait-enabled build produces `libGRDB-dynamic.dylib`.
- Verified in a production app with multiple frameworks (Swift ≥ 6.1).
- `Package@swift-6.0.swift` is untouched (traits require SwiftPM 6.1+, so the 6.0 fallback keeps the static `GRDB`).