### PR TITLE
Re-record snapshots

### DIFF
--- a/Tests/SQLiteDataTests/CloudKitTests/AccountLifecycleTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/AccountLifecycleTests.swift
@@ -40,7 +40,7 @@
       }
 
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-      @Test($accountStatus.set(.noAccount))
+      @Test(.taskLocal($accountStatus, .noAccount))
       func signInUploadsLocalRecordsToCloudKit() async throws {
         try await userDatabase.userWrite { db in
           try db.seed {
@@ -608,8 +608,8 @@
 
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     @Test(
-      $accountStatus.set(.noAccount),
-      $prepareDatabase.set { userDatabase in
+      .taskLocal($accountStatus, .noAccount),
+      .taskLocal($prepareDatabase) { userDatabase in
         try await userDatabase.write { db in
           try db.seed {
             RemindersList(id: 1, title: "Personal")

--- a/Tests/SQLiteDataTests/CloudKitTests/AttachedMetadatabaseTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/AttachedMetadatabaseTests.swift
@@ -13,7 +13,7 @@
 
   extension BaseCloudKitTests {
     @MainActor
-    @Suite($attachMetadatabase.set(false))
+    @Suite(.taskLocal($attachMetadatabase, false))
     final class AttachedMetadatabaseTests: BaseCloudKitTests, @unchecked Sendable {
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func basics() async throws {

--- a/Tests/SQLiteDataTests/CloudKitTests/MetadataTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/MetadataTests.swift
@@ -625,7 +625,7 @@
       }
 
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-      @Test($attachMetadatabase.set(true))
+      @Test(.taskLocal($attachMetadatabase, true))
       func observation() async throws {
         let remindersList = RemindersList(id: 1, title: "Personal")
         try await userDatabase.userWrite { db in
@@ -654,7 +654,7 @@
       }
 
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-      @Test($attachMetadatabase.set(true))
+      @Test(.taskLocal($attachMetadatabase, true))
       func observation_GeneratedColumn() async throws {
         let remindersList = RemindersList(id: 1, title: "Personal")
         try await userDatabase.userWrite { db in

--- a/Tests/SQLiteDataTests/CloudKitTests/NewTableSyncTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/NewTableSyncTests.swift
@@ -13,7 +13,7 @@
   extension BaseCloudKitTests {
     @MainActor
     @Suite(
-      $prepareDatabase.set { userDatabase in
+      .taskLocal($prepareDatabase) { userDatabase in
         try await userDatabase.userWrite { db in
           try db.seed {
             RemindersList(id: 1, title: "Personal")

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineDelegateTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineDelegateTests.swift
@@ -16,7 +16,7 @@
     final class SyncEngineDelegateTests: BaseCloudKitTests, @unchecked Sendable {
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
 
-      @Test($syncEngineDelegate.set(MyDelegate()))
+      @Test(.taskLocal($syncEngineDelegate, MyDelegate()))
       func accountChanged() async throws {
         try await userDatabase.userWrite { db in
           try db.seed {
@@ -175,7 +175,7 @@
         try await syncEngine.processPendingDatabaseChanges(scope: .private)
       }
 
-      @Test($syncEngineDelegate.set(DefaultImplementationDelegate()))
+      @Test(.taskLocal($syncEngineDelegate, DefaultImplementationDelegate()))
       func accountChanged_DefaultImplementation() async throws {
         try await userDatabase.userWrite { db in
           try db.seed {

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineLifecycleTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineLifecycleTests.swift
@@ -582,7 +582,7 @@
         // * Start sync engine
         // * Verify that data is sent to CloudKit database and cached locally.
         @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-        @Test($startImmediately.set(false))
+        @Test(.taskLocal($startImmediately, false))
         func writeAndThenStart() async throws {
           try await userDatabase.userWrite { db in
             try db.seed {

--- a/Tests/SQLiteDataTests/CloudKitTests/TriggerTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/TriggerTests.swift
@@ -1420,7 +1420,7 @@
               FOR EACH ROW WHEN (("new"."zoneName") <> ("old"."zoneName")) OR (("new"."ownerName") <> ("old"."ownerName")) BEGIN
                 UPDATE "sqlitedata_icloud_metadata"
                 SET "zoneName" = "new"."zoneName", "ownerName" = "new"."ownerName", "lastKnownServerRecord" = NULL, "_lastKnownServerRecordAllFields" = NULL
-                WHERE (("sqlitedata_icloud_metadata"."recordName") IN ((WITH "descendantMetadatas" AS (
+                WHERE (("sqlitedata_icloud_metadata"."recordName") IN (WITH "descendantMetadatas" AS (
                   SELECT "sqlitedata_icloud_metadata"."recordName" AS "recordName", NULL AS "parentRecordName"
                   FROM "sqlitedata_icloud_metadata"
                   WHERE (("sqlitedata_icloud_metadata"."recordName") = ("new"."recordName"))
@@ -1430,7 +1430,7 @@
                   JOIN "descendantMetadatas" ON ("sqlitedata_icloud_metadata"."parentRecordName") = ("descendantMetadatas"."recordName")
                 )
                 SELECT "descendantMetadatas"."recordName"
-                FROM "descendantMetadatas")));
+                FROM "descendantMetadatas"));
               END
               """
             ]

--- a/Tests/SQLiteDataTests/Internal/BaseCloudKitTests.swift
+++ b/Tests/SQLiteDataTests/Internal/BaseCloudKitTests.swift
@@ -7,7 +7,7 @@
   import SQLiteData
   import SnapshotTesting
   import Testing
-import TestLocals
+  import TestLocals
   import os
 
   @Suite(
@@ -17,7 +17,7 @@ import TestLocals
       $0.continuousClock = TestClock<Duration>()
       $0.dataManager = InMemoryDataManager()
     },
-    $attachMetadatabase.set(false)
+    .taskLocal($attachMetadatabase, false)
   )
   class BaseCloudKitTests: @unchecked Sendable {
     let userDatabase: UserDatabase


### PR DESCRIPTION
StructuredQueries has a bug fix with `IN` subquery rendering that we should pull in.