### PR TITLE
Nest temporary databases in a single directory

### DIFF
--- a/Sources/SQLiteData/Internal/TemporaryDatabase.swift
+++ b/Sources/SQLiteData/Internal/TemporaryDatabase.swift
@@ -13,24 +13,7 @@ func temporaryDatabasePool(configuration: Configuration = Configuration()) throw
   )
 }
 
-private let temporaryDatabaseDirectory: URL = {
-  let directory = URL.temporaryDirectory.appending(
-    path: "co.pointfree.SQLiteData",
-    directoryHint: .isDirectory
-  )
-  let processDirectories =
-    (try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil))
-    ?? []
-  for processDirectory in processDirectories {
-    guard
-      let processIdentifier = pid_t(processDirectory.lastPathComponent),
-      kill(processIdentifier, 0) != 0,
-      errno == ESRCH
-    else { continue }
-    try? FileManager.default.removeItem(at: processDirectory)
-  }
-  return directory.appending(
-    path: "\(ProcessInfo.processInfo.processIdentifier)",
-    directoryHint: .isDirectory
-  )
-}()
+private let temporaryDatabaseDirectory = URL.temporaryDirectory.appending(
+  path: "co.pointfree.SQLiteData",
+  directoryHint: .isDirectory
+)


### PR DESCRIPTION
This is a partial revert of #537. Instead of doing extra work to try to detect parallel test suites, let's just make it easier for folks to purge the directory themselves if they need to.