### PR TITLE
[WIP] feat: add a method to force sync the syncEngine without deleting the local data

### DIFF
--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -759,17 +759,26 @@
     /// > Important: It is only appropriate to call this method when the device's iCloud account
     /// > logs out or changes.
     public func deleteLocalData() async throws {
+      try await refreshLocalData(shouldReset: true)
+    }
+
+    /// Restarts the sync engine and triggers a new synchronization cycle.
+    /// This works around a known `CKSyncEngine` behavior where pending
+    /// remote changes may not be fetched until another sync trigger occurs.
+    public func refreshLocalData(shouldReset: Bool = false) async throws {
       stop()
       try tearDownSyncEngine()
       await withErrorReporting(.sqliteDataCloudKitFailure) {
         try await userDatabase.write { db in
-          for table in tables {
-            func open<T>(_: some SynchronizableTable<T>) {
-              withErrorReporting(.sqliteDataCloudKitFailure) {
-                try T.delete().execute(db)
+          if shouldReset {
+            for table in tables {
+              func open<T>(_: some SynchronizableTable<T>) {
+                withErrorReporting(.sqliteDataCloudKitFailure) {
+                  try T.delete().execute(db)
+                }
               }
+              open(table)
             }
-            open(table)
           }
           try setUpSyncEngine(writableDB: db)
         }


### PR DESCRIPTION
Based on the very recent conversation [in Slack](https://pointfreecommunity.slack.com/archives/C08CZUG4Z9D/p1786892634659759?thread_ts=1786879103.115709&cid=C08CZUG4Z9D), I found that tearing down and setting up the sync engine forces it to synchronize changes with CloudKit.

I think the underlying issue is likely related to the sync triggers, but this workaround works for now.

Also, to keep a single source of truth, I reused the existing implementation by adding an argument to the existing function instead of introducing a separate code path.

Please take a look, test, and let me know what you think.