### PR TITLE
Adopt typed throws for `init(decoder:)`

### DIFF
--- a/Examples/Reminders/Helpers.swift
+++ b/Examples/Reminders/Helpers.swift
@@ -43,7 +43,7 @@ extension Color {
       return .int(hexValue)
     }
 
-    public init(decoder: inout some QueryDecoder) throws {
+    public init(decoder: inout some QueryDecoder) throws(QueryDecodingError) {
       try self.init(hexValue: Int64(decoder: &decoder))
     }
   }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c23a65a671a050ad4a9a14e2506d4c5d127c928aa245e735949f4e4891331401",
+  "originHash" : "ba6d4e90e9607818435d4f4d30b5042ffb70e5a99e3406a72f0f448c58ce9fb7",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "8dc1fbf2f6255a73dec53b4648164884898db4c5",
-        "version" : "1.14.1"
+        "revision" : "9381ab822de01c4e9f3a7eb8eabb6ae808febed3",
+        "version" : "1.15.0"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "8a733f414adc1224c5185c3a35c30ee1ef217171",
-        "version" : "0.36.0"
+        "branch" : "typed-decoding",
+        "revision" : "3e647860eab2e63825ed447cbbeac24123b9bcd0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -65,7 +65,8 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.4"),
     .package(
       url: "https://github.com/pointfreeco/swift-structured-queries",
-      from: "0.36.0",
+      // from: "0.36.0",
+      branch: "typed-decoding",
       traits: [
         .trait(
           name: "LazyInitializableByDefault",

--- a/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKit+StructuredQueries.swift
@@ -41,16 +41,16 @@
       try? self.init(data: Data(bytes))
     }
 
-    public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+    public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws(QueryDecodingError) {
       try self.init(data: try Data(decoder: &decoder))
     }
 
-    private init(data: Data) throws {
-      let coder = try NSKeyedUnarchiver(forReadingFrom: data)
+    private init(data: Data) throws(QueryDecodingError) {
+      guard let coder = try? NSKeyedUnarchiver(forReadingFrom: data)
+      else { throw .dataCorrupted }
       coder.requiresSecureCoding = true
-      guard let queryOutput = Record(coder: coder) else {
-        throw DecodingError()
-      }
+      guard let queryOutput = Record(coder: coder)
+      else { throw .dataCorrupted }
       if isTesting {
         queryOutput._recordChangeTag =
           coder
@@ -58,8 +58,6 @@
       }
       self.init(queryOutput: queryOutput)
     }
-
-    private struct DecodingError: Error {}
   }
 
   public struct _AllFieldsRepresentation<Record: CKRecord>: QueryBindable, QueryRepresentable {
@@ -83,15 +81,16 @@
       try? self.init(data: Data(bytes))
     }
 
-    public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+    public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws(QueryDecodingError) {
       try self.init(data: try Data(decoder: &decoder))
     }
 
-    private init(data: Data) throws {
-      let coder = try NSKeyedUnarchiver(forReadingFrom: data)
+    private init(data: Data) throws(QueryDecodingError) {
+      guard let coder = try? NSKeyedUnarchiver(forReadingFrom: data)
+      else { throw .dataCorrupted }
       coder.requiresSecureCoding = true
       guard let queryOutput = Record(coder: coder) else {
-        throw DecodingError()
+        throw .dataCorrupted
       }
       if isTesting {
         queryOutput._recordChangeTag =
@@ -117,16 +116,14 @@
         guard case .int(let rawValue) = queryBinding else { return nil }
         try? self.init(rawValue: Int(rawValue))
       }
-      public init(decoder: inout some QueryDecoder) throws {
+      public init(decoder: inout some QueryDecoder) throws(QueryDecodingError) {
         try self.init(rawValue: Int(decoder: &decoder))
       }
-      private init(rawValue: Int) throws {
-        guard let queryOutput = CKDatabase.Scope(rawValue: rawValue) else {
-          throw DecodingError()
-        }
+      private init(rawValue: Int) throws(QueryDecodingError) {
+        guard let queryOutput = CKDatabase.Scope(rawValue: rawValue)
+        else { throw .dataCorrupted }
         self.init(queryOutput: queryOutput)
       }
-      private struct DecodingError: Error {}
     }
   }
 

--- a/Sources/SQLiteData/CloudKit/Internal/PendingRecordZoneChange.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/PendingRecordZoneChange.swift
@@ -48,15 +48,18 @@
         try? self.init(data: Data(bytes))
       }
 
-      package init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+      package init(
+        decoder: inout some StructuredQueriesCore.QueryDecoder
+      ) throws(QueryDecodingError) {
         try self.init(data: Data(decoder: &decoder))
       }
 
-      private init(data: Data) throws {
-        let coder = try NSKeyedUnarchiver(forReadingFrom: data)
+      private init(data: Data) throws(QueryDecodingError) {
+        guard let coder = try? NSKeyedUnarchiver(forReadingFrom: data)
+        else { throw .dataCorrupted }
         coder.requiresSecureCoding = true
         guard let recordID = CKRecord.ID(coder: coder) else {
-          throw DecodingError()
+          throw .dataCorrupted
         }
         let changeType = coder.decodeObject(of: NSString.self, forKey: "changeType") as? String
         switch changeType {
@@ -65,12 +68,11 @@
         case "deleteRecord":
           self.init(queryOutput: .deleteRecord(recordID))
         default:
-          throw DecodingError()
+          throw .dataCorrupted
         }
       }
     }
 
-    private struct DecodingError: Error {}
     private struct BindingError: Error {}
   }
 #endif


### PR DESCRIPTION
Depends on https://github.com/pointfreeco/swift-structured-queries/pull/350

There's also some backwards compatibility we could discuss.