### PR TITLE
Expose the last record zone fetch error from CloudKit

### DIFF
--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -424,6 +424,10 @@
       isSendingChanges || isFetchingChanges
     }
 
+    public var lastRecordZoneFetchError: CKError? {
+      recordZoneFetchError
+    }
+
     /// Stops the sync engine if it is running.
     ///
     /// All edits made after stopping the sync engine will not be synchronized to CloudKit.
@@ -944,6 +948,17 @@
         }
       }
     }
+    private var recordZoneFetchError: CKError? {
+      get {
+        observationRegistrar.access(self, keyPath: \.lastRecordZoneFetchError)
+        return activityCounts.withValue(\.recordZoneFetchError)
+      }
+      set {
+        observationRegistrar.withMutation(of: self, keyPath: \.lastRecordZoneFetchError) {
+          activityCounts.withValue { $0.recordZoneFetchError = newValue }
+        }
+      }
+    }
   }
 
   extension PrimaryKeyedTable {
@@ -1039,9 +1054,10 @@
         await MainActor.run {
           fetchingChangesCount += 1
         }
-      case .didFetchRecordZoneChanges:
+      case .didFetchRecordZoneChanges(_, let error):
         await MainActor.run {
           fetchingChangesCount -= 1
+          recordZoneFetchError = error
         }
 
       case .willFetchChanges:
@@ -2529,6 +2545,7 @@
   private struct ActivityCounts {
     var sendingChangesCount = 0
     var fetchingChangesCount = 0
+    var recordZoneFetchError: CKError?
   }
 
   #if DEBUG


### PR DESCRIPTION
This allows clients to report on errors such as rate limiting.