### PR TITLE
ID `@Fetch*.load` events to fix cancel race

### DIFF
--- a/Sources/SQLiteData/Fetch.swift
+++ b/Sources/SQLiteData/Fetch.swift
@@ -39,12 +39,16 @@ public struct Fetch<Value: Sendable>: Sendable {
     private let box: FetchBox<Value>
     private let state: SwiftUI.State<FetchBox<Value>>
     private let generation = SwiftUI.State(wrappedValue: 0)
+
+    var loadGeneration: LoadGeneration { state.wrappedValue.loadGeneration }
   #else
     /// The underlying shared reader powering the property wrapper.
     ///
     /// Shared readers come from the [Sharing](https://github.com/pointfreeco/swift-sharing)
     /// package, a general solution to observing and persisting changes to external data sources.
     public let sharedReader: SharedReader<Value>
+
+    let loadGeneration = LoadGeneration()
   #endif
 
   /// Data associated with the underlying query.
@@ -58,7 +62,10 @@ public struct Fetch<Value: Sendable>: Sendable {
   /// ``isLoading``, and ``publisher``.
   public var projectedValue: Self {
     get { self }
-    nonmutating set { sharedReader.projectedValue = newValue.sharedReader.projectedValue }
+    nonmutating set {
+      loadGeneration.invalidate()
+      sharedReader.projectedValue = newValue.sharedReader.projectedValue
+    }
   }
 
   /// Returns a ``sharedReader`` for the given key path.
@@ -127,8 +134,15 @@ public struct Fetch<Value: Sendable>: Sendable {
     _ request: some FetchKeyRequest<Value>,
     database: (any DatabaseReader)? = nil
   ) async throws -> FetchSubscription {
-    try await sharedReader.load(.fetch(request, database: database))
-    return FetchSubscription(sharedReader: sharedReader)
+    try await withSubscription {
+      try await sharedReader.load(.fetch(request, database: database))
+    }
+  }
+
+  private func withSubscription(_ load: () async throws -> Void) async throws -> FetchSubscription {
+    let token = loadGeneration.begin()
+    try await load()
+    return FetchSubscription(sharedReader: sharedReader, token: token)
   }
 
   #if !canImport(SwiftUI)
@@ -183,8 +197,9 @@ extension Fetch {
     database: (any DatabaseReader)? = nil,
     scheduler: some ValueObservationScheduler & Hashable
   ) async throws -> FetchSubscription {
-    try await sharedReader.load(.fetch(request, database: database, scheduler: scheduler))
-    return FetchSubscription(sharedReader: sharedReader)
+    try await withSubscription {
+      try await sharedReader.load(.fetch(request, database: database, scheduler: scheduler))
+    }
   }
 }
 
@@ -249,8 +264,9 @@ extension Fetch: Equatable where Value: Equatable {
       database: (any DatabaseReader)? = nil,
       animation: Animation?
     ) async throws -> FetchSubscription {
-      try await sharedReader.load(.fetch(request, database: database, animation: animation))
-      return FetchSubscription(sharedReader: sharedReader)
+      try await withSubscription {
+        try await sharedReader.load(.fetch(request, database: database, animation: animation))
+      }
     }
   }
 #endif

