### PR TITLE
feat: expose recovery actions only for recoverable `SyncEngine.SharingError`s

### DIFF
--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -33,12 +33,27 @@
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension SyncEngine {
+    /// Describes an action that can be performed by the caller to recover from
+    /// an error and retry the failed operation.
     public enum RecoveryAction {
+      /// No sync metadata found for record. Has the record been saved to the database
+      /// and synchronized to iCloud? Invoke 'SyncEngine.sendChanges()' to force
+      /// synchronization.
       case sendChangesAndRetry
+      /// Sync engine is not running. Make sure engine is running by invoking the 'start()'
+      /// method, or using the 'startImmediately' argument when initializing the engine.
       case startAndRetry
     }
 
+    /// A protocol for errors that provide a system-defined recovery action.
+    ///
+    /// A conforming error may provide a recovery action when the failed
+    /// operation can potentially succeed after performing an additional
+    /// synchronization operation.
     public protocol RecoverableSharingError: LocalizedError {
+      /// The recovery action that can be performed before retrying the
+      /// failed operation, or `nil` when no automatic recovery action
+      /// is available.
       var recoveryAction: RecoveryAction? { get }
     }
   }

--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -35,7 +35,7 @@
   extension SyncEngine {
     /// Describes an action that can be performed by the caller to recover from
     /// an error and retry the failed operation.
-    public enum RecoveryAction {
+    public enum SharingErrorRecoveryAction {
       /// No sync metadata found for record. Has the record been saved to the database
       /// and synchronized to iCloud? Invoke 'SyncEngine.sendChanges()' to force
       /// synchronization.
@@ -54,13 +54,13 @@
       /// The recovery action that can be performed before retrying the
       /// failed operation, or `nil` when no automatic recovery action
       /// is available.
-      var recoveryAction: RecoveryAction? { get }
+      var recoveryAction: SharingErrorRecoveryAction? { get }
     }
   }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension SyncEngine.SharingError: SyncEngine.RecoverableSharingError {
-    var recoveryAction: SyncEngine.RecoveryAction? {
+    var recoveryAction: SyncEngine.SharingErrorRecoveryAction? {
       switch reason {
       case .shareCouldNotBeCreated: nil
       case .recordMetadataNotFound: .sendChangesAndRetry

--- a/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
+++ b/Sources/SQLiteData/CloudKit/CloudKitSharing.swift
@@ -33,7 +33,33 @@
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension SyncEngine {
-    private struct SharingError: LocalizedError {
+    public enum RecoveryAction {
+      case sendChangesAndRetry
+      case startAndRetry
+    }
+
+    public protocol RecoverableSharingError: LocalizedError {
+      var recoveryAction: RecoveryAction? { get }
+    }
+  }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension SyncEngine.SharingError: SyncEngine.RecoverableSharingError {
+    var recoveryAction: SyncEngine.RecoveryAction? {
+      switch reason {
+      case .shareCouldNotBeCreated: nil
+      case .recordMetadataNotFound: .sendChangesAndRetry
+      case .recordNotRoot: nil
+      case .recordTableNotSynchronized: nil
+      case .recordTablePrivate: nil
+      case .syncEngineNotRunning: .startAndRetry
+      }
+    }
+  }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension SyncEngine {
+    fileprivate struct SharingError: LocalizedError {
       enum Reason {
         case shareCouldNotBeCreated
         case recordMetadataNotFound

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -86,7 +86,7 @@
         let recoverable = try #require(error as? any SyncEngine.RecoverableSharingError)
         assertInlineSnapshot(of: recoverable.recoveryAction, as: .customDump) {
         """
-        SyncEngine.RecoveryAction.startAndRetry
+        SyncEngine.SharingErrorRecoveryAction.startAndRetry
         """
         }
       }
@@ -327,7 +327,7 @@
         let recoverable = try #require(error as? any SyncEngine.RecoverableSharingError)
         assertInlineSnapshot(of: recoverable.recoveryAction, as: .customDump) {
         """
-        SyncEngine.RecoveryAction.sendChangesAndRetry
+        SyncEngine.SharingErrorRecoveryAction.sendChangesAndRetry
         """
         }
       }

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -82,6 +82,13 @@
           )
           """#
         }
+
+        let recoverable = try #require(error as? any SyncEngine.RecoverableSharingError)
+        assertInlineSnapshot(of: recoverable.recoveryAction, as: .customDump) {
+        """
+        SyncEngine.RecoveryAction.startAndRetry
+        """
+        }
       }
 
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
@@ -315,6 +322,13 @@
             debugDescription: "No sync metadata found for record. Has the record been saved to the database and synchronized to iCloud? Invoke \'SyncEngine.sendChanges()\' to force synchronization."
           )
           """#
+        }
+
+        let recoverable = try #require(error as? any SyncEngine.RecoverableSharingError)
+        assertInlineSnapshot(of: recoverable.recoveryAction, as: .customDump) {
+        """
+        SyncEngine.RecoveryAction.sendChangesAndRetry
+        """
         }
       }
 


### PR DESCRIPTION
## Summary

Expose a public recovery action for `SyncEngine.SharingError` without making the error type itself public.

This allows callers to determine when a sharing operation can be recovered by starting the sync engine or sending pending changes and retrying.

### Usage

For example, a sharing operation can use the recovery action to synchronize the engine and retry when possible:

```swift
do {
  sharedRecord = try await syncEngine.share(record: myRecord) { ... }
} catch let error as SyncEngine.RecoverableSharingError {
  switch error.recoveryAction {
  case .sendChangesAndRetry: try await syncEngine.sendChanges()
  case .startAndRetry: try await syncEngine.start()
  case .none: throw error // Re-throws unrecoverable errors
  }
  sharedRecord = try await syncEngine.share(record: myRecord) { ... }
}
```

### Motivation

Following the recent [thread on the sqlite-data Slack channel](https://pointfreecommunity.slack.com/archives/C08CZUG4Z9D/p1787338631450289), it turns out that `SharingError` is currently private, but some of its errors provide actionable recovery guidance in their `debugDescription`.

For example, `.recordMetadataNotFound` explicitly suggests calling `sendChanges()` to force synchronization:
https://github.com/pointfreeco/sqlite-data/blob/f6bd67aaff68cfbbed7f0a575248306a70d3e3ae/Sources/SQLiteData/CloudKit/CloudKitSharing.swift#L138-L143

Without a public recovery API, callers cannot reliably identify this condition and perform the suggested recovery.

This change exposes the recovery contract while keeping the underlying `SharingError` and its internal reasons private.

### Changes

- Add `SyncEngine.SharingErrorRecoveryAction`.
- Add `SyncEngine.RecoverableSharingError` to expose recovery actions without exposing `SharingError`.
- Provide `.startAndRetry` for `.syncEngineNotRunning`.
- Provide `.sendChangesAndRetry` for `.recordMetadataNotFound`.
- Add tests covering the exposed recovery actions following the existing testing pattern and using inline snapshots.