### PR TITLE
Surface `ColumnCoding` trait through SQLiteData

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,12 +23,16 @@ let package = Package(
   ],
   traits: [
     .trait(
-      name: "LazyInitializableByDefault",
-      description: "Optionalize draft properties that have no default."
-    ),
-    .trait(
       name: "CasePaths",
       description: "Introduce support for enum tables."
+    ),
+    .trait(
+      name: "ColumnCoding",
+      description: "Align the Codable coding of tables and selections with their column names."
+    ),
+    .trait(
+      name: "LazyInitializableByDefault",
+      description: "Optionalize draft properties that have no default."
     ),
     .trait(
       name: "SuppressPlatformSQLiteAvailability",
@@ -67,11 +71,8 @@ let package = Package(
       url: "https://github.com/pointfreeco/swift-structured-queries",
       from: "0.36.0",
       traits: [
-        .trait(
-          name: "LazyInitializableByDefault",
-          condition: .when(traits: ["LazyInitializableByDefault"])
-        ),
         .trait(name: "CasePaths", condition: .when(traits: ["CasePaths"])),
+        .trait(name: "ColumnCoding", condition: .when(traits: ["ColumnCoding"])),
         .trait(
           name: "LazyInitializableByDefault",
           condition: .when(traits: ["LazyInitializableByDefault"])


### PR DESCRIPTION
This adds an explicit passthrough trait like we have for other StructuredQueries traits.