--- a/Sources/SQLiteData/FetchAll+Sections.swift
+++ b/Sources/SQLiteData/FetchAll+Sections.swift
@@ -196,7 +196,8 @@ extension FetchAll {
   ///   - database: The database to read from. A value of `nil` will use the default database
   ///     (`@Dependency(\.defaultDatabase)`).
   public init<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table
   >(
     wrappedValue: [Element] = [],
     _ statement: Select<V, From, ()>,
@@ -232,7 +233,9 @@ extension FetchAll {
   ///     (`@Dependency(\.defaultDatabase)`).
   @_documentation(visibility: private)
   public init<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J: StructuredQueriesCore.Table
   >(
     wrappedValue: [Element] = [],
     _ statement: Select<V, From, J>,
@@ -371,7 +374,8 @@ extension FetchAll {
   /// - Returns: A subscription associated with the observation.
   @discardableResult
   public func load<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table
   >(
     _ statement: Select<V, From, ()>,
     @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns) -> _Sectioning<String?>?,
@@ -404,7 +408,9 @@ extension FetchAll {
   @_documentation(visibility: private)
   @discardableResult
   public func load<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J: StructuredQueriesCore.Table
   >(
     _ statement: Select<V, From, J>,
     @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns, J.TableColumns) ->
@@ -522,14 +528,15 @@ extension FetchAll {
     guard let sectioning else {
       removeSections()
       let statement: Select<From, From, ()> = statement.selectStar()
-      try await sharedReader.load(
-        FetchKey(
-          request: FetchAllStatementValueRequest(statement: statement),
-          database: database,
-          scheduler: scheduler
+      return try await withSubscription {
+        try await sharedReader.load(
+          FetchKey(
+            request: FetchAllStatementValueRequest(statement: statement),
+            database: database,
+            scheduler: scheduler
+          )
         )
-      )
-      return FetchSubscription(sharedReader: sharedReader)
+      }
     }
     return try await loadSections(
       request: FetchAllSectionedStatementValueRequest(statement: statement, sectionBy: sectioning),
@@ -553,14 +560,15 @@ extension FetchAll {
     defer {
       sharedReader.projectedValue = sectionedReader.elements.projectedValue
     }
-    try await sectionedReader.load(
-      FetchKey(
-        request: request,
-        database: database,
-        scheduler: scheduler
+    return try await withSubscription {
+      try await sectionedReader.load(
+        FetchKey(
+          request: request,
+          database: database,
+          scheduler: scheduler
+        )
       )
-    )
-    return FetchSubscription(sharedReader: sharedReader, sectionedReader: sectionedReader)
+    }
   }
 }
 
@@ -714,7 +722,8 @@ extension FetchAll {
   ///   - scheduler: The scheduler to observe from. By default, database observation is performed
   ///     asynchronously on the main queue.
   public init<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table
   >(
     wrappedValue: [Element] = [],
     _ statement: Select<V, From, ()>,
@@ -753,7 +762,9 @@ extension FetchAll {
   ///     asynchronously on the main queue.
   @_documentation(visibility: private)
   public init<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J: StructuredQueriesCore.Table
   >(
     wrappedValue: [Element] = [],
     _ statement: Select<V, From, J>,
@@ -905,7 +916,8 @@ extension FetchAll {
   /// - Returns: A subscription associated with the observation.
   @discardableResult
   public func load<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table
   >(
     _ statement: Select<V, From, ()>,
     @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns) -> _Sectioning<String?>?,
@@ -941,7 +953,9 @@ extension FetchAll {
   @_documentation(visibility: private)
   @discardableResult
   public func load<
-    V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
+    V: QueryRepresentable,
+    From: StructuredQueriesCore.Table,
+    J: StructuredQueriesCore.Table
   >(
     _ statement: Select<V, From, J>,
     @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns, J.TableColumns) ->
@@ -1155,7 +1169,8 @@ extension FetchAll {
     ///     the fetched results.
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<
-      V: QueryRepresentable, From: StructuredQueriesCore.Table
+      V: QueryRepresentable,
+      From: StructuredQueriesCore.Table
     >(
       wrappedValue: [Element] = [],
       _ statement: Select<V, From, ()>,
@@ -1191,7 +1206,9 @@ extension FetchAll {
     @_documentation(visibility: private)
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<
-      V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
+      V: QueryRepresentable,
+      From: StructuredQueriesCore.Table,
+      J: StructuredQueriesCore.Table
     >(
       wrappedValue: [Element] = [],
       _ statement: Select<V, From, J>,
@@ -1340,7 +1357,8 @@ extension FetchAll {
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     @discardableResult
     public func load<
-      V: QueryRepresentable, From: StructuredQueriesCore.Table
+      V: QueryRepresentable,
+      From: StructuredQueriesCore.Table
     >(
       _ statement: Select<V, From, ()>,
       @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns) -> _Sectioning<String?>?,
@@ -1374,7 +1392,9 @@ extension FetchAll {
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     @discardableResult
     public func load<
-      V: QueryRepresentable, From: StructuredQueriesCore.Table, J: StructuredQueriesCore.Table
+      V: QueryRepresentable,
+      From: StructuredQueriesCore.Table,
+      J: StructuredQueriesCore.Table
     >(
       _ statement: Select<V, From, J>,
       @_SectionBuilder<String?> sectionBy sectioning: (From.TableColumns, J.TableColumns) ->

--- a/Sources/SQLiteData/FetchAll.swift
+++ b/Sources/SQLiteData/FetchAll.swift
@@ -48,6 +48,8 @@ public struct FetchAll<Element: Sendable>: Sendable {
     private let box: FetchAllBox<Element>
     private let state: SwiftUI.State<FetchAllBox<Element>>
     private let generation = SwiftUI.State(wrappedValue: 0)
+
+    var loadGeneration: LoadGeneration { state.wrappedValue.loadGeneration }
   #else
     /// The underlying shared reader powering the property wrapper.
     ///
@@ -59,6 +61,8 @@ public struct FetchAll<Element: Sendable>: Sendable {
       SharedReader(value: ResultsSectionCollection())
 
     let sectioning = LockIsolated<_Sectioning<String?>?>(nil)
+
+    let loadGeneration = LoadGeneration()
   #endif
 
   /// A collection of data associated with the underlying query.
@@ -73,6 +77,7 @@ public struct FetchAll<Element: Sendable>: Sendable {
   public var projectedValue: Self {
     get { self }
     nonmutating set {
+      loadGeneration.invalidate()
       sharedReader.projectedValue = newValue.sharedReader.projectedValue
       sectionedReader.projectedValue = newValue.sectionedReader.projectedValue
       sectioning.setValue(newValue.sectioning.value)
@@ -247,13 +252,22 @@ public struct FetchAll<Element: Sendable>: Sendable {
     V.QueryOutput: Sendable
   {
     removeSections()
-    try await sharedReader.load(
-      .fetch(
-        FetchAllStatementValueRequest(statement: statement),
-        database: database
+    return try await withSubscription {
+      try await sharedReader.load(
+        .fetch(
+          FetchAllStatementValueRequest(statement: statement),
+          database: database
+        )
       )
-    )
-    return FetchSubscription(sharedReader: sharedReader)
+    }
+  }
+
+  func withSubscription(_ load: () async throws -> Void) async throws -> FetchSubscription {
+    let token = loadGeneration.begin()
+    try await load()
+    return sectioning.value == nil
+      ? FetchSubscription(sharedReader: sharedReader, token: token)
+      : FetchSubscription(sharedReader: sharedReader, sectionedReader: sectionedReader, token: token)
   }
 
   #if !canImport(SwiftUI)
@@ -435,14 +449,15 @@ extension FetchAll {
     V.QueryOutput: Sendable
   {
     removeSections()
-    try await sharedReader.load(
-      .fetch(
-        FetchAllStatementValueRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
+    return try await withSubscription {
+      try await sharedReader.load(
+        .fetch(
+          FetchAllStatementValueRequest(statement: statement),
+          database: database,
+          scheduler: scheduler
+        )
       )
-    )
-    return FetchSubscription(sharedReader: sharedReader)
+    }
   }
 }
 
@@ -635,14 +650,15 @@ extension FetchAll: Equatable where Element: Equatable {
       V.QueryOutput: Sendable
     {
       removeSections()
-      try await sharedReader.load(
-        .fetch(
-          FetchAllStatementValueRequest(statement: statement),
-          database: database,
-          animation: animation
+      return try await withSubscription {
+        try await sharedReader.load(
+          .fetch(
+            FetchAllStatementValueRequest(statement: statement),
+            database: database,
+            animation: animation
+          )
         )
-      )
-      return FetchSubscription(sharedReader: sharedReader)
+      }
     }
   }
 #endif

--- a/Sources/SQLiteData/FetchOne.swift
+++ b/Sources/SQLiteData/FetchOne.swift
@@ -39,12 +39,16 @@ public struct FetchOne<Value: Sendable>: Sendable {
     private let box: FetchBox<Value>
     private let state: SwiftUI.State<FetchBox<Value>>
     private let generation = SwiftUI.State(wrappedValue: 0)
+
+    var loadGeneration: LoadGeneration { state.wrappedValue.loadGeneration }
   #else
     /// The underlying shared reader powering the property wrapper.
     ///
     /// Shared readers come from the [Sharing](https://github.com/pointfreeco/swift-sharing)
     /// package, a general solution to observing and persisting changes to external data sources.
     public let sharedReader: SharedReader<Value>
+
+    let loadGeneration = LoadGeneration()
   #endif
 
   /// A value associated with the underlying query.
@@ -58,7 +62,10 @@ public struct FetchOne<Value: Sendable>: Sendable {
   /// ``isLoading``, and ``publisher``.
   public var projectedValue: Self {
     get { self }
-    nonmutating set { sharedReader.projectedValue = newValue.sharedReader.projectedValue }
+    nonmutating set {
+      loadGeneration.invalidate()
+      sharedReader.projectedValue = newValue.sharedReader.projectedValue
+    }
   }
 
   /// Returns a ``sharedReader`` for the given key path.
@@ -408,10 +415,11 @@ public struct FetchOne<Value: Sendable>: Sendable {
   where
     Value == V.QueryOutput
   {
-    try await sharedReader.load(
-      .fetch(FetchOneStatementValueRequest(statement: statement), database: database)
-    )
-    return FetchSubscription(sharedReader: sharedReader)
+    try await withSubscription {
+      try await sharedReader.load(
+        .fetch(FetchOneStatementValueRequest(statement: statement), database: database)
+      )
+    }
   }
 
   /// Replaces the wrapped value with data from the given query.
@@ -429,10 +437,11 @@ public struct FetchOne<Value: Sendable>: Sendable {
   where
     Value == V.QueryOutput?
   {
-    try await sharedReader.load(
-      .fetch(FetchOneStatementOptionalValueRequest(statement: statement), database: database)
-    )
-    return FetchSubscription(sharedReader: sharedReader)
+    try await withSubscription {
+      try await sharedReader.load(
+        .fetch(FetchOneStatementOptionalValueRequest(statement: statement), database: database)
+      )
+    }
   }
 
   /// Replaces the wrapped value with data from the given query.
@@ -454,10 +463,11 @@ public struct FetchOne<Value: Sendable>: Sendable {
     S.Joins == ()
   {
     let statement = statement.selectStar().asSelect().limit(1)
-    try await sharedReader.load(
-      .fetch(FetchOneStatementOptionalValueRequest(statement: statement), database: database)
-    )
-    return FetchSubscription(sharedReader: sharedReader)
+    return try await withSubscription {
+      try await sharedReader.load(
+        .fetch(FetchOneStatementOptionalValueRequest(statement: statement), database: database)
+      )
+    }
   }
 
   /// Replaces the wrapped value with data from the given query.
@@ -478,10 +488,11 @@ public struct FetchOne<Value: Sendable>: Sendable {
     S.QueryValue: StructuredQueriesCore._OptionalProtocol,
     Value == S.QueryValue.QueryOutput
   {
-    try await sharedReader.load(
-      .fetch(FetchOneStatementOptionalProtocolRequest(statement: statement), database: database)
-    )
-    return FetchSubscription(sharedReader: sharedReader)
+    try await withSubscription {
+      try await sharedReader.load(
+        .fetch(FetchOneStatementOptionalProtocolRequest(statement: statement), database: database)
+      )
+    }
   }
 
   /// Replaces the wrapped value with data from the given query.
@@ -501,10 +512,17 @@ public struct FetchOne<Value: Sendable>: Sendable {
     Value: StructuredQueriesCore._OptionalProtocol,
     Value.QueryOutput == Value
   {
-    try await sharedReader.load(
-      .fetch(FetchOneStatementOptionalProtocolRequest(statement: statement), database: database)
-    )
-    return FetchSubscription(sharedReader: sharedReader)
+    try await withSubscription {
+      try await sharedReader.load(
+        .fetch(FetchOneStatementOptionalProtocolRequest(statement: statement), database: database)
+      )
+    }
+  }
+
+  private func withSubscription(_ load: () async throws -> Void) async throws -> FetchSubscription {
+    let token = loadGeneration.begin()
+    try await load()
+    return FetchSubscription(sharedReader: sharedReader, token: token)
   }
 
   #if !canImport(SwiftUI)
@@ -918,14 +936,15 @@ extension FetchOne {
   where
     Value == V.QueryOutput
   {
-    try await sharedReader.load(
-      .fetch(
-        FetchOneStatementValueRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
+    try await withSubscription {
+      try await sharedReader.load(
+        .fetch(
+          FetchOneStatementValueRequest(statement: statement),
+          database: database,
+          scheduler: scheduler
+        )
       )
-    )
-    return FetchSubscription(sharedReader: sharedReader)
+    }
   }
 
   /// Replaces the wrapped value with data from the given query.
@@ -946,14 +965,15 @@ extension FetchOne {
   where
     Value == V.QueryOutput?
   {
-    try await sharedReader.load(
-      .fetch(
-        FetchOneStatementOptionalValueRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
+    try await withSubscription {
+      try await sharedReader.load(
+        .fetch(
+          FetchOneStatementOptionalValueRequest(statement: statement),
+          database: database,
+          scheduler: scheduler
+        )
       )
-    )
-    return FetchSubscription(sharedReader: sharedReader)
+    }
   }
 
   /// Replaces the wrapped value with data from the given query.
@@ -978,14 +998,15 @@ extension FetchOne {
     S.Joins == ()
   {
     let statement = statement.selectStar().asSelect().limit(1)
-    try await sharedReader.load(
-      .fetch(
-        FetchOneStatementOptionalValueRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
+    return try await withSubscription {
+      try await sharedReader.load(
+        .fetch(
+          FetchOneStatementOptionalValueRequest(statement: statement),
+          database: database,
+          scheduler: scheduler
+        )
       )
-    )
-    return FetchSubscription(sharedReader: sharedReader)
+    }
   }
 
   /// Replaces the wrapped value with data from the given query.
@@ -1009,14 +1030,15 @@ extension FetchOne {
     S.QueryValue: StructuredQueriesCore._OptionalProtocol,
     Value == S.QueryValue.QueryOutput
   {
-    try await sharedReader.load(
-      .fetch(
-        FetchOneStatementOptionalProtocolRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
+    try await withSubscription {
+      try await sharedReader.load(
+        .fetch(
+          FetchOneStatementOptionalProtocolRequest(statement: statement),
+          database: database,
+          scheduler: scheduler
+        )
       )
-    )
-    return FetchSubscription(sharedReader: sharedReader)
+    }
   }
 
   /// Replaces the wrapped value with data from the given query.
@@ -1039,14 +1061,15 @@ extension FetchOne {
     Value: StructuredQueriesCore._OptionalProtocol,
     Value.QueryOutput == Value
   {
-    try await sharedReader.load(
-      .fetch(
-        FetchOneStatementOptionalProtocolRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
+    try await withSubscription {
+      try await sharedReader.load(
+        .fetch(
+          FetchOneStatementOptionalProtocolRequest(statement: statement),
+          database: database,
+          scheduler: scheduler
+        )
       )
-    )
-    return FetchSubscription(sharedReader: sharedReader)
+    }
   }
 }
 

--- a/Sources/SQLiteData/FetchSubscription.swift
+++ b/Sources/SQLiteData/FetchSubscription.swift
@@ -18,18 +18,25 @@ public struct FetchSubscription: Sendable {
   let cancellable = LockIsolated<Task<Void, any Error>?>(nil)
   let onCancel: @Sendable () -> Void
 
-  init<Value>(sharedReader: SharedReader<Value>) {
-    onCancel = { sharedReader.projectedValue = SharedReader(value: sharedReader.wrappedValue) }
+  init<Value>(sharedReader: SharedReader<Value>, token: LoadGeneration.Token) {
+    onCancel = {
+      token.ifCurrent {
+        sharedReader.projectedValue = SharedReader(value: sharedReader.wrappedValue)
+      }
+    }
   }
 
   init<Element: Sendable>(
     sharedReader: SharedReader<[Element]>,
-    sectionedReader: SharedReader<ResultsSectionCollection<Element, String?>>
+    sectionedReader: SharedReader<ResultsSectionCollection<Element, String?>>,
+    token: LoadGeneration.Token
   ) {
     onCancel = {
-      let sections = sectionedReader.wrappedValue
-      sectionedReader.projectedValue = SharedReader(value: sections)
-      sharedReader.projectedValue = SharedReader(value: sections.elements)
+      token.ifCurrent {
+        let sections = sectionedReader.wrappedValue
+        sectionedReader.projectedValue = SharedReader(value: sections)
+        sharedReader.projectedValue = SharedReader(value: sections.elements)
+      }
     }
   }
 

--- a/Sources/SQLiteData/Internal/FetchBox.swift
+++ b/Sources/SQLiteData/Internal/FetchBox.swift
@@ -6,6 +6,7 @@
 
   final class FetchBox<Value: Sendable>: Sendable {
     let sharedReader: SharedReader<Value>
+    let loadGeneration = LoadGeneration()
     private let storage = LockIsolated(Storage())
 
     var fetchKeyID: FetchKeyID? {
@@ -25,6 +26,7 @@
         return true
       }
       guard isAdopted else { return }
+      loadGeneration.invalidate()
       sharedReader.projectedValue = other.sharedReader.projectedValue
     }
 
@@ -48,6 +50,7 @@
     let sharedReader: SharedReader<[Element]>
     let sectionedReader: SharedReader<ResultsSectionCollection<Element, String?>>
     let sectioning = LockIsolated<_Sectioning<String?>?>(nil)
+    let loadGeneration = LoadGeneration()
     private let storage = LockIsolated(Storage())
 
     var fetchKeyID: FetchKeyID? {
@@ -68,6 +71,7 @@
         return true
       }
       guard isAdopted else { return }
+      loadGeneration.invalidate()
       sharedReader.projectedValue = other.sharedReader.projectedValue
       sectionedReader.projectedValue = other.sectionedReader.projectedValue
       sectioning.setValue(other.sectioning.value)

--- a/Sources/SQLiteData/Internal/LoadGeneration.swift
+++ b/Sources/SQLiteData/Internal/LoadGeneration.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+final class LoadGeneration: Sendable {
+  private let count = LockIsolated(0)
+
+  func begin() -> Token {
+    Token(
+      count: count,
+      generation: count.withLock {
+        $0 += 1
+        return $0
+      }
+    )
+  }
+
+  func invalidate() {
+    count.withLock { $0 += 1 }
+  }
+
+  struct Token: Sendable {
+    fileprivate let count: LockIsolated<Int>
+    fileprivate let generation: Int
+
+    func ifCurrent(_ body: sending () -> Void) {
+      count.withLock {
+        guard $0 == generation else { return }
+        body()
+      }
+    }
+  }
+}
+
+private final class LockIsolated<Value>: @unchecked Sendable {
+  private var _value: Value
+  private let lock = NSLock()
+  init(_ value: sending Value) {
+    self._value = value
+  }
+  func withLock<T>(
+    _ operation: sending (inout sending Value) throws -> sending T
+  ) rethrows -> sending T {
+    lock.lock()
+    defer { lock.unlock() }
+    var value = _value
+    defer { _value = value }
+    return try operation(&value)
+  }
+}

--- a/Sources/SQLiteData/Internal/LoadGeneration.swift
+++ b/Sources/SQLiteData/Internal/LoadGeneration.swift
@@ -1,48 +1,31 @@
 import Foundation
 
-final class LoadGeneration: Sendable {
-  private let count = LockIsolated(0)
+final class LoadGeneration: @unchecked Sendable {
+  private let lock = NSLock()
+  private var count = 0
 
   func begin() -> Token {
-    Token(
-      count: count,
-      generation: count.withLock {
-        $0 += 1
-        return $0
-      }
-    )
+    lock.lock()
+    defer { lock.unlock() }
+    count += 1
+    return Token(loadGeneration: self, generation: count)
   }
 
   func invalidate() {
-    count.withLock { $0 += 1 }
+    lock.lock()
+    defer { lock.unlock() }
+    count += 1
   }
 
   struct Token: Sendable {
-    fileprivate let count: LockIsolated<Int>
+    fileprivate let loadGeneration: LoadGeneration
     fileprivate let generation: Int
 
-    func ifCurrent(_ body: sending () -> Void) {
-      count.withLock {
-        guard $0 == generation else { return }
-        body()
-      }
+    func ifCurrent(_ body: () -> Void) {
+      loadGeneration.lock.lock()
+      defer { loadGeneration.lock.unlock() }
+      guard loadGeneration.count == generation else { return }
+      body()
     }
-  }
-}
-
-private final class LockIsolated<Value>: @unchecked Sendable {
-  private var _value: Value
-  private let lock = NSLock()
-  init(_ value: sending Value) {
-    self._value = value
-  }
-  func withLock<T>(
-    _ operation: sending (inout sending Value) throws -> sending T
-  ) rethrows -> sending T {
-    lock.lock()
-    defer { lock.unlock() }
-    var value = _value
-    defer { _value = value }
-    return try operation(&value)
   }
 }

--- a/Tests/SQLiteDataTests/FetchSubscriptionTests.swift
+++ b/Tests/SQLiteDataTests/FetchSubscriptionTests.swift
@@ -53,6 +53,24 @@ import Testing
     #expect(didComplete.value)
   }
 
+  @Test func staleCancellationDoesNotStopNewerLoad() async throws {
+    @FetchAll var records: [Record]
+
+    let firstSubscription = try await $records.load(Record.all)
+    let task = Task {
+      try? await firstSubscription.task
+    }
+    try await $records.load(Record.where { $0.id > 0 })
+    task.cancel()
+    await task.value
+
+    try await database.write { db in
+      try Record.insert { Record.Draft() }.execute(db)
+    }
+    try await $records.load()
+    #expect(records.count == 1)
+  }
+
   @Test func cancellingOneFetchDoesNotCancelAnother() async throws {
     @FetchAll var records1: [Record]
     #expect(records1.count == 0)


### PR DESCRIPTION
It's possible for a `@Fetch*.load` to race an existing one such that a `FetchSubscription` cancellation is applied to the wrong load event. This PR identifies each load event to determine whether or not the current one should be cancelled or not.